### PR TITLE
Add concrete test cases for Action type class

### DIFF
--- a/exercises/chapter6/test/Main.purs
+++ b/exercises/chapter6/test/Main.purs
@@ -127,6 +127,9 @@ Note to reader: Delete this line to expand comment block -}
           test "Multiply Int append" do
             Assert.equal (act m1 (act m2 a))
               $ act (m1 <> m2) a
+          test "Multiply Int append concrete" do
+            Assert.equal 60
+              $ act (m1 <> m2) a
         -- Multiply String is the actual exercise question
         suite "Multiply String" do
           let
@@ -136,6 +139,9 @@ Note to reader: Delete this line to expand comment block -}
               $ act (mempty :: Multiply) a
           test "Multiply String append" do
             Assert.equal (act m1 (act m2 a))
+              $ act (m1 <> m2) a
+          test "Multiply String append concrete" do
+            Assert.equal "foofoofoofoofoofoofoofoofoofoofoofoo"
               $ act (m1 <> m2) a
       suite "Exercise - Action Class - actionArray instance" do
         suite "Multiply Array Int" do
@@ -147,6 +153,9 @@ Note to reader: Delete this line to expand comment block -}
           test "Multiply Array Int append" do
             Assert.equal (act m1 (act m2 a))
               $ act (m1 <> m2) a
+          test "Multiply Array Int append concrete" do
+            Assert.equal [ 12, 24, 36 ]
+              $ act (m1 <> m2) a
         suite "Multiply Array String" do
           let
             a = [ "foo", "bar", "baz" ]
@@ -155,6 +164,13 @@ Note to reader: Delete this line to expand comment block -}
               $ act (mempty :: Multiply) a
           test "Multiply Array String append" do
             Assert.equal (act m1 (act m2 a))
+              $ act (m1 <> m2) a
+          test "Multiply Array String append concrete" do
+            Assert.equal 
+              [ "foofoofoofoofoofoofoofoofoofoofoofoo"
+              , "barbarbarbarbarbarbarbarbarbarbarbar"
+              , "bazbazbazbazbazbazbazbazbazbazbazbaz"
+              ]
               $ act (m1 <> m2) a
       suite "Exercise - Action Class - actionSelf instance" do
         let


### PR DESCRIPTION
This adds some concrete test cases for the Action type class in Chapter 6. There were some instances where the tests would pass with an incorrect implementation so these check that the implementation goes beyond satisfying the type class laws.

e.g.) The following "just get it to compile" implementation will result in all tests passing, even if it doesn't produce the correct expected values:
```purescript
{- Solutions.purs -}
instance actionArray :: Action m a => Action m (Array a) where
  act m arr = arr

{- Main.purs -}
suite "Exercise - Action Class - actionArray instance" do
  suite "Multiply Array Int" do
    let
      a = [ 1, 2, 3 ]
    test "Multiply Array Int mempty" do
      Assert.equal a
        $ act (mempty :: Multiply) a
    test "Multiply Array Int append" do
      Assert.equal (act m1 (act m2 a))
        $ act (m1 <> m2) a
```