### PR TITLE
Add additional John with a different address to bookWithDuplicates

### DIFF
--- a/exercises/chapter3/test/Main.purs
+++ b/exercises/chapter3/test/Main.purs
@@ -41,8 +41,20 @@ book =
     $ insertEntry ned
         emptyBook
 
+otherJohn :: Entry
+otherJohn =
+  { firstName: "John"
+  , lastName: "Smith"
+  , address:
+      { street: "678 Fake Rd.", city: "Fakeville", state: "NY" }
+  }
+
+
 bookWithDuplicate :: AddressBook
-bookWithDuplicate = insertEntry john book
+bookWithDuplicate = 
+  insertEntry john
+    $ insertEntry otherJohn
+      book
 
 main :: Effect Unit
 main =


### PR DESCRIPTION
I found that using the `(==)` operator with the function passed to `nubBy` causes this test to pass so I added an additional record to cause it to fail against an Entry with the same name but different address.

Assuming that this is the intended behavior based on the description in the book:

> removes duplicate address book entries with the same first and last names

