### PR TITLE
Make Monad demo easier to import into repl

### DIFF
--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -217,7 +217,7 @@ As an example of working with monads abstractly, this section will present a fun
 
 The function we will write is called `foldM`. It generalizes the `foldl` function that we met earlier to a monadic context. Here is its type signature:
 
-```haskell
+```text
 import Prelude
 import Data.List
 
@@ -249,7 +249,7 @@ To write `foldM`, we can simply break the input list into cases.
 
 If the list is empty, then to produce the result of type `a`, we only have one option: we have to return the second argument:
 
-```haskell
+```text
 foldM _ a Nil = pure a
 ```
 
@@ -259,7 +259,7 @@ What if the list is non-empty? In that case, we have a value of type `a`, a valu
 
 It only remains to recurse on the tail of the list. The implementation is simple:
 
-```haskell
+```text
 foldM f a (b : bs) = do
   a' <- f a b
   foldM f a' bs
@@ -269,7 +269,7 @@ Note that this implementation is almost identical to that of `foldl` on lists, w
 
 We can define and test this function in PSCi. Here is an example - suppose we defined a "safe division" function on integers, which tested for division by zero and used the `Maybe` type constructor to indicate failure:
 
-```haskell
+```text
 import Data.Maybe
 
 safeDivide :: Int -> Int -> Maybe Int

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -217,7 +217,7 @@ As an example of working with monads abstractly, this section will present a fun
 
 The function we will write is called `foldM`. It generalizes the `foldl` function that we met earlier to a monadic context. Here is its type signature:
 
-```text
+```haskell
 import Prelude
 import Data.List
 
@@ -249,7 +249,7 @@ To write `foldM`, we can simply break the input list into cases.
 
 If the list is empty, then to produce the result of type `a`, we only have one option: we have to return the second argument:
 
-```text
+```haskell
 foldM _ a Nil = pure a
 ```
 
@@ -259,7 +259,7 @@ What if the list is non-empty? In that case, we have a value of type `a`, a valu
 
 It only remains to recurse on the tail of the list. The implementation is simple:
 
-```text
+```haskell
 foldM f a (b : bs) = do
   a' <- f a b
   foldM f a' bs
@@ -269,7 +269,7 @@ Note that this implementation is almost identical to that of `foldl` on lists, w
 
 We can define and test this function in PSCi. Here is an example - suppose we defined a "safe division" function on integers, which tested for division by zero and used the `Maybe` type constructor to indicate failure:
 
-```text
+```haskell
 import Data.Maybe
 
 safeDivide :: Int -> Int -> Maybe Int
@@ -280,8 +280,6 @@ safeDivide a b = Just (a / b)
 Then we can use `foldM` to express iterated safe division:
 
 ```text
-> import Data.List
-
 > foldM safeDivide 100 (fromFoldable [5, 2, 2])
 (Just 5)
 

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -218,6 +218,9 @@ As an example of working with monads abstractly, this section will present a fun
 The function we will write is called `foldM`. It generalizes the `foldl` function that we met earlier to a monadic context. Here is its type signature:
 
 ```haskell
+import Prelude
+import Data.List
+
 foldM :: forall m a b
        . Monad m
       => (a -> b -> m a)
@@ -267,6 +270,8 @@ Note that this implementation is almost identical to that of `foldl` on lists, w
 We can define and test this function in PSCi. Here is an example - suppose we defined a "safe division" function on integers, which tested for division by zero and used the `Maybe` type constructor to indicate failure:
 
 ```haskell
+import Data.Maybe
+
 safeDivide :: Int -> Int -> Maybe Int
 safeDivide _ 0 = Nothing
 safeDivide a b = Just (a / b)


### PR DESCRIPTION
Improve convenience for loading `safeDivide` into repl w/o compile errors.