### PR TITLE
Add 'Chapter x' to Exercises and Conclusion headers to fix ToC links

### DIFF
--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -719,7 +719,7 @@ Try out the code, by running `spago bundle-app --to dist/Main.js`, and then open
 
 _Note_: You may need to serve the HTML and JavaScript files from a HTTP server locally in order to avoid certain browser-specific issues.
 
- ## Exercises
+ ## Chapter 10 Exercises
 
  1. (Easy) Use `decodeJSON` to parse a JSON document representing a two-dimensional JavaScript array of integers, such as `[[1, 2, 3], [4, 5], [6]]`. What if the elements are allowed to be null? What if the arrays themselves are allowed to be null?
  1. (Medium) Convince yourself that the implementation of `savedData` should type-check, and write down the inferred types of each subexpression in the computation.
@@ -740,7 +740,7 @@ _Note_: You may need to serve the HTML and JavaScript files from a HTTP server l
 
      Write instances for `Encode` and `Decode` for the `IntOrString` data type which implement this behavior, and verify that encoded values can correctly be decoded in PSCi.
 
-## Conclusion
+## Chapter 10 Conclusion
 
 In this chapter, we've learned how to work with foreign JavaScript code from PureScript, and vice versa, and we've seen the issues involved with writing trustworthy code using the FFI:
 

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -1011,11 +1011,11 @@ This demonstrates two basic functions defined in the `Node.Yargs.Applicative` mo
 
 Notice how we were able to use the notation afforded by the applicative operators to give a compact, declarative specification of our command line interface. In addition, it is simple to add new command line arguments, simply by adding a new function argument to `runGame`, and then using `<*>` to lift `runGame` over an additional argument in the definition of `env`.
 
- ## Exercises
+ ## Chapter 11 Exercises
 
  1. (Medium) Add a new Boolean-valued property `cheatMode` to the `GameEnvironment` record. Add a new command line flag `-c` to the `yargs` configuration which enables cheat mode. The `cheat` command from the previous exercise should be disallowed if cheat mode is not enabled.
 
-## Conclusion
+## Chapter 11 Conclusion
 
 This chapter was a practical demonstration of the techniques we've learned so far, using monad transformers to build a pure specification of our game, and the `Effect` monad to build a front-end using the console.
 

--- a/text/chapter12.md
+++ b/text/chapter12.md
@@ -24,7 +24,7 @@ function readText(onSuccess, onFailure) {
       onFailure(error.code);
     } else {
       onSuccess(data);
-    }   
+    }
   });
 }
 ```
@@ -45,7 +45,7 @@ function copyFile(onSuccess, onFailure) {
           onSuccess();
         }
       });
-    }   
+    }
   });
 }
 ```
