### PR TITLE
Revert "Refactor `phoneNumberRegex` to use verbal expressions (#165)"

### DIFF
--- a/exercises/chapter10/packages.dhall
+++ b/exercises/chapter10/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter10/spago.dhall
+++ b/exercises/chapter10/spago.dhall
@@ -14,7 +14,6 @@ You can edit this file as you like.
   , "react-basic-hooks"
   , "test-unit"
   , "validation"
-  , "verbal-expressions"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/exercises/chapter10/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter10/src/Data/AddressBook/Validation.purs
@@ -4,10 +4,11 @@ import Prelude
 import Data.AddressBook (Address, Person, PhoneNumber, address, person, phoneNumber)
 import Data.Either (Either(..))
 import Data.String (length)
-import Data.String.Regex (Regex, test)
-import Data.String.VerEx (digit, endOfLine, exactly, find, startOfLine, toRegex)
+import Data.String.Regex (Regex, test, regex)
+import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, unV, invalid)
+import Partial.Unsafe (unsafePartial)
 
 type Errors
   = Array String
@@ -30,14 +31,8 @@ lengthIs _ _ _ = pure unit
 
 phoneNumberRegex :: Regex
 phoneNumberRegex =
-  toRegex do
-    startOfLine
-    exactly 3 digit
-    find "-"
-    exactly 3 digit
-    find "-"
-    exactly 4 digit
-    endOfLine
+  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
+    Right r -> r
 
 matches :: String -> Regex -> String -> V Errors Unit
 matches _ regex value

--- a/exercises/chapter11/packages.dhall
+++ b/exercises/chapter11/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter12/packages.dhall
+++ b/exercises/chapter12/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter13/packages.dhall
+++ b/exercises/chapter13/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter14/packages.dhall
+++ b/exercises/chapter14/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter2/packages.dhall
+++ b/exercises/chapter2/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter3/packages.dhall
+++ b/exercises/chapter3/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter4/packages.dhall
+++ b/exercises/chapter4/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter5/packages.dhall
+++ b/exercises/chapter5/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter6/packages.dhall
+++ b/exercises/chapter6/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter7/packages.dhall
+++ b/exercises/chapter7/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter7/spago.dhall
+++ b/exercises/chapter7/spago.dhall
@@ -10,7 +10,6 @@ You can edit this file as you like.
   , "strings"
   , "test-unit"
   , "validation"
-  , "verbal-expressions"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/exercises/chapter7/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter7/src/Data/AddressBook/Validation.purs
@@ -4,10 +4,11 @@ import Prelude
 import Data.AddressBook (Address, Person, PhoneNumber, address, person, phoneNumber)
 import Data.Either (Either(..))
 import Data.String (length)
-import Data.String.Regex (Regex, test)
-import Data.String.VerEx (digit, endOfLine, exactly, find, startOfLine, toRegex)
+import Data.String.Regex (Regex, test, regex)
+import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, unV, invalid)
+import Partial.Unsafe (unsafePartial)
 
 type Errors
   = Array String
@@ -30,14 +31,8 @@ lengthIs _ _ _ = pure unit
 
 phoneNumberRegex :: Regex
 phoneNumberRegex =
-  toRegex do
-    startOfLine
-    exactly 3 digit
-    find "-"
-    exactly 3 digit
-    find "-"
-    exactly 4 digit
-    endOfLine
+  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
+    Right r -> r
 
 matches :: String -> Regex -> String -> V Errors Unit
 matches _ regex value

--- a/exercises/chapter8/packages.dhall
+++ b/exercises/chapter8/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/exercises/chapter8/spago.dhall
+++ b/exercises/chapter8/spago.dhall
@@ -4,13 +4,7 @@ You can edit this file as you like.
 -}
 { name = "my-project"
 , dependencies =
-  [ "console"
-  , "effect"
-  , "psci-support"
-  , "react-basic-hooks"
-  , "validation"
-  , "verbal-expressions"
-  ]
+  [ "console", "effect", "psci-support", "react-basic-hooks", "validation" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/exercises/chapter8/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter8/src/Data/AddressBook/Validation.purs
@@ -4,10 +4,11 @@ import Prelude
 import Data.AddressBook (Address, Person, PhoneNumber, address, person, phoneNumber)
 import Data.Either (Either(..))
 import Data.String (length)
-import Data.String.Regex (Regex, test)
-import Data.String.VerEx (digit, endOfLine, exactly, find, startOfLine, toRegex)
+import Data.String.Regex (Regex, test, regex)
+import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, unV, invalid)
+import Partial.Unsafe (unsafePartial)
 
 type Errors
   = Array String
@@ -30,14 +31,8 @@ lengthIs _ _ _ = pure unit
 
 phoneNumberRegex :: Regex
 phoneNumberRegex =
-  toRegex do
-    startOfLine
-    exactly 3 digit
-    find "-"
-    exactly 3 digit
-    find "-"
-    exactly 4 digit
-    endOfLine
+  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
+    Right r -> r
 
 matches :: String -> Regex -> String -> V Errors Unit
 matches _ regex value

--- a/exercises/chapter9/packages.dhall
+++ b/exercises/chapter9/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/scripts/packages.dhall
+++ b/scripts/packages.dhall
@@ -20,13 +20,6 @@ let overrides =
         }
       }
 
-let additions =
-      { verbal-expressions =
-        { dependencies = [ "free", "strings", "transformers", "tuples" ]
-        , repo =
-            "https://github.com/VerbalExpressions/purescript-verbal-expressions.git"
-        , version = "v4.0.0"
-        }
-      }
+let additions = {=}
 
 in  upstream // overrides // additions


### PR DESCRIPTION
This reverts commit e0e47a5d4415f2342fff093b2e68434cf370f290.

I moved a bit too fast with merging #165, as there are a bunch of other Todos in #166 that need to be completed so we don't present readers with mismatched and confusing material.

@ptrfrncsmrph Feel free to pick this up again if you see solutions to any of the below issues:

Verbal Expressions may not be "expressive" enough to tackle the chapter exercises (although it may just be user error on my end). Described some of these issues in https://github.com/VerbalExpressions/purescript-verbal-expressions/issues/10 (point 2 is the current blocker). We should either add the missing pieces to the library or at least improve its documentation a bit to help readers.

Also saved some progress for completing #166 in draft PR #175 (which fails CI due to a bad `nonEmptyVerEx`).

Note that the process for changing `packages.dhall` is now:
1. Edit `scripts/packages.dhall`
2. Run: `./scripts/updatePackages.sh` to copy to the `packages.dhall` in each chapter. I'm hoping this simplifies maintenance.