### PR TITLE
Fixes the 'Line' type center calculation formula

### DIFF
--- a/exercises/chapter5/src/Data/Picture.purs
+++ b/exercises/chapter5/src/Data/Picture.purs
@@ -11,6 +11,12 @@ data Point = Point
   , y :: Number
   }
 
+getX :: Point -> Number
+getX (Point p) = p.x
+
+getY :: Point -> Number
+getY (Point p) = p.y
+
 showPoint :: Point -> String
 showPoint (Point { x, y }) =
   "(" <> show x <> ", " <> show y <> ")"
@@ -37,7 +43,7 @@ origin = Point { x: 0.0, y: 0.0 }
 getCenter :: Shape -> Point
 getCenter (Circle c r) = c
 getCenter (Rectangle c w h) = c
-getCenter (Line (Point s) (Point e)) = Point { x: s.x - e.x, y: s.y - e.y }
+getCenter (Line (Point s) (Point e)) = Point { x: (s.x + e.x) / 2.0, y: (s.y + e.y) / 2.0 }
 getCenter (Text loc text) = loc
 
 type Picture = Array Shape

--- a/exercises/chapter5/test/no-peeking/Solutions.purs
+++ b/exercises/chapter5/test/no-peeking/Solutions.purs
@@ -9,9 +9,12 @@ import Data.Picture
   , Picture
   , Point(Point)
   , Shape(Circle, Rectangle, Line, Text)
-  , origin
   , bounds
+  , getCenter
+  , getX
+  , getY
   , intersect
+  , origin
   )
 import Data.Picture as DataP
 import Math as Math
@@ -59,14 +62,15 @@ circleAtOrigin = Circle origin 10.0
 centerShape :: Shape -> Shape
 centerShape (Circle c r) = Circle origin r
 centerShape (Rectangle c w h) = Rectangle origin w h
-centerShape (Line (Point s) (Point e)) =
+centerShape line@(Line (Point s) (Point e)) =
   (Line
     (Point { x: s.x - deltaX, y: s.y - deltaY })
     (Point { x: e.x - deltaX, y: e.y - deltaY })
   )
   where
-  deltaX = (e.x + s.x) / 2.0
-  deltaY = (e.y + s.y) / 2.0
+  delta = getCenter line
+  deltaX = getX delta
+  deltaY = getY delta
 centerShape (Text loc text) = Text origin text
 
 scaleShape :: Number -> Shape -> Shape


### PR DESCRIPTION
Changes the formula to x=(p1.x+p2.x)/2 y=(p1.y+p2.y)/2

Reuses the 'getCenter' function in the centerShape example implementation.

fixes #219 