### PR TITLE
Ch8 Remove newtype wrapper in Address Book

### DIFF
--- a/exercises/chapter8/src/Data/AddressBook.purs
+++ b/exercises/chapter8/src/Data/AddressBook.purs
@@ -2,14 +2,14 @@ module Data.AddressBook where
 
 import Prelude
 
-newtype Address = Address
-  { street :: String
-  , city   :: String
-  , state  :: String
-  }
+type Address
+  = { street :: String
+    , city :: String
+    , state :: String
+    }
 
 address :: String -> String -> String -> Address
-address street city state = Address { street, city, state }
+address street city state = { street, city, state }
 
 data PhoneType
   = HomePhone
@@ -17,59 +17,37 @@ data PhoneType
   | CellPhone
   | OtherPhone
 
-newtype PhoneNumber = PhoneNumber
-  { "type" :: PhoneType
-  , number :: String
-  }
-
-phoneNumber :: PhoneType -> String -> PhoneNumber
-phoneNumber ty number = PhoneNumber
-  { "type": ty
-  , number: number
-  }
-
-newtype Person = Person
-  { firstName   :: String
-  , lastName    :: String
-  , homeAddress :: Address
-  , phones      :: Array PhoneNumber
-  }
-
-person :: String -> String -> Address -> Array PhoneNumber -> Person
-person firstName lastName homeAddress phones =
-  Person { firstName, lastName, homeAddress, phones }
-
-examplePerson :: Person
-examplePerson =
-  person "John" "Smith"
-         (address "123 Fake St." "FakeTown" "CA")
-         [ phoneNumber HomePhone "555-555-5555"
-         , phoneNumber CellPhone "555-555-0000"
-         ]
-
-instance showAddress :: Show Address where
-  show (Address o) = "Address " <>
-    "{ street: " <> show o.street <>
-    ", city: "   <> show o.city <>
-    ", state: "  <> show o.state <>
-    " }"
-
 instance showPhoneType :: Show PhoneType where
   show HomePhone = "HomePhone"
   show WorkPhone = "WorkPhone"
   show CellPhone = "CellPhone"
   show OtherPhone = "OtherPhone"
 
-instance showPhoneNumber :: Show PhoneNumber where
-  show (PhoneNumber o) = "PhoneNumber " <>
-    "{ type: "   <> show o."type" <>
-    ", number: " <> show o.number <>
-    " }"
+type PhoneNumber
+  = { "type" :: PhoneType
+    , number :: String
+    }
 
-instance showPerson :: Show Person where
-  show (Person o) = "Person " <>
-    "{ firstName: "   <> show o.firstName <>
-    ", lastName: "    <> show o.lastName <>
-    ", homeAddress: " <> show o.homeAddress <>
-    ", phones: "      <> show o.phones <>
-    " }"
+phoneNumber :: PhoneType -> String -> PhoneNumber
+phoneNumber ty number =
+  { "type": ty
+  , number: number
+  }
+
+type Person
+  = { firstName :: String
+    , lastName :: String
+    , homeAddress :: Address
+    , phones :: Array PhoneNumber
+    }
+
+person :: String -> String -> Address -> Array PhoneNumber -> Person
+person firstName lastName homeAddress phones = { firstName, lastName, homeAddress, phones }
+
+examplePerson :: Person
+examplePerson =
+  person "John" "Smith"
+    (address "123 Fake St." "FakeTown" "CA")
+    [ phoneNumber HomePhone "555-555-5555"
+    , phoneNumber CellPhone "555-555-0000"
+    ]

--- a/exercises/chapter8/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter8/src/Data/AddressBook/Validation.purs
@@ -1,7 +1,7 @@
 module Data.AddressBook.Validation where
 
 import Prelude
