### PR TITLE
clarify 'type's constructors'

### DIFF
--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -384,7 +384,7 @@ The `Point` data type illustrates some interesting points:
 
 This declaration defines `Shape` as a sum of different constructors, and for each constructor identifies the data that is included. A `Shape` is either a `Circle` which contains a center `Point` and a radius (a number), or a `Rectangle`, or a `Line`, or `Text`. There are no other ways to construct a value of type `Shape`.
 
-An algebraic data type is introduced using the `data` keyword, followed by the name of the new type and any type arguments. The type's constructors are defined after the equals symbol, and are separated by pipe characters (`|`).
+An algebraic data type is introduced using the `data` keyword, followed by the name of the new type and any type arguments. The type's constructors (i.e. its _data constructors_) are defined after the equals symbol, and are separated by pipe characters (`|`).
 
 Let's see another example from PureScript's standard libraries. We saw the `Maybe` type, which is used to define optional values, earlier in the book. Here is its definition from the `maybe` package:
 


### PR DESCRIPTION
Based on discussion [here](https://github.com/purescript-contrib/purescript-book/issues/203), this change clarifies the usage of the terms `type's constructors`