### PR TITLE
Remove 'purescript-' prefix from packages

### DIFF
--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -8,7 +8,7 @@ This chapter will introduce PureScript's _foreign function interface_ (or _FFI_)
 - How to create new effect types and actions for use with the `Effect` monad, based on existing JavaScript code,
 - How to call PureScript code from JavaScript,
 - How to understand the representation of PureScript values at runtime,
-- How to work with untyped data using the `purescript-foreign` package.
+- How to work with untyped data using the `foreign` package.
 
 Towards the end of this chapter, we will revisit our recurring address book example. The goal of the chapter will be to add the following new functionality to our application using the FFI:
 
@@ -19,7 +19,7 @@ Towards the end of this chapter, we will revisit our recurring address book exam
 
 The source code for this module is a continuation of the source code from chapters 3, 7 and 8. As such, the source tree includes the appropriate source files from those chapters.
 
-This chapter intruduces the `purescript-foreign-generic` library as a dependency. This library adds support for _datatype generic programming_ to the `purescript-foreign` library. The `purescript-foreign` library is a sub-dependency and provides a data type and functions for working with _untyped data_.
+This chapter intruduces the `foreign-generic` library as a dependency. This library adds support for _datatype generic programming_ to the `foreign` library. The `foreign` library is a sub-dependency and provides a data type and functions for working with _untyped data_.
 
 _Note_: to avoid browser-specific issues with local storage when the webpage is served from a local file, it might be necessary to run this chapter's project over HTTP.
 
@@ -259,7 +259,7 @@ shout(require('Data.Show').showNumber)(42);
      ```
 
      What can you say about the expressions which have these types?
- 1. (Medium) Try using the functions defined in the `purescript-arrays` package, calling them from JavaScript, by compiling the library using `spago build` and importing modules using the `require` function in NodeJS. _Hint_: you may need to configure the output path so that the generated CommonJS modules are available on the NodeJS module path.
+ 1. (Medium) Try using the functions defined in the `arrays` package, calling them from JavaScript, by compiling the library using `spago build` and importing modules using the `require` function in NodeJS. _Hint_: you may need to configure the output path so that the generated CommonJS modules are available on the NodeJS module path.
 
 ## Using JavaScript Code From PureScript
 
@@ -417,7 +417,7 @@ foreign import data Fn2 :: Type -> Type -> Type -> Type
 
 This defines the type constructor `Fn2` which takes three type arguments. `Fn2 a b c` is a type representing JavaScript functions of two arguments of types `a` and `b`, and with return type `c`.
 
-The `purescript-functions` package defines similar type constructors for function arities from 0 to 10.
+The `functions` package defines similar type constructors for function arities from 0 to 10.
 
 We can create a function of two arguments by using the `mkFn2` function, as follows:
 
@@ -470,7 +470,7 @@ The definition of the `Effect` type constructor is given in the `Effect` module 
 foreign import data Effect :: Type -> Type
 ```
 
-As a simple example, consider the `random` function defined in the `purescript-random` package. Recall that its type was:
+As a simple example, consider the `random` function defined in the `random` package. Recall that its type was:
 
 ```haskell
 foreign import random :: Effect Number
@@ -484,7 +484,7 @@ exports.random = Math.random;
 
 Notice that the `random` function is represented at runtime as a function of no arguments. It performs the side effect of generating a random number, and returns it, and the return value matches the runtime representation of the `Number` type: it is a non-null JavaScript number.
 
-As a slightly more interesting example, consider the `log` function defined by the `Effect.Console` module in the `purescript-console` package. The `log` function has the following type:
+As a slightly more interesting example, consider the `log` function defined by the `Effect.Console` module in the `console` package. The `log` function has the following type:
 
 ```haskell
 foreign import log :: String -> Effect Unit
@@ -551,7 +551,7 @@ The interested reader can inspect the source code for this module to see the def
 
 `setItem` takes a key and a value (both strings), and returns a computation which stores the value in local storage at the specified key.
 
-The type of `getItem` is more interesting. It takes a key, and attempts to retrieve the associated value from local storage. However, since the `getItem` method on `window.localStorage` can return `null`, the return type is not `String`, but `Foreign` which is defined by the `purescript-foreign` package in the `Foreign` module.
+The type of `getItem` is more interesting. It takes a key, and attempts to retrieve the associated value from local storage. However, since the `getItem` method on `window.localStorage` can return `null`, the return type is not `String`, but `Foreign` which is defined by the `foreign` package in the `Foreign` module.
 
 `Foreign` provides a way to work with _untyped data_, or more generally, data whose runtime representation is uncertain.
 
@@ -575,12 +575,12 @@ newtype FormData = FormData
   }
 ```
 
-The problem is that we have no guarantee that the JSON will have the correct form. Put another way, we don't know that the JSON represents the correct type of data at runtime. This is the sort of problem that is solved by the `purescript-foreign` library. Here are some other examples:
+The problem is that we have no guarantee that the JSON will have the correct form. Put another way, we don't know that the JSON represents the correct type of data at runtime. This is the sort of problem that is solved by the `foreign` library. Here are some other examples:
 
 - A JSON response from a web service
 - A value passed to a function from JavaScript code
 
-Let's try the `purescript-foreign` and `purescript-foreign-generic` libraries in PSCi.
+Let's try the `foreign` and `foreign-generic` libraries in PSCi.
 
 Start by importing some modules:
 
@@ -590,7 +590,7 @@ Start by importing some modules:
 > import Foreign.JSON
 ```
 
-A good way to obtain a `Foreign` value is to parse a JSON document. `purescript-foreign-generic` defines the following two functions:
+A good way to obtain a `Foreign` value is to parse a JSON document. `foreign-generic` defines the following two functions:
 
 ```haskell
 parseJSON :: String -> F Foreign
@@ -605,7 +605,7 @@ type F = Except MultipleErrors
 
 Here, `Except` is a monad for handling exceptions in pure code, much like `Either`. We can convert a value in the `F` monad into a value in the `Either` monad by using the `runExcept` function.
 
-Most of the functions in the `purescript-foreign` and `purescript-foreign-generic` libraries return a value in the `F` monad, which means that we can use do notation and the applicative functor combinators to build typed values.
+Most of the functions in the `foreign` and `foreign-generic` libraries return a value in the `F` monad, which means that we can use do notation and the applicative functor combinators to build typed values.
 
 The `Decode` type class represents those types which can be obtained from untyped data. There are type class instances defined for the primitive types and arrays, and we can define our own instances as well.
 
@@ -631,11 +631,11 @@ Recall that in the `Either` monad, the `Right` data constructor indicates succes
 (Left (NonEmptyList (NonEmpty (ErrorAtIndex 2 (TypeMismatch "Int" "Boolean")) Nil)))
 ```
 
-The `purescript-foreign-generic` library tells us where in the JSON document the type error occurred.
+The `foreign-generic` library tells us where in the JSON document the type error occurred.
 
 ## Handling Null and Undefined Values
 