-import Data.AddressBook (Address(..), Person(..), PhoneNumber(..), address, person, phoneNumber)
+import Data.AddressBook (Address, Person, PhoneNumber, address, person, phoneNumber)
 import Data.Either (Either(..))
 import Data.String (length)
 import Data.String.Regex (Regex, test, regex)
@@ -10,47 +10,53 @@ import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, unV, invalid)
 import Partial.Unsafe (unsafePartial)
 
-type Errors = Array String
+type Errors
+  = Array String
 
 nonEmpty :: String -> String -> V Errors Unit
-nonEmpty field "" = invalid ["Field '" <> field <> "' cannot be empty"]
-nonEmpty _     _  = pure unit
+nonEmpty field "" = invalid [ "Field '" <> field <> "' cannot be empty" ]
+
+nonEmpty _ _ = pure unit
 
 arrayNonEmpty :: forall a. String -> Array a -> V Errors Unit
-arrayNonEmpty field [] = invalid ["Field '" <> field <> "' must contain at least one value"]
-arrayNonEmpty _     _  = pure unit
+arrayNonEmpty field [] = invalid [ "Field '" <> field <> "' must contain at least one value" ]
+
+arrayNonEmpty _ _ = pure unit
 
 lengthIs :: String -> Int -> String -> V Errors Unit
-lengthIs field len value | length value /= len = invalid ["Field '" <> field <> "' must have length " <> show len]
-lengthIs _     _   _     = pure unit
+lengthIs field len value
+  | length value /= len = invalid [ "Field '" <> field <> "' must have length " <> show len ]
+
+lengthIs _ _ _ = pure unit
 
 phoneNumberRegex :: Regex
 phoneNumberRegex =
-  unsafePartial
-    case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
-      Right r -> r
+  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
+    Right r -> r
 
 matches :: String -> Regex -> String -> V Errors Unit
-matches _     regex value | test regex value = pure unit
-matches field _     _     = invalid ["Field '" <> field <> "' did not match the required format"]
+matches _ regex value
+  | test regex value = pure unit
+
+matches field _ _ = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address
-validateAddress (Address o) =
-  address <$> (nonEmpty "Street" o.street *> pure o.street)
-          <*> (nonEmpty "City"   o.city   *> pure o.city)
-          <*> (lengthIs "State" 2 o.state *> pure o.state)
+validateAddress a =
+  address <$> (nonEmpty "Street" a.street *> pure a.street)
+    <*> (nonEmpty "City" a.city *> pure a.city)
+    <*> (lengthIs "State" 2 a.state *> pure a.state)
 
 validatePhoneNumber :: PhoneNumber -> V Errors PhoneNumber
-validatePhoneNumber (PhoneNumber o) =
-  phoneNumber <$> pure o."type"
-              <*> (matches "Number" phoneNumberRegex o.number *> pure o.number)
+validatePhoneNumber pn =
+  phoneNumber <$> pure pn."type"
+    <*> (matches "Number" phoneNumberRegex pn.number *> pure pn.number)
 
 validatePerson :: Person -> V Errors Person
-validatePerson (Person o) =
-  person <$> (nonEmpty "First Name" o.firstName *> pure o.firstName)
-         <*> (nonEmpty "Last Name"  o.lastName  *> pure o.lastName)
-         <*> validateAddress o.homeAddress
-         <*> (arrayNonEmpty "Phone Numbers" o.phones *> traverse validatePhoneNumber o.phones)
+validatePerson p =
+  person <$> (nonEmpty "First Name" p.firstName *> pure p.firstName)
+    <*> (nonEmpty "Last Name" p.lastName *> pure p.lastName)
+    <*> validateAddress p.homeAddress
+    <*> (arrayNonEmpty "Phone Numbers" p.phones *> traverse validatePhoneNumber p.phones)
 
 validatePerson' :: Person -> Either Errors Person
 validatePerson' p = unV Left Right $ validatePerson p

--- a/exercises/chapter8/src/Main.purs
+++ b/exercises/chapter8/src/Main.purs
@@ -1,7 +1,7 @@
 module Main where
 
 import Prelude