@@ -71,7 +71,7 @@ function copyFile(onSuccess, onFailure) {
       onFailure(error.code);
     } else {
       writeCopy(data, onSuccess, onFailure);
-    }   
+    }
   });
 }
 ```
@@ -430,7 +430,7 @@ Because applicative functors support lifting of functions of arbitrary arity, we
 
 We can also combine parallel computations with sequential portions of code, by using applicative combinators in a do notation block, or vice versa, using `parallel` and `sequential` to change type constructors where appropriate.
 
- ## Exercises
+ ## Chapter 12 Exercises
 
  1. (Easy) Use `parallel` and `sequential` to make two HTTP requests and collect their response bodies in parallel. Your combining function should concatenate the two response bodies, and your continuation should use `print` to print the result to the console.
  1. (Medium) The applicative functor which corresponds to `Async` is also an instance of `Alternative`. The `<|>` operator defined by this instance runs two computations in parallel, and returns the result from the computation which completes first.
@@ -455,12 +455,12 @@ We can also combine parallel computations with sequential portions of code, by u
      ```javascript
      { references: ['/tmp/1.json', '/tmp/2.json'] }
      ```
-     
+
      Write a utility which takes a single filename as input, and spiders the JSON files on disk referenced transitively by that file, collecting a list of all referenced files.
 
      Your utility should use the `foreign` library to parse the JSON documents, and should fetch files referenced by a single file in parallel.
 
-## Conclusion
+## Chapter 12 Conclusion
 
 In this chapter, we have seen a practical demonstration of monad transformers:
 

--- a/text/chapter13.md
+++ b/text/chapter13.md
@@ -384,7 +384,7 @@ Success : Success : ...
 
 `quickCheckPure` might be useful in other situations, such as generating random input data for performance benchmarks, or generating sample form data for web applications.
 
- ## Exercises
+ ## Chapter 13 Exercises
 
  1. (Easy) Write `Coarbitrary` instances for the `Byte` and `Sorted` type constructors.
  1. (Medium) Write a (higher-order) property which asserts associativity of the `mergeWith f` function for any function `f`. Test your property in PSCi using `quickCheckPure`.
@@ -397,7 +397,7 @@ Success : Success : ...
      _Hint_: Use the `oneOf` function defined in `Test.QuickCheck.Gen` to define your `Arbitrary` instance.
  1. (Medium) Use the `all` function to simplify the result of the `quickCheckPure` function - your function should return `true` if every test passes, and `false` otherwise. Try using the `First` monoid, defined in `monoids` with the `foldMap` function to preserve the first error in case of failure.
 
-## Conclusion
+## Chapter 13 Conclusion
 
 In this chapter, we met the `quickcheck` package, which can be used to write tests in a declarative way using the paradigm of _generative testing_. In particular:
 

--- a/text/chapter14.md
+++ b/text/chapter14.md
@@ -702,10 +702,10 @@ unit
 
 You can verify that multiple calls to `newName` do in fact result in unique names.
 
- ## Exercises
+ ## Chapter 14 Exercises
 
  1. (Medium) We can simplify the API further by hiding the `Element` type from its users. Make these changes in the following steps:
-     
+
      - Combine functions like `p` and `img` (with return type `Element`) with the `elem` action to create new actions with return type `Content Unit`.
      - Change the `render` function to accept an argument of type `Content Unit` instead of `Element`.
  1. (Medium) Hide the implementation of the `Content` monad by using a `newtype` instead of a type synonym. You should not export the data
@@ -720,7 +720,7 @@ You can verify that multiple calls to `newName` do in fact result in unique name
 
      _Hint_: use the `ask` action and the `ReaderT` monad transformer to interpret this action. Alternatively, you might prefer to use the `RWS` monad.
 
-## Conclusion
+## Chapter 14 Conclusion
 
 In this chapter, we developed a domain-specific language for creating HTML documents, by incrementally improving a naive implementation using some standard techniques:
 

--- a/text/chapter2.md
+++ b/text/chapter2.md
@@ -293,12 +293,12 @@ Array Int
 
 Try out the interactive mode now. If you get stuck at any point, simply use the Clear command `:clear` to unload any modules which may be compiled in memory.
 
-## Exercises
+## Chapter 2 Exercises
 
  1. (Easy) Use the `pi` constant, which is defined in the `Math` module, to write a function `circleArea` which computes the area of a circle with a given radius. Test your function using PSCi (_Hint_: don't forget to import `pi` by modifying the `import Math` statement).
  1. (Medium) Use `spago install` to install the `globals` package as a dependency. Test out its functions in PSCi (_Hint_: you can use the `:browse` command in PSCi to browse the contents of a module; try `:browse Global` and compare what PSCi tells you to what you find in **[Pursuit](https://pursuit.purescript.org/packages/purescript-globals/4.1.0/docs/Global)**).
 
-## Conclusion
+## Chapter 2 Conclusion
 
 In this chapter, we set up a simple PureScript project using the Spago tool.
 

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -608,14 +608,14 @@ Either way, this gives a clear definition of the `findEntry` function: "`findEnt
 
 I will let you make your own decision which definition is easier to understand, but it is often useful to think of functions as building blocks in this way - each function executing a single task, and solutions assembled using function composition.
 