-Real-world JSON documents contain null and undefined values, so we need to be able to handle those too. `purescript-foreign-generic` solves this problem with the 'Maybe' type constructor to represent missing values.
+Real-world JSON documents contain null and undefined values, so we need to be able to handle those too. `foreign-generic` solves this problem with the 'Maybe' type constructor to represent missing values.
 
 ```text
 > import Prelude
@@ -657,7 +657,7 @@ The type `Maybe Int` represents values which are either integers, or null. What 
 
 ## Generic JSON Serialization
 
-In fact, we rarely need to write instances for the `Decode` class, since the `purescript-foreign-generic` class allows us to _derive_ instances using a technique called _datatype-generic programming_. A full explanation of this technique is beyond the scope of this book, but it allows us to write functions once, and reuse them over many different data types, based on the structure of a the types themselves.
+In fact, we rarely need to write instances for the `Decode` class, since the `foreign-generic` class allows us to _derive_ instances using a technique called _datatype-generic programming_. A full explanation of this technique is beyond the scope of this book, but it allows us to write functions once, and reuse them over many different data types, based on the structure of a the types themselves.
 
 To derive a `Decode` instance for our `FormData` type (so that we may deserialize it from its JSON representation), we first use the `derive` keyword to derive an instance of the `Generic` type class, which looks like this:
 
@@ -729,7 +729,7 @@ _Note_: You may need to serve the HTML and JavaScript files from a HTTP server l
      data Tree a = Leaf a | Branch (Tree a) (Tree a)
      ```
 
