### PR TITLE
Travis-CI for mdbook and gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ deploy:
   edge: true # use Travis-CI dpl v2
   provider: pages
   local_dir: book
-  token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  deploy_key: $GITHUB_REPO_DEPLOY_KEY  # Set in the settings page of your repository, as a secure variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+os: linux
+language: shell
+install:
+  - wget https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz
+  - tar -xzvf mdbook-*.tar.gz
+script:
+  ./mdbook build
+deploy:
+  edge: true # use Travis-CI dpl v2
+  provider: pages
+  local_dir: book
+  token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,6 @@
+[book]
+authors = ["Phil Freeman"]
+language = "en"
+multilingual = false
+src = "text"
+title = "PureScript by Example"

--- a/text/SUMMARY.md
+++ b/text/SUMMARY.md
@@ -1,0 +1,16 @@
+# Summary
+
+* [Introduction](chapter1.md)
+* [Getting Started](chapter2.md)
+* [Functions and Records](chapter3.md)
+* [Recursion, Maps And Folds](chapter4.md)
+* [Pattern Matching](chapter5.md)
+* [Type Classes](chapter6.md)
+* [Applicative Validation](chapter7.md)
+* [The Effect and Aff Monads](chapter8.md)
+* [Canvas Graphics](chapter9.md)
+* [The Foreign Function Interface](chapter10.md)
+* [Monadic Adventures](chapter11.md)
+* [Callback Hell](chapter12.md)
+* [Generative Testing](chapter13.md)
+* [Domain-Specific Languages](chapter14.md)


### PR DESCRIPTION
Here is an example of the [Travis job](https://travis-ci.org/github/milesfrain/purescript-book/builds/674997913) running on my [travis-demo branch](https://github.com/milesfrain/purescript-book/commit/5afb867d893db5cd9d7bfa85f3e22dc197338606).

Preview: https://milesfrain.github.io/purescript-book/

The only difference with this PR is the removal [these lines](https://github.com/milesfrain/purescript-book/commit/5afb867d893db5cd9d7bfa85f3e22dc197338606#diff-354f30a63fb0907d4ad57269548329e3R13-R14) to default to master branch:
```
  on:
    branch: travis-demo # Will default to master branch if on.branch is removed
```

The remaining configuration steps are:
* ~~[Activate travis on this repo](https://travis-ci.com/github/purescript-contrib/purescript-book).~~ Edit: Already running on travis-ci.**com** (previously liked to inactive travis-ci.**org** instance ... confusing).
* Generate and add [github token](https://docs.travis-ci.com/user/deployment/pages/#setting-the-github-token) to Travis repo.
* Whatever else might be needed for compatibility with a custom domain name: [book.purescript.org](https://book.purescript.org/)

@hdgarrood we could use your help with these administrative tasks.