### PR TITLE
Ch4 change 'whereIs' function signature

### DIFF
--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -162,10 +162,10 @@ Note to reader: Delete this line to expand comment block -}
       suite "Exercise - whereIs" do
         test "locates a file"
           $ Assert.equal (Just ("/bin/"))
-          $ whereIs "ls"
+          $ whereIs root "ls"
         test "doesn't locate a file"
           $ Assert.equal (Nothing)
-          $ whereIs "lss"
+          $ whereIs root "cat"
 
 {- Note to reader: Delete this line to expand comment block
 -}

--- a/exercises/chapter4/test/no-peeking/Solutions.purs
+++ b/exercises/chapter4/test/no-peeking/Solutions.purs
@@ -6,7 +6,7 @@ import Data.Array (cons, filter, head, last, length, tail, (..))
 import Data.Foldable (foldl)
 import Data.Int (rem, quot)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
-import Data.Path (Path, filename, isDirectory, ls, root, size)
+import Data.Path (Path, filename, isDirectory, ls, size)
 import Data.String.Common (split)
 import Data.String.Pattern (Pattern(..))
 import Data.Tuple (Tuple(..), snd)
@@ -127,8 +127,8 @@ allSizes paths =
     )
     paths
 
-whereIs :: String -> Maybe String
-whereIs fileName = head $ whereIs' $ allFiles root
+whereIs :: Path -> String -> Maybe String
+whereIs path fileName = head $ whereIs' $ allFiles path
   where
   whereIs' :: Array Path -> Array String
   whereIs' paths = do

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -647,10 +647,10 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
  1. (Difficult) Write a function `whereIs` to search for a file by name. The function should return a value of type `Maybe Path`, indicating the directory containing the file, if it exists. It should behave as follows:
 
      ```text
-     > whereIs "/bin/ls"
+     > whereIs root "ls"
      Just (/bin/)
 
-     > whereIs "/bin/cat"
+     > whereIs root "cat"
      Nothing
      ```
 


### PR DESCRIPTION
Change 'whereIs' signature so it accepts an arbitary path as an argument.
Update the instruction to show that it should take an additional path parameter.
Correcting file names in the instuction so they do not contain their base paths.

fixes #216