-     Derive `Encode` and `Decode` instances for this type using `purescript-foreign-generic`, and verify that encoded values can correctly be decoded in PSCi. Hint: This requires a [Generic Instance](https://github.com/paf31/24-days-of-purescript-2016/blob/master/11.markdown#deriving-generic-instances), also see previous section on "Instance Dependencies", and finally, search the web for "eta-expansion" if you encounter recursion issues during testing.
+     Derive `Encode` and `Decode` instances for this type using `foreign-generic`, and verify that encoded values can correctly be decoded in PSCi. Hint: This requires a [Generic Instance](https://github.com/paf31/24-days-of-purescript-2016/blob/master/11.markdown#deriving-generic-instances), also see previous section on "Instance Dependencies", and finally, search the web for "eta-expansion" if you encounter recursion issues during testing.
  1. (Difficult) The following `data` type should be represented directly in JSON as either an integer or a string:
 
      ```haskell

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -8,10 +8,10 @@ The goal of this chapter will be to learn about _monad transformers_, which prov
 
 This module's project introduces the following new dependencies:
 
-- `purescript-ordered-collections`, which provides data typs for immutable maps and sets
-- `purescript-transformers`, which provides implementations of standard monad transformers
-- `purescript-node-readline`, which provides FFI bindings to the [`readline`](https://nodejs.org/api/readline.html) interface provided by NodeJS
-- `purescript-yargs`, which provides an applicative interface to the [`yargs`](https://www.npmjs.com/package/yargs) command line argument processing library
+- `ordered-collections`, which provides data typs for immutable maps and sets
+- `transformers`, which provides implementations of standard monad transformers
+- `node-readline`, which provides FFI bindings to the [`readline`](https://nodejs.org/api/readline.html) interface provided by NodeJS
+- `yargs`, which provides an applicative interface to the [`yargs`](https://www.npmjs.com/package/yargs) command line argument processing library
 
 It is also necessary to install the `yargs` module using NPM:
 
@@ -79,11 +79,11 @@ Congratulations, Phil!
 You win!
 ```
 
-The game is very simple, but the aim of the chapter is to use the `purescript-transformers` package to build a library which will enable rapid development of this type of game.
+The game is very simple, but the aim of the chapter is to use the `transformers` package to build a library which will enable rapid development of this type of game.
 
 ## The State Monad
 
-We will start by looking at some of the monads provided by the `purescript-transformers` package.
+We will start by looking at some of the monads provided by the `transformers` package.
 
 The first example is the `State` monad, which provides a way to model _mutable state_ in pure code. We have already seen an approach to mutable state provided by the `Effect` monad. `State` provides an alternative.
 
@@ -167,7 +167,7 @@ Given the `sumArray` function above, we could use `execState` in PSCi to sum the
 
 ## The Reader Monad
 
-Another monad provided by the `purescript-transformers` package is the `Reader` monad. This monad provides the ability to read from a global configuration. Whereas the `State` monad provides the ability to read and write a single piece of mutable state, the `Reader` monad only provides the ability to read a single piece of data.
+Another monad provided by the `transformers` package is the `Reader` monad. This monad provides the ability to read from a global configuration. Whereas the `State` monad provides the ability to read and write a single piece of mutable state, the `Reader` monad only provides the ability to read a single piece of data.
 
 The `Reader` type constructor takes two type arguments: a type `r` which represents the configuration type, and the return type `a`.
 
@@ -339,7 +339,7 @@ Tuple 3 ["gcdLog 21 15","gcdLog 6 15","gcdLog 6 9","gcdLog 6 3","gcdLog 3 3"]
 
  ## Exercises
 
- 1. (Medium) Rewrite the `sumArray` function above using the `Writer` monad and the `Additive Int` monoid from the `purescript-monoid` package.
+ 1. (Medium) Rewrite the `sumArray` function above using the `Writer` monad and the `Additive Int` monoid from the `monoid` package.
  1. (Medium) The _Collatz_ function is defined on natural numbers `n` as `n / 2` when `n` is even, and `3 * n + 1` when `n` is odd. For example, the iterated Collatz sequence starting at `10` is as follows:
 
      ```text
@@ -440,11 +440,11 @@ This is not very remarkable, since we could have implemented this without `State
 (Right (Tuple "te" "st"))
 ```
 
-We can use the `split` function with a handful of other actions to build a basic parsing library. In fact, this is the approach taken by the `purescript-parsing` library. This is the power of monad transformers - we can create custom-built monads for a variety of problems, choosing the side-effects that we need, and keeping the expressiveness of do notation and applicative combinators.
+We can use the `split` function with a handful of other actions to build a basic parsing library. In fact, this is the approach taken by the `parsing` library. This is the power of monad transformers - we can create custom-built monads for a variety of problems, choosing the side-effects that we need, and keeping the expressiveness of do notation and applicative combinators.
 
 ## The ExceptT Monad Transformer
 
-The `purescript-transformers` package also defines the `ExceptT e` monad transformer, which is the transformer corresponding to the `Either e` monad. It provides the following API:
+The `transformers` package also defines the `ExceptT e` monad transformer, which is the transformer corresponding to the `Either e` monad. It provides the following API:
 
 ```haskell
 class MonadError e m where
@@ -460,7 +460,7 @@ The `MonadError` class captures those monads which support throwing and catching
 
 The `runExceptT` handler is used to run a computation of type `ExceptT e m a`.
 
-This API is similar to that provided by the `purescript-exceptions` package and the `Exception` effect. However, there are some important differences:
+This API is similar to that provided by the `exceptions` package and the `Exception` effect. However, there are some important differences:
 
 - `Exception` uses actual JavaScript exceptions, whereas `ExceptT` models errors as a pure data structure.
 - The `Exception` effect only supports exceptions of one type, namely JavaScript's `Error` type, whereas `ExceptT` supports errors of any type. In particular, we are free to define new error types.
@@ -589,9 +589,9 @@ modify :: forall m s. MonadState s m => (s -> s) -> m Unit
 
 The `Control.Monad.State.Class` module defines the `MonadState` (multi-parameter) type class, which allows us to abstract over "monads which support pure mutable state". As one would expect, the `State s` type constructor is an instance of the `MonadState s` type class, but there are many more interesting instances of this class.
 
-In particular, there are instances of `MonadState` for the `WriterT`, `ReaderT` and `ExceptT` monad transformers, provided in the `purescript-transformers` package. Each of these monad transformers has an instance for `MonadState` whenever the underlying `Monad` does. In practice, this means that as long as `StateT` appears _somewhere_ in the monad transformer stack, and everything above `StateT` is an instance of `MonadState`, then we are free to use `get`, `put` and `modify` directly, without the need to use `lift`.
+In particular, there are instances of `MonadState` for the `WriterT`, `ReaderT` and `ExceptT` monad transformers, provided in the `transformers` package. Each of these monad transformers has an instance for `MonadState` whenever the underlying `Monad` does. In practice, this means that as long as `StateT` appears _somewhere_ in the monad transformer stack, and everything above `StateT` is an instance of `MonadState`, then we are free to use `get`, `put` and `modify` directly, without the need to use `lift`.
 
-Indeed, the same is true of the actions we covered for the `ReaderT`, `WriterT`, and `ExceptT` transformers. `purescript-transformers` defines a type class for each of the major transformers, allowing us to abstract over monads which support their operations.
+Indeed, the same is true of the actions we covered for the `ReaderT`, `WriterT`, and `ExceptT` transformers. `transformers` defines a type class for each of the major transformers, allowing us to abstract over monads which support their operations.
 
 In the case of the `split` function above, the monad stack we constructed is an instance of each of the `MonadState`, `MonadWriter` and `MonadError` type classes. This means that we don't need to call `lift` at all! We can just use the actions `get`, `put`, `tell` and `throwError` as if they were defined on the monad stack itself:
 
@@ -611,7 +611,7 @@ This computation really looks like we have extended our programming language to 
 
 ## Alternatives
 
-The `purescript-control` package defines a number of abstractions for working with computations which can fail. One of these is the `Alternative` type class:
+The `control` package defines a number of abstractions for working with computations which can fail. One of these is the `Alternative` type class:
 
 ```haskell
 class Functor f <= Alt f where
@@ -746,7 +746,7 @@ Again, this illustrates the power of reusability that monad transformers bring -
 
 ## The RWS Monad
 
-One particular combination of monad transformers is so common that it is provided as a single monad transformer in the `purescript-transformers` package. The `Reader`, `Writer` and `State` monads are combined into the _reader-writer-state_ monad, or more simply the `RWS` monad. This monad has a corresponding monad transformer called the `RWST` monad transformer.
+One particular combination of monad transformers is so common that it is provided as a single monad transformer in the `transformers` package. The `Reader`, `Writer` and `State` monads are combined into the _reader-writer-state_ monad, or more simply the `RWS` monad. This monad has a corresponding monad transformer called the `RWST` monad transformer.
 
 We will use the `RWS` monad to model the game logic for our text adventure game.
 
@@ -885,7 +885,7 @@ The remainder of the `Game` module defines a set of similar actions, each using 
 
 Since our game logic runs in the `RWS` monad, it is necessary to run the computation in order to respond to the user's commands.
 
-The front-end of our game is built using two packages: `purescript-yargs`, which provides an applicative interface to the `yargs` command line parsing library, and `purescript-node-readline`, which wraps NodeJS' `readline` module, allowing us to write interactive console-based applications.
+The front-end of our game is built using two packages: `yargs`, which provides an applicative interface to the `yargs` command line parsing library, and `node-readline`, which wraps NodeJS' `readline` module, allowing us to write interactive console-based applications.
 
 The interface to our game logic is provided by the function `game` in the `Game` module:
 
@@ -909,9 +909,9 @@ The front-end of our application is defined by a function `runGame`, with the fo
 runGame :: GameEnvironment -> Effect Unit
 ```
 
-This function interacts with the user via the console (using the `purescript-node-readline` and `purescript-console` packages). `runGame` takes the game configuration as a function argument.
+This function interacts with the user via the console (using the `node-readline` and `console` packages). `runGame` takes the game configuration as a function argument.
 
-The `purescript-node-readline` package provides the `LineHandler` type, which represents actions in the `Effect` monad which handle user input from the terminal. Here is the corresponding API:
+The `node-readline` package provides the `LineHandler` type, which represents actions in the `Effect` monad which handle user input from the terminal. Here is the corresponding API:
 
 ```haskell
 type LineHandler a = String -> Effect a
@@ -975,9 +975,9 @@ The `runGame` function finally attaches the initial line handler to the console 
 
 ## Handling Command Line Options
 
-The final piece of the application is responsible for parsing command line options and creating the `GameEnvironment` configuration record. For this, we use the `purescript-yargs` package.
+The final piece of the application is responsible for parsing command line options and creating the `GameEnvironment` configuration record. For this, we use the `yargs` package.
 
-`purescript-yargs` is an example of _applicative command line option parsing_. Recall that an applicative functor allows us to lift functions of arbitrary arity over a type constructor representing some type of side-effect. In the case of the `purescript-yargs` package, the functor we are interested in is the `Y` functor, which adds the side-effect of reading from command line options. It provides the following handler:
+`yargs` is an example of _applicative command line option parsing_. Recall that an applicative functor allows us to lift functions of arbitrary arity over a type constructor representing some type of side-effect. In the case of the `yargs` package, the functor we are interested in is the `Y` functor, which adds the side-effect of reading from command line options. It provides the following handler:
 
 ```haskell
 runY :: forall a. YargsSetup -> Y (Effect a) -> Effect a

--- a/text/chapter12.md
+++ b/text/chapter12.md
@@ -85,9 +85,9 @@ Next, we will see how to use the techniques we have learned so far to solve thes
 
 ## The Continuation Monad
 
-Let's translate the `copyFile` example above into PureScript by using the FFI. In doing so, the structure of the computation will become apparent, and we will be led naturally to a monad transformer which is defined in the `purescript-transformers` package - the continuation monad transformer `ContT`.
+Let's translate the `copyFile` example above into PureScript by using the FFI. In doing so, the structure of the computation will become apparent, and we will be led naturally to a monad transformer which is defined in the `transformers` package - the continuation monad transformer `ContT`.
 
-_Note_: in practice, it is not necessary to write these functions by hand every time. Asynchronous file IO functions can be found in the `purescript-node-fs` and `purescript-node-fs-aff` libraries.
+_Note_: in practice, it is not necessary to write these functions by hand every time. Asynchronous file IO functions can be found in the `node-fs` and `node-fs-aff` libraries.
 
 First, we need to gives types to `readFile` and `writeFile` using the FFI. Let's start by defining some type synonyms, and a new effect for file IO:
 
@@ -193,7 +193,7 @@ writeFile path text k =
 
 Now we can spot an important pattern. Each of these functions takes a callback which returns a value in some monad (in this case `Eff (fs :: FS | eff)`) and returns a value in _the same monad_. This means that when the first callback returns a result, that monad can be used to bind the result to the input of the next asynchronous function. In fact, that's exactly what we did by hand in the `copyFile` example.
 
-This is the basis of the _continuation monad transformer_, which is defined in the `Control.Monad.Cont.Trans` module in `purescript-transformers`.
+This is the basis of the _continuation monad transformer_, which is defined in the `Control.Monad.Cont.Trans` module in `transformers`.
 
 `ContT` is defined as a newtype as follows:
 
@@ -393,7 +393,7 @@ We've seen how to use the `ContT` monad and do notation to compose asynchronous 
 
 If we are using `ContT` to transform the `Eff` monad, then we can compute in parallel simply by initiating our two computations one after the other.
 
-The `purescript-parallel` package defines a type class `Parallel` for monads like `Async` which support parallel execution. When we met applicative functors earlier in the book, we observed how applicative functors can be useful for combining parallel computations. In fact, an instance for `Parallel` defines a correspondence between a monad `m` (such as `Async`) and an applicative functor `f` which can be used to combine computations in parallel:
+The `parallel` package defines a type class `Parallel` for monads like `Async` which support parallel execution. When we met applicative functors earlier in the book, we observed how applicative functors can be useful for combining parallel computations. In fact, an instance for `Parallel` defines a correspondence between a monad `m` (such as `Async`) and an applicative functor `f` which can be used to combine computations in parallel:
 
 ```haskell
 class (Monad m, Applicative f) <= Parallel f m | m -> f, f -> m where
@@ -406,7 +406,7 @@ The class defines two functions:
 - `parallel`, which takes computations in the monad `m` and turns them into computations in the applicative functor `f`, and
 - `sequential`, which performs a conversion in the opposite direction.
 
-The `purescript-parallel` library provides a `Parallel` instance for the `Async` monad. It uses mutable references to combine `Async` actions in parallel, by keeping track of which of the two continuations has been called. When both results have been returned, we can compute the final result and pass it to the main continuation.
+The `parallel` library provides a `Parallel` instance for the `Async` monad. It uses mutable references to combine `Async` actions in parallel, by keeping track of which of the two continuations has been called. When both results have been returned, we can compute the final result and pass it to the main continuation.
 
 We can use the `parallel` function to create a version of our `readFileCont` action which can be combined in parallel. Here is a simple example which reads two text files in parallel, and concatenates and prints their results:
 
@@ -445,7 +445,7 @@ We can also combine parallel computations with sequential portions of code, by u
      ```
 
      which returns `Nothing` if the specified computation does not provide a result within the given number of milliseconds.
- 1. (Medium) `purescript-parallel` also provides instances of the `Parallel` class for several monad transformers, including `ExceptT`.
+ 1. (Medium) `parallel` also provides instances of the `Parallel` class for several monad transformers, including `ExceptT`.
 
      Rewrite the parallel file IO example to use `ExceptT` for error handling, instead of lifting `append` with `lift2`. Your solution should use the `ExceptT` transformer to transform the `Async` monad.
 
@@ -458,7 +458,7 @@ We can also combine parallel computations with sequential portions of code, by u
      
      Write a utility which takes a single filename as input, and spiders the JSON files on disk referenced transitively by that file, collecting a list of all referenced files.
 
-     Your utility should use the `purescript-foreign` library to parse the JSON documents, and should fetch files referenced by a single file in parallel.
+     Your utility should use the `foreign` library to parse the JSON documents, and should fetch files referenced by a single file in parallel.
 
 ## Conclusion
 

--- a/text/chapter13.md
+++ b/text/chapter13.md
@@ -4,17 +4,17 @@
 
 In this chapter, we will see a particularly elegant application of type classes to the problem of testing. Instead of testing our code by telling the compiler _how_ to test, we simply assert _what_ properties our code should have. Test cases can be generated randomly from this specification, using type classes to hide the boilerplate code of random data generation. This is called _generative testing_ (or _property-based testing_), a technique made popular by the [QuickCheck](https://wiki.haskell.org/Introduction_to_QuickCheck1) library in Haskell.
 
-The `purescript-quickcheck` package is a port of Haskell's QuickCheck library to PureScript, and for the most part, it preserves the types and syntax of the original library. We will see how to use `purescript-quickcheck` to test a simple library, using Spago to integrate our test suite into our development process.
+The `quickcheck` package is a port of Haskell's QuickCheck library to PureScript, and for the most part, it preserves the types and syntax of the original library. We will see how to use `quickcheck` to test a simple library, using Spago to integrate our test suite into our development process.
 
 ## Project Setup
 
-This chapter's project adds `purescript-quickcheck` as a dependency.
+This chapter's project adds `quickcheck` as a dependency.
 
 In a Spago project, test sources should be placed in the `test` directory, and the main module for the test suite should be named `Test.Main`. The test suite can be run using the `spago test` command.
 
 ## Writing Properties
 
-The `Merge` module implements a simple function `merge`, which we will use to demonstrate the features of the `purescript-quickcheck` library.
+The `Merge` module implements a simple function `merge`, which we will use to demonstrate the features of the `quickcheck` library.
 
 ```haskell
 merge :: Array Int -> Array Int -> Array Int
@@ -33,7 +33,7 @@ In a typical test suite, we might test `merge` by generating a few small test ca
 
 - If `xs` and `ys` are sorted, then `merge xs ys` is the sorted result of both arrays appended together.
 
-`purescript-quickcheck` allows us to test this property directly, by generating random test cases. We simply state the properties that we want our code to have, as functions. In this case, we have a single property:
+`quickcheck` allows us to test this property directly, by generating random test cases. We simply state the properties that we want our code to have, as functions. In this case, we have a single property:
 
 ```haskell
 main = do
@@ -41,7 +41,7 @@ main = do
     eq (merge (sort xs) (sort ys)) (sort $ xs <> ys)
 ```
 
-When we run this code, `purescript-quickcheck` will attempt to disprove the properties we claimed, by generating random inputs `xs` and `ys`, and passing them to our functions. If our function returns `false` for any inputs, the property will be incorrect, and the library will raise an error. Fortunately, the library is unable to disprove our properties after generating 100 random test cases:
+When we run this code, `quickcheck` will attempt to disprove the properties we claimed, by generating random inputs `xs` and `ys`, and passing them to our functions. If our function returns `false` for any inputs, the property will be incorrect, and the library will raise an error. Fortunately, the library is unable to disprove our properties after generating 100 random test cases:
 
 ```text
 $ spago test
@@ -64,7 +64,7 @@ As we can see, this error message is not very helpful, but it can be improved wi
 
 ## Improving Error Messages
 
-To provide error messages along with our failed test cases, `purescript-quickcheck` provides the `<?>` operator. Simply separate the property definition from the error message using `<?>`, as follows:
+To provide error messages along with our failed test cases, `quickcheck` provides the `<?>` operator. Simply separate the property definition from the error message using `<?>`, as follows:
 
 ```haskell
 quickCheck \xs ys ->
@@ -137,11 +137,11 @@ Here, `xs` and `ys` both have type `Array Int`, since the `ints` function has be
  ## Exercises
 
  1. (Easy) Write a function `bools` which forces the types of `xs` and `ys` to be `Array Boolean`, and add additional properties which test `mergePoly` at that type.
- 1. (Medium) Choose a pure function from the core libraries (for example, from the `purescript-arrays` package), and write a QuickCheck property for it, including an appropriate error message. Your property should use a helper function to fix any polymorphic type arguments to either `Int` or `Boolean`.
+ 1. (Medium) Choose a pure function from the core libraries (for example, from the `arrays` package), and write a QuickCheck property for it, including an appropriate error message. Your property should use a helper function to fix any polymorphic type arguments to either `Int` or `Boolean`.
 
 ## Generating Arbitrary Data
 
-Now we will see how the `purescript-quickcheck` library is able to randomly generate test cases for our properties.
+Now we will see how the `quickcheck` library is able to randomly generate test cases for our properties.
 
 Those types whose values can be randomly generated are captured by the `Arbitrary` type class:
 
@@ -154,7 +154,7 @@ The `Gen` type constructor represents the side-effects of _deterministic random 
 
 `Gen` is also a monad and an applicative functor, so we have the usual collection of combinators at our disposal for creating new instances of the `Arbitrary` type class.
 
-For example, we can use the `Arbitrary` instance for the `Int` type, provided in the `purescript-quickcheck` library, to create a distribution on the 256 byte values, using the `Functor` instance for `Gen` to map a function from integers to bytes over arbitrary integer values:
+For example, we can use the `Arbitrary` instance for the `Int` type, provided in the `quickcheck` library, to create a distribution on the 256 byte values, using the `Functor` instance for `Gen` to map a function from integers to bytes over arbitrary integer values:
 
 ```haskell
 newtype Byte = Byte Int
@@ -395,11 +395,11 @@ Success : Success : ...
      ```
 
      _Hint_: Use the `oneOf` function defined in `Test.QuickCheck.Gen` to define your `Arbitrary` instance.
- 1. (Medium) Use the `all` function to simplify the result of the `quickCheckPure` function - your function should return `true` if every test passes, and `false` otherwise. Try using the `First` monoid, defined in `purescript-monoids` with the `foldMap` function to preserve the first error in case of failure.
+ 1. (Medium) Use the `all` function to simplify the result of the `quickCheckPure` function - your function should return `true` if every test passes, and `false` otherwise. Try using the `First` monoid, defined in `monoids` with the `foldMap` function to preserve the first error in case of failure.
 
 ## Conclusion
 
-In this chapter, we met the `purescript-quickcheck` package, which can be used to write tests in a declarative way using the paradigm of _generative testing_. In particular:
+In this chapter, we met the `quickcheck` package, which can be used to write tests in a declarative way using the paradigm of _generative testing_. In particular:
 
 - We saw how to automate QuickCheck tests using `spago test`.
 - We saw how to write properties as functions, and how to use the `<?>` operator to improve error messages.

--- a/text/chapter14.md
+++ b/text/chapter14.md
@@ -8,7 +8,7 @@ A domain-specific language is a language which is well-suited to development in 
 
 - The `Game` monad and its associated actions, developed in chapter 11, constitute a domain-specific language for the domain of _text adventure game development_.
 - The library of combinators which we wrote for the `Async` and `Parallel` functors in chapter 12 could be considered an example of a domain-specific language for the domain of _asynchronous programming_.
-- The `purescript-quickcheck` package, covered in chapter 13, is a domain-specific language for the domain of _generative testing_. Its combinators enable a particularly expressive notation for test properties.
+- The `quickcheck` package, covered in chapter 13, is a domain-specific language for the domain of _generative testing_. Its combinators enable a particularly expressive notation for test properties.
 
 This chapter will take a more structured approach to some of standard techniques in the implementation of domain-specific languages. It is by no means a complete exposition of the subject, but should provide you with enough knowledge to build some practical DSLs for your own tasks.
 
@@ -16,7 +16,7 @@ Our running example will be a domain-specific language for creating HTML documen
 
 ## Project Setup
 
-The project accompanying this chapter adds one new dependency - the `purescript-free` library, which defines the _free monad_, one of the tools which we will be using.
+The project accompanying this chapter adds one new dependency - the `free` library, which defines the _free monad_, one of the tools which we will be using.
 
 We will test this chapter's project in PSCi.
 
@@ -391,7 +391,7 @@ p [ _class := "main" ] $ do
 
 However, do notation is not the only benefit of a free monad. The free monad allows us to separate the _representation_ of our monadic actions from their _interpretation_, and even support _multiple interpretations_ of the same actions.
 
-The `Free` monad is defined in the `purescript-free` library, in the `Control.Monad.Free` module. We can find out some basic information about it using PSCi, as follows:
+The `Free` monad is defined in the `free` library, in the `Control.Monad.Free` module. We can find out some basic information about it using PSCi, as follows:
 
 ```text
 > import Control.Monad.Free

--- a/text/chapter2.md
+++ b/text/chapter2.md
@@ -164,13 +164,13 @@ The generated modules will be placed in the `output` directory by default. Each 
 
 ## Tracking Dependencies
 
-To write the `diagonal` function (the goal of this chapter), we will need to be able to compute square roots. The `purescript-math` package contains type definitions for functions defined on the JavaScript `Math` object, so let's install it:
+To write the `diagonal` function (the goal of this chapter), we will need to be able to compute square roots. The `math` package contains type definitions for functions defined on the JavaScript `Math` object, so let's install it:
 
 ```text
 $ spago install math
 ```
 
-The `purescript-math` library sources should now be available in the `.spago/math/{version}/` subdirectory, and will be included when you compile your project.
+The `math` library sources should now be available in the `.spago/math/{version}/` subdirectory, and will be included when you compile your project.
 
 ## Computing Diagonals
 

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -25,7 +25,7 @@ import Data.Maybe (Maybe)
 Here, we import several modules:
 
 - The `Control.Plus` module, which defines the `empty` value.
-- The `Data.List` module, which is provided by the `purescript-lists` package which can be installed using Spago. It contains a few functions which we will need for working with linked lists.
+- The `Data.List` module, which is provided by the `lists` package which can be installed using Spago. It contains a few functions which we will need for working with linked lists.
 - The `Data.Maybe` module, which defines data types and functions for working with optional values.
 
 Notice that the imports for these modules are listed explicitly in parentheses. This is generally a good practice, as it helps to avoid conflicting imports.

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -18,11 +18,11 @@ The `FileOperations` module contains functions which use the `Data.Path` API. So
 
 The project has the following dependencies:
 
-- `purescript-maybe`, which defines the `Maybe` type constructor
-- `purescript-arrays`, which defines functions for working with arrays
-- `purescript-strings`, which defines functions for working with JavaScript strings
-- `purescript-foldable-traversable`, which defines functions for folding arrays and other data structures
-- `purescript-console`, which defines functions for printing to the console
+- `maybe`, which defines the `Maybe` type constructor
+- `arrays`, which defines functions for working with arrays
+- `strings`, which defines functions for working with JavaScript strings
+- `foldable-traversable`, which defines functions for folding arrays and other data structures
+- `console`, which defines functions for printing to the console
 
 ## Introduction
 
@@ -288,7 +288,7 @@ Great! Now that we have all of the pairs of potential factors, we can use `filte
 [[1,10],[2,5]]
 ```
 
-This code uses the `product` function from the `Data.Foldable` module in the `purescript-foldable-traversable` library.
+This code uses the `product` function from the `Data.Foldable` module in the `foldable-traversable` library.
 
 Excellent! We've managed to find the correct set of factor pairs without duplicates.
 
@@ -337,7 +337,7 @@ and the result would be the same.
 
 ## Guards
 
-One further change we can make to the `factors` function is to move the filter inside the array comprehension. This is possible using the `guard` function from the `Control.MonadZero` module (from the `purescript-control` package):
+One further change we can make to the `factors` function is to move the filter inside the array comprehension. This is possible using the `guard` function from the `Control.MonadZero` module (from the `control` package):
 
 ```haskell
 import Control.MonadZero (guard)
@@ -475,7 +475,7 @@ This is a problem. If we are going to adopt recursion as a standard technique fr
 
 PureScript provides a partial solution to this problem in the form of _tail recursion optimization_.
 
-_Note_: more complete solutions to the problem can be implemented in libraries using so-called _trampolining_, but that is beyond the scope of this chapter. The interested reader can consult the documentation for the `purescript-free` and `purescript-tailrec` packages.
+_Note_: more complete solutions to the problem can be implemented in libraries using so-called _trampolining_, but that is beyond the scope of this chapter. The interested reader can consult the documentation for the `free` and `tailrec` packages.
 
 The key observation which enables tail recursion optimization is the following: a recursive call in _tail position_ to a function can be replaced with a _jump_, which does not allocate a stack frame. A call is in _tail position_ when it is the last call made before a function returns. This is the reason why we observed a stack overflow in the example - the recursive call to `f` was _not_ in tail position.
 

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -16,8 +16,8 @@ The source code for this chapter is defined in the file `src/Data/Picture.purs`.
 
 The project uses some packages which we have already seen, and adds the following new dependencies:
 
-- `purescript-globals`, which provides access to some common JavaScript values and functions.
-- `purescript-math`, which provides access to the JavaScript `Math` module.
+- `globals`, which provides access to some common JavaScript values and functions.
+- `math`, which provides access to the JavaScript `Math` module.
 
 The `Data.Picture` module defines a data type `Shape` for simple shapes, and a type `Picture` for collections of shapes, along with functions for working with those types.  
 
@@ -385,7 +385,7 @@ This declaration defines `Shape` as a sum of different constructors, and for eac
 
 An algebraic data type is introduced using the `data` keyword, followed by the name of the new type and any type arguments. The type's constructors are defined after the equals symbol, and are separated by pipe characters (`|`).
 
-Let's see another example from PureScript's standard libraries. We saw the `Maybe` type, which is used to define optional values, earlier in the book. Here is its definition from the `purescript-maybe` package:
+Let's see another example from PureScript's standard libraries. We saw the `Maybe` type, which is used to define optional values, earlier in the book. Here is its definition from the `maybe` package:
 
 ```haskell
 data Maybe a = Nothing | Just a
@@ -399,7 +399,7 @@ Data constructors can also be used to define recursive data structures. Here is 
 data List a = Nil | Cons a (List a)
 ```
 
-This example is taken from the `purescript-lists` package. Here, the `Nil` constructor represents an empty list, and `Cons` is used to create non-empty lists from a head element and a tail. Notice how the tail is defined using the data type `List a`, making this a recursive data type.
+This example is taken from the `lists` package. Here, the `Nil` constructor represents an empty list, and `Cons` is used to create non-empty lists from a head element and a tail. Notice how the tail is defined using the data type `List a`, making this a recursive data type.
 
 ## Using ADTs
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -14,11 +14,11 @@ The source code for this chapter is defined in the file `src/Data/Hashable.purs`
 
 The project has the following dependencies:
 
-- `purescript-maybe`, which defines the `Maybe` data type, which represents optional values.
-- `purescript-tuples`, which defines the `Tuple` data type, which represents pairs of values.
-- `purescript-either`, which defines the `Either` data type, which represents disjoint unions.
-- `purescript-strings`, which defines functions which operate on strings.
-- `purescript-functions`, which defines some helper functions for defining PureScript functions.
+- `maybe`, which defines the `Maybe` data type, which represents optional values.
+- `tuples`, which defines the `Tuple` data type, which represents pairs of values.
+- `either`, which defines the `Either` data type, which represents disjoint unions.
+- `strings`, which defines functions which operate on strings.
+- `functions`, which defines some helper functions for defining PureScript functions.
 
 The module `Data.Hashable` imports several modules provided by these packages.
 
@@ -177,7 +177,7 @@ class EuclideanRing a <= Field a
 
 The `Field` type class is composed from several more general _superclasses_. This allows us to talk abstractly about types which support some but not all of the `Field` operations. For example, a type of natural numbers would be closed under addition and multiplication, but not necessarily under subtraction, so that type might have an instance of the `Semiring` class (which is a superclass of `Num`), but not an instance of `Ring` or `Field`.
 
-Superclasses will be explained later in this chapter, but the full numeric type class hierarchy is beyond the scope of this chapter. The interested reader is encouraged to read the documentation for the superclasses of `Field` in `purescript-prelude`.
+Superclasses will be explained later in this chapter, but the full numeric type class hierarchy is beyond the scope of this chapter. The interested reader is encouraged to read the documentation for the superclasses of `Field` in `prelude`.
 
 ### Semigroups and Monoids
 
@@ -188,11 +188,11 @@ class Semigroup a where
   append :: a -> a -> a
 ```
 
-Strings form a semigroup under regular string concatenation, and so do arrays. Several other standard instances are provided by the `purescript-prelude` package.
+Strings form a semigroup under regular string concatenation, and so do arrays. Several other standard instances are provided by the `prelude` package.
 
 The `<>` concatenation operator, which we have already seen, is provided as an alias for `append`.
 
-The `Monoid` type class (provided by the `purescript-prelude` package) extends the `Semigroup` type class with the concept of an empty value, called `mempty`:
+The `Monoid` type class (provided by the `prelude` package) extends the `Semigroup` type class with the concept of an empty value, called `mempty`:
 
 ```haskell
 class Semigroup m <= Monoid m where
@@ -215,13 +215,13 @@ A `Monoid` type class instance for a type describes how to _accumulate_ a result
 [1,2,3,4,5,6]
 ```
 
-The `purescript-prelude` package provides many examples of monoids and semigroups, which we will use in the rest of the book.
+The `prelude` package provides many examples of monoids and semigroups, which we will use in the rest of the book.
 
 ### Foldable
 
 If the `Monoid` type class identifies those types which act as the result of a fold, then the `Foldable` type class identifies those type constructors which can be used as the source of a fold.
 
-The `Foldable` type class is provided in the `purescript-foldable-traversable` package, which also contains instances for some standard containers such as arrays and `Maybe`.
+The `Foldable` type class is provided in the `foldable-traversable` package, which also contains instances for some standard containers such as arrays and `Maybe`.
 
 The type signatures for the functions belonging to the `Foldable` class are a little more complicated than the ones we've seen so far:
 
@@ -247,7 +247,7 @@ Let's try out `foldMap` in PSCi:
 
 Here, we choose the monoid for strings, which concatenates strings together, and the `show` function which renders an `Int` as a `String`. Then, passing in an array of integers, we see that the results of `show`ing each integer have been concatenated into a single `String`.
 
-But arrays are not the only types which are foldable. `purescript-foldable-traversable` also defines `Foldable` instances for types like `Maybe` and `Tuple`, and other libraries like `purescript-lists` define `Foldable` instances for their own data types. `Foldable` captures the notion of an _ordered container_.
+But arrays are not the only types which are foldable. `foldable-traversable` also defines `Foldable` instances for types like `Maybe` and `Tuple`, and other libraries like `lists` define `Foldable` instances for their own data types. `Foldable` captures the notion of an _ordered container_.
 
 ### Functor, and Type Class Laws
 
@@ -375,7 +375,7 @@ Overlapping type class instances found for Data.Show.Show T
 
 The overlapping instances rule is enforced so that automatic selection of type class instances is a predictable process. If we allowed two type class instances for a type to exist, then either could be chosen depending on the order of module imports, and that could lead to unpredictable behavior of the program at runtime, which is undesirable.
 
-If it is truly the case that there are two valid type class instances for a type, satisfying the appropriate laws, then a common approach is to define newtypes which wrap the existing type. Since different newtypes are allowed to have different type class instances under the overlapping instances rule, there is no longer an issue. This approach is taken in PureScript's standard libraries, for example in `purescript-maybe`, where the `Maybe a` type has multiple valid instances for the `Monoid` type class.
+If it is truly the case that there are two valid type class instances for a type, satisfying the appropriate laws, then a common approach is to define newtypes which wrap the existing type. Since different newtypes are allowed to have different type class instances under the overlapping instances rule, there is no longer an issue. This approach is taken in PureScript's standard libraries, for example in `maybe`, where the `Maybe a` type has multiple valid instances for the `Monoid` type class.
 
 ## Instance Dependencies
 
@@ -396,7 +396,7 @@ instance showEither :: (Show a, Show b) => Show (Either a b) where
   ...
 ```
 
-These two type class instances are provided in the `purescript-prelude` library.
+These two type class instances are provided in the `prelude` library.
 
 When the program is compiled, the correct type class instance for `Show` is chosen based on the inferred type of the argument to `show`. The selected instance might depend on many such instance relationships, but this complexity is not exposed to the developer.
 

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -14,8 +14,8 @@ The source code for this chapter is defined in the files `src/Data/AddressBook.p
 
 The project has a number of dependencies, many of which we have seen before. There are two new dependencies:
 
-- `purescript-control`, which defines functions for abstracting control flow using type classes like `Applicative`.
-- `purescript-validation`, which defines a functor for _applicative validation_, the subject of this chapter.
+- `control`, which defines functions for abstracting control flow using type classes like `Applicative`.
+- `validation`, which defines a functor for _applicative validation_, the subject of this chapter.
 
 The `Data.AddressBook` module defines data types and `Show` instances for the types in our project, and the `Data.AddressBook.Validation` module contains validation rules for those types.
 
@@ -476,7 +476,7 @@ This function can be seen to work in PSCi, but has a limitation which we have se
 
 The `Either String` applicative functor only provides the first error encountered. Given the input here, we would prefer to see two errors - one for the missing first name, and a second for the missing last name.
 
-There is another applicative functor which is provided by the `purescript-validation` library. This functor is called `V`, and it provides the ability to return errors in any _semigroup_. For example, we can use `V (Array String)` to return an array of `String`s as errors, concatenating new errors onto the end of the array.
+There is another applicative functor which is provided by the `validation` library. This functor is called `V`, and it provides the ability to return errors in any _semigroup_. For example, we can use `V (Array String)` to return an array of `String`s as errors, concatenating new errors onto the end of the array.
 
 The `Data.AddressBook.Validation` module uses the `V (Array String)` applicative functor to validate the data structures in the `Data.AddressBook` module.
 
@@ -719,7 +719,7 @@ However, in general, applicative functors are more general than this. The applic
 
 For example, the `V` validation functor returned an _array_ of errors, but it would work just as well if we picked the `Set` semigroup, in which case it would not matter what order we ran the various validators. We could even run them in parallel over the data structure!
 
-As a second example, the `purescript-parallel` package provides a type class `Parallel` which supports _parallel computations_. `Parallel` provides a function `parallel` which uses some `Applicative` functor to compute the result of its input computation _in parallel_:
+As a second example, the `parallel` package provides a type class `Parallel` which supports _parallel computations_. `Parallel` provides a function `parallel` which uses some `Applicative` functor to compute the result of its input computation _in parallel_:
 
 ```haskell
 f <$> parallel computation1

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -10,9 +10,9 @@ The goal of this chapter is to explain why monads are a useful abstraction, and 
 
 The project adds the following dependencies:
 
-- `purescript-effect`, which defines the `Effect` monad, the subject of the second half of the chapter.
-- `purescript-aff`, an asynchronous effect monad.
-- `purescript-random`, a monadic random number generator.
+- `effect`, which defines the `Effect` monad, the subject of the second half of the chapter.
+- `aff`, an asynchronous effect monad.
+- `random`, a monadic random number generator.
 
 ## Monads and Do Notation
 
@@ -325,7 +325,7 @@ In the last chapter, we saw that the `Applicative` type class can be used to exp
 
  ## Exercises
 
- 1. (Easy) Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `purescript-arrays` package. Use do notation with the `Maybe` monad to combine these functions into a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type.
+ 1. (Easy) Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `arrays` package. Use do notation with the `Maybe` monad to combine these functions into a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type.
  1. (Medium) Write a function `sums` which uses `foldM` to determine all possible totals that could be made using a set of coins. The coins will be specified as an array which contains the value of each coin. Your function should have the following result:
 
      ```text
@@ -338,7 +338,7 @@ In the last chapter, we saw that the `Applicative` type class can be used to exp
 
      _Hint_: This function can be written as a one-liner using `foldM`. You might want to use the `nub` and `sort` functions to remove duplicates and sort the result respectively.
  1. (Medium) Confirm that the `ap` function and the `apply` operator agree for the `Maybe` monad.
- 1. (Medium) Verify that the monad laws hold for the `Monad` instance for the `Maybe` type, as defined in the `purescript-maybe` package.
+ 1. (Medium) Verify that the monad laws hold for the `Monad` instance for the `Maybe` type, as defined in the `maybe` package.
  1. (Medium) Write a function `filterM` which generalizes the `filter` function on lists. Your function should have the following type signature:
 
      ```haskell
@@ -411,7 +411,7 @@ The Spago build tool (and other tools) provide a shortcut, by generating additio
 
 The goal of the `Effect` monad is to provide a well-typed API for computations with side-effects, while at the same time generating efficient JavaScript. 
 
-Here is an example. It uses the `purescript-random` package, which defines functions for generating random numbers:
+Here is an example. It uses the `random` package, which defines functions for generating random numbers:
 
 ```haskell
 module Main where
@@ -460,7 +460,7 @@ asyncFunction onSuccess onError = ...
 
 But as is true in JavaScript, this can quickly get out of hand and result in "callback hell". 
 
-The `Aff` monad solves this problem similar to how `Promise` solves it in JavaScript, and there is a great library called `purescript-aff-promise` that provides interop with JavaScript `Promise`.
+The `Aff` monad solves this problem similar to how `Promise` solves it in JavaScript, and there is a great library called `aff-promise` that provides interop with JavaScript `Promise`.
 
 ## Effect to Aff and Aff to Effect
 

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -2,14 +2,14 @@
 
 ## Chapter Goals
 
-This chapter will be an extended example focussing on the `purescript-canvas` package, which provides a way to generate 2D graphics from PureScript using the HTML5 Canvas API.
+This chapter will be an extended example focussing on the `canvas` package, which provides a way to generate 2D graphics from PureScript using the HTML5 Canvas API.
 
 ## Project Setup
 
 This module's project introduces the following new dependencies:
 
-- `purescript-canvas`, which gives types to methods from the HTML5 Canvas API
-- `purescript-refs`, which provides a side-effect for using _global mutable references_
+- `canvas`, which gives types to methods from the HTML5 Canvas API
+- `refs`, which provides a side-effect for using _global mutable references_
 
 The source code for the chapter is broken up into a set of modules, each of which defines a `main` method. Different sections of this chapter are implemented in different files, and the `Main` module can be changed by modifying the Spago build command to run the appropriate file's `main` method at each point.
 
@@ -253,7 +253,7 @@ and view the result by opening `html/index.html`.
 
 There is more to the canvas than just rendering simple shapes. Every canvas maintains a transformation which is used to transform shapes before rendering. Shapes can be translated, rotated, scaled, and skewed.
 
-The `purescript-canvas` library supports these transformations using the following functions:
+The `canvas` library supports these transformations using the following functions:
 
 ```haskell
 translate :: Context2D
@@ -300,7 +300,7 @@ The effect of this sequence of actions is that the scene is rotated, then scaled
 
 A common use case is to render some subset of the scene using a transformation, and then to reset the transformation afterwards.
 
-The Canvas API provides the `save` and `restore` methods, which manipulate a _stack_ of states associated with the canvas. `purescript-canvas` wraps this functionality into the following functions:
+The Canvas API provides the `save` and `restore` methods, which manipulate a _stack_ of states associated with the canvas. `canvas` wraps this functionality into the following functions:
 
 ```haskell
 save
@@ -324,7 +324,7 @@ rotated ctx render = do
   restore ctx
 ```
 
-In the interest of abstracting over common use cases using higher-order functions, the `purescript-canvas` library provides the `withContext` function, which performs some canvas action while preserving the original context state:
+In the interest of abstracting over common use cases using higher-order functions, the `canvas` library provides the `withContext` function, which performs some canvas action while preserving the original context state:
 
 ```haskell
 withContext
@@ -344,7 +344,7 @@ rotated ctx render =
 
 ## Global Mutable State
 
-In this section, we'll use the `purescript-refs` package to demonstrate another effect in the `Effect` monad.
+In this section, we'll use the `refs` package to demonstrate another effect in the `Effect` monad.
 
 The `Effect.Ref` module provides a type constructor for global mutable references, and an associated effect:
 
@@ -414,7 +414,7 @@ and open the `html/index.html` file. If you click the canvas repeatedly, you sho
 
 ## L-Systems
 
-In this final example, we will use the `purescript-canvas` package to write a function for rendering _L-systems_ (or _Lindenmayer systems_).
+In this final example, we will use the `canvas` package to write a function for rendering _L-systems_ (or _Lindenmayer systems_).
 
 An L-system is defined by an _alphabet_, an initial sequence of letters from the alphabet, and a set of _production rules_. Each production rule takes a letter of the alphabet and returns a sequence of replacement letters. This process is iterated some number of times starting with the initial sequence of letters.
 
@@ -550,7 +550,7 @@ lsystem init prod interpret n state = go init n
 
 The `go` function works by recursion on its second argument. There are two cases: when `n` is zero, and when `n` is non-zero.
 
-In the first case, the recursion is complete, and we simply need to interpret the current sentence according to the interpretation function. We have a sentence of type `Array a`, a state of type `s`, and a function of type `s -> a -> Effect s`. This sounds like a job for the `foldM` function which we defined earlier, and which is available from the `purescript-control` package:
+In the first case, the recursion is complete, and we simply need to interpret the current sentence according to the interpretation function. We have a sentence of type `Array a`, a state of type `s`, and a function of type `s -> a -> Effect s`. This sounds like a job for the `foldM` function which we defined earlier, and which is available from the `control` package:
 
 ```haskell
   go s 0 = foldM interpret state s
@@ -664,7 +664,7 @@ and open `html/index.html`. You should see the Koch curve rendered to the canvas
 
 ## Conclusion
 
-In this chapter, we learned how to use the HTML5 Canvas API from PureScript by using the `purescript-canvas` library. We also saw a practical demonstration of many of the techniques we have learned already: maps and folds, records and row polymorphism, and the `Effect` monad for handling side-effects.
+In this chapter, we learned how to use the HTML5 Canvas API from PureScript by using the `canvas` library. We also saw a practical demonstration of many of the techniques we have learned already: maps and folds, records and row polymorphism, and the `Effect` monad for handling side-effects.
 
 The examples also demonstrated the power of higher-order functions and _separating data from implementation_. It would be possible to extend these ideas to completely separate the representation of a scene from its rendering function, using an algebraic data type, for example:
 
@@ -678,6 +678,6 @@ data Scene
   | ...
 ```
 
-This approach is taken in the `purescript-drawing` package, and it brings the flexibility of being able to manipulate the scene as data in various ways before rendering.
+This approach is taken in the `drawing` package, and it brings the flexibility of being able to manipulate the scene as data in various ways before rendering.
 
-In the next chapter, we will see how to implement libraries like `purescript-canvas` which wrap existing JavaScript functionality, by using PureScript's _foreign function interface_.
+In the next chapter, we will see how to implement libraries like `canvas` which wrap existing JavaScript functionality, by using PureScript's _foreign function interface_.


### PR DESCRIPTION
This used to be required by bower, but is not required by spago