-import Data.AddressBook (PhoneNumber, address, examplePerson, person)
+import Data.AddressBook (PhoneNumber, examplePerson)
 import Data.AddressBook.Validation (Errors, validatePerson')
 import Data.Array (mapWithIndex, updateAt)
 import Data.Either (Either(..))
@@ -39,7 +39,7 @@ renderValidationErrors xs =
 
 -- Helper function to render a single form field with an
 -- event handler to update
-formField :: String -> String -> String -> ((String -> String) -> Effect Unit) -> R.JSX
+formField :: String -> String -> String -> (String -> Effect Unit) -> R.JSX
 formField name placeholder value setValue =
   D.label
     { className: "form-group row"
@@ -58,7 +58,7 @@ formField name placeholder value setValue =
                     , onChange:
                         let
                           handleValue :: Maybe String -> Effect Unit
-                          handleValue (Just v) = setValue (\_ -> v)
+                          handleValue (Just v) = setValue v
 
                           handleValue Nothing = pure unit
                         in
@@ -73,23 +73,12 @@ mkAddressBookApp :: Effect (ReactComponent {})
 mkAddressBookApp =
   -- incomming \props are unused
   component "AddressBookApp" \props -> R.do
-    -- Each form field is tracked as a separate piece of state.
     -- `useState` takes a default initial value and returns the
     -- current value and a way to update the value.
     -- Consult react-hooks docs for a more detailed explanation of `useState`.
-    Tuple firstName setFirstName <- useState examplePerson.firstName
-    Tuple lastName setLastName <- useState examplePerson.lastName
-    Tuple street setStreet <- useState examplePerson.homeAddress.street
-    Tuple city setCity <- useState examplePerson.homeAddress.city
-    Tuple state setState <- useState examplePerson.homeAddress.state
-    Tuple phoneNumbers setPhoneNumbers <- useState examplePerson.phones
+    Tuple person setPerson <- useState examplePerson
     let
-      unvalidatedPerson =
-        person firstName lastName
-          (address street city state)
-          phoneNumbers
-
-      errors = case validatePerson' unvalidatedPerson of
+      errors = case validatePerson' person of
         Left e -> e
         Right _ -> []
 
@@ -97,26 +86,18 @@ mkAddressBookApp =
       updateAt' :: forall a. Int -> a -> Array a -> Array a
       updateAt' i x xs = fromMaybe xs (updateAt i x xs)
 
+      -- helper-function to render a single phone number at a given index
       renderPhoneNumber :: Int -> PhoneNumber -> R.JSX
       renderPhoneNumber index phone =
-        let
-          -- Same signature as the other `set` hooks, but customized to update a specific phone index
-          setPhoneNumber :: (String -> String) -> Effect Unit
-          setPhoneNumber setter =
-            setPhoneNumbers \_ ->
-              updateAt'
-                index
-                -- Each `set` hook runs a provided `setter` function which describes
-                -- how to determine the new state from the previous state.
-                -- In our case, the formField handler ignores the previous state.
-                (phone { number = setter "ignore" })
-                phoneNumbers
-        in
-          formField
-            (show phone."type")
-            "XXX-XXX-XXXX"
-            phone.number
-            setPhoneNumber
+        formField
+          (show phone."type")
+          "XXX-XXX-XXXX"
+          phone.number
+          (\s -> setPerson _ { phones = updateAt' index phone { number = s } person.phones })
+
+      -- helper-function to render all phone numbers
+      renderPhoneNumbers :: Array R.JSX
+      renderPhoneNumbers = mapWithIndex renderPhoneNumber person.phones
     pure
       $ D.div
           { className: "container"
@@ -127,15 +108,20 @@ mkAddressBookApp =
                       , children:
                           [ D.form_
                               $ [ D.h3_ [ D.text "Basic Information" ]
-                                , formField "First Name" "First Name" firstName setFirstName
-                                , formField "Last Name" "Last Name" lastName setLastName
+                                , formField "First Name" "First Name" person.firstName \s ->
+                                    setPerson _ { firstName = s }
+                                , formField "Last Name" "Last Name" person.lastName \s ->
+                                    setPerson _ { lastName = s }
                                 , D.h3_ [ D.text "Address" ]
-                                , formField "Street" "Street" street setStreet
-                                , formField "City" "City" city setCity
-                                , formField "State" "State" state setState
+                                , formField "Street" "Street" person.homeAddress.street \s ->
+                                    setPerson _ { homeAddress { street = s } }
+                                , formField "City" "City" person.homeAddress.city \s ->
+                                    setPerson _ { homeAddress { city = s } }
+                                , formField "State" "State" person.homeAddress.state \s ->
+                                    setPerson _ { homeAddress { state = s } }
                                 , D.h3_ [ D.text "Contact Information" ]
                                 ]
-                              <> mapWithIndex renderPhoneNumber phoneNumbers
+                              <> renderPhoneNumbers
                           ]
                       }
                   ]

--- a/exercises/chapter8/src/Main.purs
+++ b/exercises/chapter8/src/Main.purs
@@ -69,12 +69,6 @@ formField name placeholder value setValue =
         ]
     }
 
-mkAddressBookApp2 :: Effect (ReactComponent {})
-mkAddressBookApp2 =
-  component
-    "AddressBookApp"
-    (\props -> pure $ D.text "Hi! I'm an address book")
-
 mkAddressBookApp :: Effect (ReactComponent {})
 mkAddressBookApp =
   -- incomming \props are unused

--- a/exercises/chapter8/src/Main.purs
+++ b/exercises/chapter8/src/Main.purs
@@ -1,7 +1,7 @@
 module Main where
 
 import Prelude
-import Data.AddressBook (Address(..), Person(..), PhoneNumber(..), address, examplePerson, person)
+import Data.AddressBook (PhoneNumber, address, examplePerson, person)
 import Data.AddressBook.Validation (Errors, validatePerson')
 import Data.Array (mapWithIndex, updateAt)
 import Data.Either (Either(..))
@@ -73,21 +73,16 @@ mkAddressBookApp :: Effect (ReactComponent {})
 mkAddressBookApp =
   -- incomming \props are unused
   component "AddressBookApp" \props -> R.do
-    let
-      -- Using "Named Pattern" with `@` so inner records
-      -- of `Person` and `Address` can be more conveniently
-      -- accessed as `p` and `a`.
-      Person p@{ homeAddress: Address a } = examplePerson
     -- Each form field is tracked as a separate piece of state.
     -- `useState` takes a default initial value and returns the
     -- current value and a way to update the value.
     -- Consult react-hooks docs for a more detailed explanation of `useState`.
-    Tuple firstName setFirstName <- useState p.firstName
-    Tuple lastName setLastName <- useState p.lastName
-    Tuple street setStreet <- useState a.street
-    Tuple city setCity <- useState a.city
-    Tuple state setState <- useState a.state
-    Tuple phoneNumbers setPhoneNumbers <- useState p.phones
+    Tuple firstName setFirstName <- useState examplePerson.firstName
+    Tuple lastName setLastName <- useState examplePerson.lastName
+    Tuple street setStreet <- useState examplePerson.homeAddress.street
+    Tuple city setCity <- useState examplePerson.homeAddress.city
+    Tuple state setState <- useState examplePerson.homeAddress.state
+    Tuple phoneNumbers setPhoneNumbers <- useState examplePerson.phones
     let
       unvalidatedPerson =
         person firstName lastName
@@ -103,7 +98,7 @@ mkAddressBookApp =
       updateAt' i x xs = fromMaybe xs (updateAt i x xs)
 
       renderPhoneNumber :: Int -> PhoneNumber -> R.JSX
-      renderPhoneNumber index (PhoneNumber phone) =
+      renderPhoneNumber index phone =
         let
           -- Same signature as the other `set` hooks, but customized to update a specific phone index
           setPhoneNumber :: (String -> String) -> Effect Unit
@@ -114,7 +109,7 @@ mkAddressBookApp =
                 -- Each `set` hook runs a provided `setter` function which describes
                 -- how to determine the new state from the previous state.
                 -- In our case, the formField handler ignores the previous state.
-                (PhoneNumber phone { number = setter "ignore" })
+                (phone { number = setter "ignore" })
                 phoneNumbers
         in
           formField

--- a/text/SUMMARY.md
+++ b/text/SUMMARY.md
@@ -8,7 +8,7 @@
 * [Pattern Matching](chapter5.md)
 * [Type Classes](chapter6.md)
 * [Applicative Validation](chapter7.md)
-* [The Effect and Aff Monads](chapter8.md)
+* [The Effect Monad](chapter8.md)
 * [Canvas Graphics](chapter9.md)
 * [The Foreign Function Interface](chapter10.md)
 * [Monadic Adventures](chapter11.md)

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -826,7 +826,7 @@ We track `person` as a piece of state with the `useState` hook.
 Tuple person setPerson <- useState examplePerson
 ```
 
-Note that you are free to break-up component state into multiple pieces of state with multiple calls to `useState`. For example, we could rewrite this app to use a separate piece of state for each record field of `Person`, but than happens to result in a slightly less convenient architecture in this case.
+Note that you are free to break-up component state into multiple pieces of state with multiple calls to `useState`. For example, we could rewrite this app to use a separate piece of state for each record field of `Person`, but that happens to result in a slightly less convenient architecture in this case.
 
 In other examples, you may encounter the `/\` infix operator for `Tuple`. This is equivalent to the above line:
 ```hs
@@ -972,17 +972,18 @@ The `onChange` attribute allows us to describe how to respond to user input. We 
 handler :: forall a. EventFn SyntheticEvent a -> (a -> Effect Unit) -> EventHandler
 ```
 
-For the first argument (`EventFn SyntheticEvent a`) we use `targetValue`. The type variable `a` in this case is `Maybe String`.
+For the first argument to `hander` we use we use `targetValue`, which provides the value of the text within the HTML `input` element. It matches the signature expected by `handler` where the type variable `a` in this case is `Maybe String`:
 ```hs
 targetValue :: EventFn SyntheticEvent (Maybe String)
 ```
+
 In JavaScript, the `input` element's `onChange` event is actually accompanied by a `String` value, but since strings in JavaScript can be null, `Maybe` is used for safety.
 
 The second argument to `handler`, `(a -> Effect Unit)`, must therefore have this signature:
 ```hs
 Maybe String -> Effect Unit
 ```
-It is a function that describes how to convert this `Maybe String` value into our desired effect. We create this `handleValue` function and pass it to `handler` as follows:
+It is a function that describes how to convert this `Maybe String` value into our desired effect. We define a custom `handleValue` function for this purpose and pass it to `handler` as follows:
 
 ```haskell
 onChange:
@@ -994,7 +995,7 @@ onChange:
     handler targetValue handleValue
 ```
 
-`setValue` is a provided function that takes a string and makes the appropriate record-update call to the `setPerson` hook.
+`setValue` is the function we provided to each `formField` call that takes a string and makes the appropriate record-update call to the `setPerson` hook.
 
 Note that `handleValue` can be substituted as:
 ```hs

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -818,31 +818,22 @@ These are the first few lines of our full component:
 mkAddressBookApp :: Effect (ReactComponent {})
 mkAddressBookApp = do
   component "AddressBookApp" \props -> R.do
-    let
-      Person p@{ homeAddress: Address a } = examplePerson
-    Tuple firstName setFirstName <- useState p.firstName
-    Tuple lastName setLastName <- useState p.lastName
+    Tuple person setPerson <- useState examplePerson
 ```
 
-Recall from Chapter 5 that the `@` symbol describes "Named Patterns". This allows use to more conveniently access the `examplePerson`'s inner records of `Person` and `Address` as `p` and `a`:
-```hs
-Person p@{ homeAddress: Address a } = examplePerson
-```
-
-Another way to structure this app is by just using records for `Person` and `Address`, rather than wrapping with `newtype`. This provides more convenient record updates, but, comes at the cost of type safety. This simplification is up for [consideration](https://github.com/purescript-contrib/purescript-book/issues/118).
-
-
-Each form field is tracked as a separate piece of state with the `useState` hook. For example:
+We track `person` as a piece of state with the `useState` hook.
 ```haskell
-Tuple firstName setFirstName <- useState p.firstName
+Tuple person setPerson <- useState examplePerson
 ```
+
+Note that you are free to break-up component state into multiple pieces of state with multiple calls to `useState`. For example, we could rewrite this app to use a separate piece of state for each record field of `Person`, but than happens to result in a slightly less convenient architecture in this case.
 
 In other examples, you may encounter the `/\` infix operator for `Tuple`. This is equivalent to the above line:
 ```hs
 firstName /\ setFirstName <- useState p.firstName
 ```
 
-`useState` takes a default initial value and returns the current value and a way to update the value. We can check the type of `useState` to gain more insight the types of `firstName` and `setFirstName`:
+`useState` takes a default initial value and returns the current value and a way to update the value. We can check the type of `useState` to gain more insight the types of `person` and `setPerson`:
 ```hs
 useState ::
   forall state.
@@ -854,30 +845,24 @@ We can strip the `Hook (UseState state)` wrapper off of the return value because
 
 So now we can observe the following signatures:
 ```hs
-firstName :: state
-setFirstName :: (state -> state) -> Effect Unit
+person :: state
+setPerson :: (state -> state) -> Effect Unit
 ```
 
-The specific type of `state` is determined by our initial default value. For this first `useState` hook, we pass in `p.firstName` which is `"John"` (a `String`) from our `examplePerson`.
+The specific type of `state` is determined by our initial default value. `Person` `Record` in this case because that is the type of `examplePerson`.
 
-`firstName` is how we access the current state at each rerender.
+`person` is how we access the current state at each rerender.
 
-`setFirstName` is how we update the state. We simply provide a function that describes how to transform the current state to the new state. In many situations we can write an update function which ignores the state input argument as we either:
-  * Completely overwrite the state, e.g.:
+`setPerson` is how we update the state. We simply provide a function that describes how to transform the current state to the new state. The record update syntax is perfect for this when the type of `state` happens to be a `Record`, for example:
 ```hs
-setFirstName (\_ -> "Natasha")
+setPerson (\currentPerson -> currentPerson {firstName = "NewName"})
 ```
-  * Already have access to the current state via the first `Tuple` value, e.g.:
+or as shorthand:
 ```hs
-setFirstName (\_ -> "The Honerable " <> firstName)
+setPerson _ {firstName = "NewName"}
 ```
 
-In other situations where we want to modify the state, but don't have access to the latest value (such as with a timed event), we need to use the state input.
-```hs
-setCount (c -> c + 1)
--- equivalent to:
-setCount (_ + 1)
-```
+Non-`Record` states can also follow this update pattern. See [this guide](https://github.com/spicydonuts/purescript-react-basic-hooks/pull/24#issuecomment-620300541) for more details on best practices.
 
 Recall that `useState` is used within an `R.do` block. `R.do` is a special react hooks variant of `do`. The `R.` prefix "qualifies" this as coming from `React.Basic.Hooks`, and means we use their hooks-compatible version of `bind` in the `R.do` block. This is known as a "qualified do". It lets us ignore the `Hook (UseState state)` wrapping and bind the inner `Tuple` of values to variables.
 
@@ -895,15 +880,20 @@ pure
                   , children:
                       [ D.form_
                           $ [ D.h3_ [ D.text "Basic Information" ]
-                            , formField "First Name" "First Name" firstName setFirstName
-                            , formField "Last Name" "Last Name" lastName setLastName
+                            , formField "First Name" "First Name" person.firstName \s ->
+                                setPerson _ { firstName = s }
+                            , formField "Last Name" "Last Name" person.lastName \s ->
+                                setPerson _ { lastName = s }
                             , D.h3_ [ D.text "Address" ]
-                            , formField "Street" "Street" street setStreet
-                            , formField "City" "City" city setCity
-                            , formField "State" "State" state setState
+                            , formField "Street" "Street" person.homeAddress.street \s ->
+                                setPerson _ { homeAddress { street = s } }
+                            , formField "City" "City" person.homeAddress.city \s ->
+                                setPerson _ { homeAddress { city = s } }
+                            , formField "State" "State" person.homeAddress.state \s ->
+                                setPerson _ { homeAddress { state = s } }
                             , D.h3_ [ D.text "Contact Information" ]
                             ]
-                          <> mapWithIndex renderPhoneNumber phoneNumbers
+                          <> renderPhoneNumbers
                       ]
                   }
               ]
@@ -945,7 +935,7 @@ className: "alert alert-danger row"
 A second helper function is `formField`, which creates a text input for a single form field:
 
 ```hs
-formField :: String -> String -> String -> ((String -> String) -> Effect Unit) -> R.JSX
+formField :: String -> String -> String -> (String -> Effect Unit) -> R.JSX
 formField name placeholder value setValue =
   D.label
     { className: "form-group row"
@@ -964,7 +954,8 @@ formField name placeholder value setValue =
                     , onChange:
                         let
                           handleValue :: Maybe String -> Effect Unit
-                          handleValue (Just v) = setValue (\_ -> v)
+                          handleValue (Just v) = setValue v
+
                           handleValue Nothing = pure unit
                         in
                           handler targetValue handleValue
@@ -997,25 +988,20 @@ It is a function that describes how to convert this `Maybe String` value into ou
 onChange:
   let
     handleValue :: Maybe String -> Effect Unit
-    handleValue (Just v) = setValue (\_ -> v)
+    handleValue (Just v) = setValue v
     handleValue Nothing = pure unit
   in
     handler targetValue handleValue
 ```
 
-`setValue` is a function that has the same signature as the second tuple value returned by `useState` hook. In most cases we pass that function through to `formField` from the hook as-is. For phone numbers, a custom `setPhoneNumber` function is used to update the phone number at a particular index.
+`setValue` is a provided function that takes a string and makes the appropriate record-update call to the `setPerson` hook.
 
-Note that `handleValue` can be substituted as this:
+Note that `handleValue` can be substituted as:
 ```hs
-onChange: handler targetValue $ traverse_ \v -> setValue \_ -> v
+onChange: handler targetValue $ traverse_ setValue
 ```
 
-Or even this:
-```hs
-onChange: handler targetValue $ traverse_ $ setValue <<< const
-```
-
-Feel free to investigate the definitions of `traverse_` and `const` to see how these three forms are indeed equivalent.
+Feel free to investigate the definition of `traverse_` to see how both forms are indeed equivalent.
 
 That covers the basics of our component implementation. However, you should read the source accompanying this chapter in order to get a full understanding of the way the component works.
 


### PR DESCRIPTION
Originally proposed in #118 

This also enables a nicer way to use a single state hook for `person`, even though it is often recommended to split state when possible, as @ptrfrncsmrph pointed out in https://github.com/milesfrain/purescript-book/pull/2 . I think the code is simpler and easier for beginners with the single piece of state.