### PR TITLE
Corrected signature removeDuplicates fixed exercise solution

### DIFF
--- a/exercises/chapter3/test/Main.purs
+++ b/exercises/chapter3/test/Main.purs
@@ -66,7 +66,7 @@ Note to reader: Delete this line to expand comment block -}
           $ isInBook "unknown" "person" book
     test "Exercise - removeDuplicates" do
       Assert.equal book
-        $ removeDuplicates john.firstName john.lastName bookWithDuplicate
+        $ removeDuplicates bookWithDuplicate
 
 {- Note to reader: Delete this line to expand comment block
 -}

--- a/exercises/chapter3/test/no-peeking/Solutions.purs
+++ b/exercises/chapter3/test/no-peeking/Solutions.purs
@@ -18,8 +18,8 @@ isInBook firstName lastName book = not null $ filter filterEntry book
   filterEntry :: Entry -> Boolean
   filterEntry entry = entry.firstName == firstName && entry.lastName == lastName
 
-removeDuplicates :: String -> String -> AddressBook -> AddressBook
-removeDuplicates firstName lastName book = nubBy filterEntry book
+removeDuplicates :: AddressBook -> AddressBook
+removeDuplicates = nubBy <<< filterEntry
   where
   filterEntry :: Entry -> Entry -> Boolean
   filterEntry e1 e2 = e1.firstName == e2.firstName && e1.lastName == e2.lastName

--- a/exercises/chapter3/test/no-peeking/Solutions.purs
+++ b/exercises/chapter3/test/no-peeking/Solutions.purs
@@ -19,7 +19,7 @@ isInBook firstName lastName book = not null $ filter filterEntry book
   filterEntry entry = entry.firstName == firstName && entry.lastName == lastName
 
 removeDuplicates :: AddressBook -> AddressBook
-removeDuplicates = nubBy <<< filterEntry
+removeDuplicates book = nubBy filterEntry book
   where
   filterEntry :: Entry -> Entry -> Boolean
   filterEntry e1 e2 = e1.firstName == e2.firstName && e1.lastName == e2.lastName


### PR DESCRIPTION
Issue #178.

Changed signature for `removeDuplicates` to `removeDuplicates :: AddressBook -> AddressBook` in `exercises/chapter3/test/no-peeking/Solutions.purs` and fixed `exercises/chapter3/test/Main.purs` accordingly.