### PR TITLE
Ch 3: Fix typo 'example' to 'entry'

### DIFF
--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -446,7 +446,7 @@ AddressBook
 Note though that the parentheses here are unnecessary - the following is equivalent:
 
 ```text
-> :type insertEntry example emptyBook
+> :type insertEntry entry emptyBook
 AddressBook
 ```
 


### PR DESCRIPTION
Very simple fix; original `example` doesn't compile.