-## Exercises
+## Chapter 3 Exercises
 
  1. (Easy) Test your understanding of the `findEntry` function by writing down the types of each of its major subexpressions. For example, the type of the `head` function as used is specialized to `AddressBook -> Maybe Entry`.
  1. (Medium) Write a function which looks up an `Entry` given a street address, by reusing the existing code in `findEntry`. Test your function in PSCi.
  1. (Medium) Write a function which tests whether a name appears in a `AddressBook`, returning a Boolean value. _Hint_: Use PSCi to find the type of the `Data.List.null` function, which test whether a list is empty or not.
  1. (Difficult) Write a function `removeDuplicates` which removes duplicate address book entries with the same first and last names. _Hint_: Use PSCi to find the type of the `Data.List.nubBy` function, which removes duplicate elements from a list based on an equality predicate.
 
-## Conclusion
+## Chapter 3 Conclusion
 
 In this chapter, we covered several new functional programming concepts:
 

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -641,7 +641,7 @@ allFiles' file = file : do
 
 Try out the new version in PSCi - you should get the same result. I'll let you decide which version you find clearer.
 
- ## Exercises
+ ## Chapter 4 Exercises
 
  1. (Easy) Write a function `onlyFiles` which returns all _files_ (not directories) in all subdirectories of a directory.
  1. (Medium) Write a fold to determine the largest and smallest files in the filesystem.
@@ -650,13 +650,13 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
      ```text
      > whereIs "/bin/ls"
      Just (/bin/)
-     
+
      > whereIs "/bin/cat"
      Nothing
      ```
 
      _Hint_: Try to write this function as an array comprehension using do notation.
 
-## Conclusion
+## Chapter 4 Conclusion
 
 In this chapter, we covered the basics of recursion in PureScript, as a means of expressing algorithms concisely. We also introduced user-defined infix operators, standard functions on arrays such as maps, filters and folds, and array comprehensions which combine these ideas. Finally, we showed the importance of using tail recursion in order to avoid stack overflow errors, and how to use accumulator parameters to convert functions to tail recursive form.

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -19,7 +19,7 @@ The project uses some packages which we have already seen, and adds the followin
 - `globals`, which provides access to some common JavaScript values and functions.
 - `math`, which provides access to the JavaScript `Math` module.
 
-The `Data.Picture` module defines a data type `Shape` for simple shapes, and a type `Picture` for collections of shapes, along with functions for working with those types.  
+The `Data.Picture` module defines a data type `Shape` for simple shapes, and a type `Picture` for collections of shapes, along with functions for working with those types.
 
 The module imports the `Data.Foldable` module, which provides functions for folding data structures:
 
