### PR TITLE
Revert "Removed ' e' typo"

### DIFF
--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -302,7 +302,7 @@ ap mf ma = do
 
 If `m` is a law-abiding member of the `Monad` type class, then there is a valid `Applicative` instance for `m` given by `ap`.
 
-The interested reader can check that `ap` agrees with `apply` for the monads we have already encountered: `Array`, `Maybe` and `Either`.
+The interested reader can check that `ap` agrees with `apply` for the monads we have already encountered: `Array`, `Maybe` and `Either e`.
 
 If every monad is also an applicative functor, then we should be able to apply our intuition for applicative functors to every monad. In particular, we can reasonably expect a monad to correspond, in some sense, to programming "in a larger language" augmented with some set of additional side-effects. We should be able to lift functions of arbitrary arities, using `map` and `apply`, into this new language.
 


### PR DESCRIPTION
Reverts purescript-contrib/purescript-book#159

So this is not actually a typo. See #160