### PR TITLE
Chap2: Remove duplicate cirleArea suite

### DIFF
--- a/exercises/chapter2/test/Main.purs
+++ b/exercises/chapter2/test/Main.purs
@@ -28,11 +28,6 @@ main = do
         Assert.equal 3.141592653589793 (circleArea 1.0)
       test "radius 3" do
         Assert.equal 28.274333882308138 (circleArea 3.0)
-    suite "circleArea" do
-      test "radius 1" do
-        Assert.equal 3.141592653589793 (circleArea 1.0)
-      test "radius 3" do
-        Assert.equal 28.274333882308138 (circleArea 3.0)
     suite "addE" do
       test "1.23" do
         Assert.equal 3.948281828459045 (addE "1.23")


### PR DESCRIPTION
I'm new to Purescript and I'm going through the Purescript book. Unless I'm mistaken, it looks like the `circleArea` test suite is duplicated in chapter 2's `test/Main.purs`.

This PR removes the duplicated suite.
Feel free to discard and close if this is actually expected and I'm just missing something...