### PR TITLE
Ch 4: Added clarification to the result line of a do statement

### DIFF
--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -311,7 +311,7 @@ factors n = filter (\xs -> product xs == n) $ do
 The keyword `do` introduces a block of code which uses do notation. The block consists of expressions of a few types:
 
 - Expressions which bind elements of an array to a name. These are indicated with the backwards-facing arrow `<-`, with a name on the left, and an expression on the right whose type is an array.
-- Expressions which do not bind elements of the array to names. The last line `pure [i, j]` is an example of this kind of expression.
+- Expressions which do not bind elements of the array to names. The `do` *result* is an example of this category of expression and is illustrated in the last line, `pure [i, j]`.
 - Expressions which give names to expressions, using the `let` keyword.
 
 This new notation hopefully makes the structure of the algorithm clearer. If you mentally replace the arrow `<-` with the word "choose", you might read it as follows: "choose an element `i` between 1 and n, then choose an element `j` between `i` and `n`, and return `[i, j]`".

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -311,7 +311,7 @@ factors n = filter (\xs -> product xs == n) $ do
 The keyword `do` introduces a block of code which uses do notation. The block consists of expressions of a few types:
 
 - Expressions which bind elements of an array to a name. These are indicated with the backwards-facing arrow `<-`, with a name on the left, and an expression on the right whose type is an array.
-- Expressions which do not bind elements of the array to names. The `do` *result* is an example of this category of expression and is illustrated in the last line, `pure [i, j]`.
+- Expressions which do not bind elements of the array to names. The `do` *result* is an example of this kind of expression and is illustrated in the last line, `pure [i, j]`.
 - Expressions which give names to expressions, using the `let` keyword.
 
 This new notation hopefully makes the structure of the algorithm clearer. If you mentally replace the arrow `<-` with the word "choose", you might read it as follows: "choose an element `i` between 1 and n, then choose an element `j` between `i` and `n`, and return `[i, j]`".


### PR DESCRIPTION
I struggled hard with the material on the `do` notation.  What I realized I was missing was that the purpose of the last line, the one containing the `pure` application, was not actually specified but was sort of implied as a side effect while explaining `pure`.

I ended up not really understanding `do` as a whole, and it took me an embarrassing day to figure it out, with help from the PureScript IRC group.

So, I made an attempt to explicitly state what the last line is for that would have helped me out immensely.  I also attempted to suggest "by default" for the `pure` function use because later it's implied that, in this `Array` context, `pure` can be substituted by an additional pair of square brackets, i.e. `[[1, 2]]`.

Hopefully you find this useful.