@@ -550,17 +550,17 @@ In the base case, we need to find the smallest bounding rectangle of an empty `P
 
 The accumulating function `combine` is defined in a `where` block. `combine` takes a bounding rectangle computed from `foldl`'s recursive call, and the next `Shape` in the array, and uses the `union` function to compute the union of the two bounding rectangles. The `shapeBounds` function computes the bounds of a single shape using pattern matching.
 
- ## Exercises
+ ## Chapter 5 Exercises
 
  1. (Medium) Extend the vector graphics library with a new operation `area` which computes the area of a `Shape`. For the purpose of this exercise, the area of a piece of text is assumed to be zero.
  1. (Difficult) Extend the `Shape` type with a new data constructor `Clipped`, which clips another `Picture` to a rectangle. Extend the `shapeBounds` function to compute the bounds of a clipped picture. Note that this makes `Shape` into a recursive data type.
 
-## Conclusion
+## Chapter 5 Conclusion
 
 In this chapter, we covered pattern matching, a basic but powerful technique from functional programming. We saw how to use simple patterns as well as array and record patterns to match parts of deep data structures.
 
 This chapter also introduced algebraic data types, which are closely related to pattern matching. We saw how algebraic data types allow concise descriptions of data structures, and provide a modular way to extend data types with new operations.
 
-Finally, we covered _row polymorphism_, a powerful type of abstraction which allows many idiomatic JavaScript functions to be given a type. 
+Finally, we covered _row polymorphism_, a powerful type of abstraction which allows many idiomatic JavaScript functions to be given a type.
 
 In the rest of the book, we will use ADTs and pattern matching extensively, so it will pay dividends to become familiar with them now. Try creating your own algebraic data types and writing functions to consume them using pattern matching.

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -208,7 +208,7 @@ A `Monoid` type class instance for a type describes how to _accumulate_ a result
 > import Data.Monoid
 > import Data.Foldable
 
-> foldl append mempty ["Hello", " ", "World"]  
+> foldl append mempty ["Hello", " ", "World"]
 "Hello World"
 
 > foldl append mempty [[1, 2, 3], [4, 5], [6]]
@@ -300,7 +300,7 @@ Many standard type classes come with their own set of similar laws. The laws giv
        , imaginary :: Number
        }
      ```
-       
+
      Define `Show` and `Eq` instances for `Complex`.
 
 ## Type Annotations
@@ -589,14 +589,14 @@ Another reason to define a superclass relationship is in the case where there is
      class Monoid m <= Action m a where
        act :: m -> a -> a
      ```
-           
+
      An _action_ is a function which describes how monoidal values can be used to modify a value of another type. There are two laws for the `Action` type class:
 
      - `act mempty a = a`
      - `act (m1 <> m2) a = act m1 (act m2 a)`
 
      That is, the action respects the operations defined by the `Monoid` class.
-        
+
      For example, the natural numbers form a monoid under multiplication:
 
      ```haskell
@@ -714,7 +714,7 @@ What about some more interesting types? To prove the type class law for the `Arr
 
 The source code for this chapter includes several other examples of `Hashable` instances, such as instances for the `Maybe` and `Tuple` type.
 
- ## Exercises
+ ## Chapter 6 Exercises
 
  1. (Easy) Use PSCi to test the hash functions for each of the defined instances.
  1. (Medium) Use the `hashEqual` function to write a function which tests if an array has any duplicate elements, using hash-equality as an approximation to value equality. Remember to check for value equality using `==` if a duplicate pair is found. _Hint_: the `nubByEq` function in `Data.Array` should make this task much simpler.
@@ -722,15 +722,15 @@ The source code for this chapter includes several other examples of `Hashable` i
 
      ```haskell
      newtype Hour = Hour Int
-     
+
      instance eqHour :: Eq Hour where
        eq (Hour n) (Hour m) = mod n 12 == mod m 12
      ```
-     
+
      The newtype `Hour` and its `Eq` instance represent the type of integers modulo 12, so that 1 and 13 are identified as equal, for example. Prove that the type class law holds for your instance.
  1. (Difficult) Prove the type class laws for the `Hashable` instances for `Maybe`, `Either` and `Tuple`.
 
-## Conclusion
+## Chapter 6 Conclusion
 
 In this chapter, we've been introduced to _type classes_, a type-oriented form of abstraction which enables powerful forms of code reuse. We've seen a collection of standard type classes from the PureScript standard libraries, and defined our own library based on a type class for computing hash codes.
 

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -158,7 +158,7 @@ Nothing
 
 Try lifting some other functions of various numbers of arguments over `Maybe` in this way.
 
-Alternatively _applicative do notation_ can be used for the same purpose in a way that looks similar to the familiar _do notation_. Here is `lift3` using _applicative do notation_. Note `ado` is used instead of `do`, and `in` is used on the final line to denote the yielded value: 
+Alternatively _applicative do notation_ can be used for the same purpose in a way that looks similar to the familiar _do notation_. Here is `lift3` using _applicative do notation_. Note `ado` is used instead of `do`, and `in` is used on the final line to denote the yielded value:
 
 ```haskell
 lift3 :: forall a b c d f
@@ -241,7 +241,7 @@ or with _applicative do_
 ```text
 > import Data.Maybe
 
-> :paste… 
+> :paste…
 … ado
 …   f <- Just "Phillip"
 …   m <- Just "A"
@@ -290,7 +290,7 @@ or with _applicative do_
 
 ```text
 > :paste
-… fullNameEither first middle last = ado 
+… fullNameEither first middle last = ado
 …  f <- first  `withError` "First name was missing"
 …  m <- middle `withError` "Middle name was missing"
 …  l <- last   `withError` "Last name was missing"
@@ -435,7 +435,7 @@ Person
                 , number: "555-555-0000"
                 }
             ]
-  }  
+  }
 ```
 
 We saw in a previous section how we could use the `Either String` functor to validate a data structure of type `Person`. For example, provided functions to validate the two names in the structure, we might validate the entire data structure as follows:
@@ -612,12 +612,12 @@ or with _applicative do_
 ```haskell
 validatePersonAdo :: Person -> V Errors Person
 validatePersonAdo (Person o) = ado
-  firstName   <- (nonEmpty "First Name" o.firstName *> 
+  firstName   <- (nonEmpty "First Name" o.firstName *>
                   pure o.firstName)
-  lastName    <- (nonEmpty "Last Name"  o.lastName  *> 
+  lastName    <- (nonEmpty "Last Name"  o.lastName  *>
                   pure o.lastName)
   address     <- validateAddress o.address
-  numbers     <- (arrayNonEmpty "Phone Numbers" o.phones *> 
+  numbers     <- (arrayNonEmpty "Phone Numbers" o.phones *>
                   traverse validatePhoneNumber o.phones)
   in person firstName lastName address numbers
 ```
@@ -698,7 +698,7 @@ These examples show that traversing the `Nothing` value returns `Nothing` with n
 
 Other traversable functors include `Array`, and `Tuple a` and `Either a` for any type `a`. Generally, most "container" data type constructors have `Traversable` instances. As an example, the exercises will include writing a `Traversable` instance for a type of binary trees.
 
- ## Exercises
+ ## Chapter 7 Exercises
 
  1. (Medium) Write a `Traversable` instance for the following binary tree data structure, which combines side-effects from left-to-right:
 
@@ -732,7 +732,7 @@ We will see this idea in more detail when we apply applicative functors to the p
 
 Applicative functors are a natural way to capture side-effects which can be combined in parallel.
 
-## Conclusion
+## Chapter 7 Conclusion
 
 In this chapter, we covered a lot of new ideas:
 

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -47,7 +47,7 @@ We can see that this function works in PSCi:
 > countThrows 10
 [[4,6],[5,5],[6,4]]
 
-> countThrows 12  
+> countThrows 12
 [[6,6]]
 ```
 
@@ -186,7 +186,7 @@ c1 = do
 
 is equivalent to this code:
 
-```haskell  
+```haskell
 c2 = do
   x <- m1
   y <- m2
@@ -203,7 +203,7 @@ The associativity law tells us that it is safe to simplify nested do notation bl
 
 _Note_ that by the definition of how do notation gets desugared into calls to `bind`, both of `c1` and `c2` are also equivalent to this code:
 
-```haskell  
+```haskell
 c3 = do
   x <- m1
   do
@@ -272,7 +272,7 @@ safeDivide _ 0 = Nothing
 safeDivide a b = Just (a / b)
 ```
 
-Then we can use `foldM` to express iterated safe division:  
+Then we can use `foldM` to express iterated safe division:
 
 ```text
 > import Data.List
@@ -323,7 +323,7 @@ Try writing `userCity` using only `pure` and `apply`: you will see that it is im
 
 In the last chapter, we saw that the `Applicative` type class can be used to express parallelism. This was precisely because the function arguments being lifted were independent of one another. Since the `Monad` type class allows computations to depend on the results of previous computations, the same does not apply - a monad has to combine its side-effects in sequence.
 
- ## Exercises
+ ## Chapter 8 Exercises
 
  1. (Easy) Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `arrays` package. Use do notation with the `Maybe` monad to combine these functions into a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type.
  1. (Medium) Write a function `sums` which uses `foldM` to determine all possible totals that could be made using a set of coins. The coins will be specified as an array which contains the value of each coin. Your function should have the following result:
@@ -359,9 +359,9 @@ In the last chapter, we saw that the `Applicative` type class can be used to exp
      ```haskell
      lift2 f (pure a) (pure b) = pure (f a b)
      ```
-     
+
      where the `Applicative` instance uses the `ap` function defined above. Recall that `lift2` was defined as follows:
-    
+
      ```haskell
      lift2 :: forall f a b c. Applicative f => (a -> b -> c) -> f a -> f b -> f c
      lift2 f a b = f <$> a <*> b
@@ -409,7 +409,7 @@ The Spago build tool (and other tools) provide a shortcut, by generating additio
 
 ## The Effect Monad
 
-The goal of the `Effect` monad is to provide a well-typed API for computations with side-effects, while at the same time generating efficient JavaScript. 
+The goal of the `Effect` monad is to provide a well-typed API for computations with side-effects, while at the same time generating efficient JavaScript.
 
 Here is an example. It uses the `random` package, which defines functions for generating random numbers:
 
@@ -439,26 +439,26 @@ Running this command, you will see a randomly chosen number between `0` and `1` 
 
 This program uses do notation to combine two native effects provided by the JavaScript runtime: random number generation and console IO.
 
-As mentioned previously, the `Effect` monad is of central importance to PureScript. The reason why it's central is because it is the conventional way to interoperate with PureScript's `Foreign Function Interface`, which provides the mechanism to execute a program and perform side effects. While it's desireable to avoid using the `Foreign Function Interface`, it's fairly critical to understand how it works and how to use it, so I recommend reading that chapter before doing any serious PureScript work. That said, the `Effect` monad is fairly simple. It has a few helper functions, but aside from that it doesn't do much except encapsulate side effects. 
+As mentioned previously, the `Effect` monad is of central importance to PureScript. The reason why it's central is because it is the conventional way to interoperate with PureScript's `Foreign Function Interface`, which provides the mechanism to execute a program and perform side effects. While it's desireable to avoid using the `Foreign Function Interface`, it's fairly critical to understand how it works and how to use it, so I recommend reading that chapter before doing any serious PureScript work. That said, the `Effect` monad is fairly simple. It has a few helper functions, but aside from that it doesn't do much except encapsulate side effects.
 
 ## The Aff Monad
 
-The `Aff` monad is an asynchronous effect monad and threading model for PureScipt. 
+The `Aff` monad is an asynchronous effect monad and threading model for PureScipt.
 
-Asynchrony is typically achieved in JavaScript with callbacks, for example: 
+Asynchrony is typically achieved in JavaScript with callbacks, for example:
 
 ```javascript
 function asyncFunction(onSuccess, onError){ ... }
 ```
 
-The same thing can be modeled with the `Effect` monad: 
+The same thing can be modeled with the `Effect` monad:
 
 ```haskell
-asyncFunction :: forall success error. (success -> Effect Unit) -> (error -> Effect Unit) -> Effect Unit 
+asyncFunction :: forall success error. (success -> Effect Unit) -> (error -> Effect Unit) -> Effect Unit
 asyncFunction onSuccess onError = ...
 ```
 
-But as is true in JavaScript, this can quickly get out of hand and result in "callback hell". 
+But as is true in JavaScript, this can quickly get out of hand and result in "callback hell".
 
 The `Aff` monad solves this problem similar to how `Promise` solves it in JavaScript, and there is a great library called `aff-promise` that provides interop with JavaScript `Promise`.
 
@@ -481,7 +481,7 @@ printRandomStyle1a :: Aff Unit
 printRandomStyle1a = liftEffect doRandom
   where
     doRandom :: Effect Unit
-    doRandom = do 
+    doRandom = do
       n <- random
       logShow n
 
@@ -510,11 +510,11 @@ main = launchAff_  do
 
 ```
 
-`printRandomStyle1a` and `printRandomStyle1b` are nearly the same, but the types more explicit in `printRandomStyle1a` to add additional clarity. In both, the `do` block results in something with type `Effect Unit` and is lifted to `Aff` outside of the `do` block. In `printRandomStyle2`, both `random` and `logShow` are lifted to `Aff` inside the `do` block, which results in an `Aff`. Often while writing PureScript, you'll encounter cases where `Aff` and `Effect` need to be mixed, so style 2 is the more common case. Finally in `printRandomStyle3`, the `liftEffect` function has been moved to the right with `#`, which applies an argument to a function instead of the regular function call with arguments. The purpose of this style is to make the intent of the statement more clear by moving the *boilerplate* out of the way to the right. 
+`printRandomStyle1a` and `printRandomStyle1b` are nearly the same, but the types more explicit in `printRandomStyle1a` to add additional clarity. In both, the `do` block results in something with type `Effect Unit` and is lifted to `Aff` outside of the `do` block. In `printRandomStyle2`, both `random` and `logShow` are lifted to `Aff` inside the `do` block, which results in an `Aff`. Often while writing PureScript, you'll encounter cases where `Aff` and `Effect` need to be mixed, so style 2 is the more common case. Finally in `printRandomStyle3`, the `liftEffect` function has been moved to the right with `#`, which applies an argument to a function instead of the regular function call with arguments. The purpose of this style is to make the intent of the statement more clear by moving the *boilerplate* out of the way to the right.
 
 # launchAff_ vs launchAff
 
-`Aff` has two similar functions for converting from an `Aff` to an `Effect`: 
+`Aff` has two similar functions for converting from an `Aff` to an `Effect`:
 
 ```haskell
 launchAff_ :: forall a. Aff a -> Effect Unit
@@ -523,11 +523,11 @@ launchAff_ :: forall a. Aff a -> Effect Unit
 launchAff :: forall a. Aff a -> Effect (Fiber a)
 ```
 
-`launchAff` gives back a `Fiber` wrapped in an `Effect`. A `Fiber` is a *forked* computation that can be *joined* back into an `Aff`. You can read more about `Fiber` in Pursuit, PureScript's library and documentation hub. The important thing to note is that there is no direct way to get the contained value in an `Aff` once it's been converted to an `Effect`. For this reason it makes sense to write most of your program in terms of `Aff` instead of `Effect` if you intend to perform asynchronous effects. This may sound limiting, but in practice it is not. Your programs are typically started in the `main` function by wiring up event handlers and listeners, which typically results in a `Unit` and can be run with `launchAff_`. 
+`launchAff` gives back a `Fiber` wrapped in an `Effect`. A `Fiber` is a *forked* computation that can be *joined* back into an `Aff`. You can read more about `Fiber` in Pursuit, PureScript's library and documentation hub. The important thing to note is that there is no direct way to get the contained value in an `Aff` once it's been converted to an `Effect`. For this reason it makes sense to write most of your program in terms of `Aff` instead of `Effect` if you intend to perform asynchronous effects. This may sound limiting, but in practice it is not. Your programs are typically started in the `main` function by wiring up event handlers and listeners, which typically results in a `Unit` and can be run with `launchAff_`.
 
 # MonadError
 
-`Aff` has an instance of `MonadError`, a type class for clean error handling. `MonadError` is covered in more detail in the *Monadic Adventures* chapter, so below is just a motivating example. 
+`Aff` has an instance of `MonadError`, a type class for clean error handling. `MonadError` is covered in more detail in the *Monadic Adventures* chapter, so below is just a motivating example.
 
 Imagine you wished to write a `quickCheckout` function by combining several preexisting functions. Without utilizing `MonadError` the code might look like the following:
 
@@ -575,7 +575,7 @@ quickCheckout item userInfo = do
 
 ```
 
-All of the data types and functions (aside from `quickCheckout`) are stubs, and meant to be ignored aside from their types. Note that `quickCheckout` is pretty ugly and the error checking is deeply nested. This is because there is a monad (`Either`) inside of a monad (`Aff`). Monads don't nicely compose so, we've got to step down into each `Aff` and check each `Either`. It's a bit annoying. This is where `MonadError` can help. 
+All of the data types and functions (aside from `quickCheckout`) are stubs, and meant to be ignored aside from their types. Note that `quickCheckout` is pretty ugly and the error checking is deeply nested. This is because there is a monad (`Either`) inside of a monad (`Aff`). Monads don't nicely compose so, we've got to step down into each `Aff` and check each `Either`. It's a bit annoying. This is where `MonadError` can help.
 
 Take a look at the alternate implementation below.
 
@@ -633,7 +633,4 @@ main = launchAff_ do
 
 ```
 
-Note here that `quickCheckout` is much cleaner and the intent of the code is much clearer. This is made possible by the `rethrow` function, which uses `throwError` from `MonadError` to *eliminate* the `Either` type. Your next question might be, "but what happens to the error?". Notice in the `main` function, `try` is called on the result of `quickCheckout`. `try` will catch the error thrown by `throwError` - if one is thrown - and wrap the result in an `Either`, so you can handle it from there. If one doesn't use `try` as is done in the `main` function, then a runtime exception will be thrown. Because you can't really know if upstream code has made use of `MonadError` it's a good idea to call `try` on an `Aff` before converting it into an `Effect`.  
-
-
-
+Note here that `quickCheckout` is much cleaner and the intent of the code is much clearer. This is made possible by the `rethrow` function, which uses `throwError` from `MonadError` to *eliminate* the `Either` type. Your next question might be, "but what happens to the error?". Notice in the `main` function, `try` is called on the result of `quickCheckout`. `try` will catch the error thrown by `throwError` - if one is thrown - and wrap the result in an `Either`, so you can handle it from there. If one doesn't use `try` as is done in the `main` function, then a runtime exception will be thrown. Because you can't really know if upstream code has made use of `MonadError` it's a good idea to call `try` on an `Aff` before converting it into an `Effect`.

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -623,7 +623,7 @@ $ spago bundle-app --main Example.LSystem --to dist/Main.js
 
 and open `html/index.html`. You should see the Koch curve rendered to the canvas.
 
- ## Exercises
+ ## Chapter 9 Exercises
 
  1. (Easy) Modify the L-system example above to use `fillPath` instead of `strokePath`. _Hint_: you will need to include a call to `closePath`, and move the call to `moveTo` outside of the `interpret` function.
  1. (Easy) Try changing the various numerical constants in the code, to understand their effect on the rendered system.
@@ -662,7 +662,7 @@ and open `html/index.html`. You should see the Koch curve rendered to the canvas
      Implement this L-system again using this representation of the alphabet.
  1. (Difficult) Use a different monad `m` in the interpretation function. You might try using `Effect.Console` to write the L-system onto the console, or using `Effect.Random` to apply random "mutations" to the state type.
 
-## Conclusion
+## Chapter 9 Conclusion
 
 In this chapter, we learned how to use the HTML5 Canvas API from PureScript by using the `canvas` library. We also saw a practical demonstration of many of the techniques we have learned already: maps and folds, records and row polymorphism, and the `Effect` monad for handling side-effects.
 


### PR DESCRIPTION
Fixes #76 

Not sure whether we want to use a different method for making the section names unique, but this at least gets the ball rolling.