### PR TITLE
Make whereIs signature match exercise instructions

### DIFF
--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -162,9 +162,11 @@ Note to reader: Delete this line to expand comment block -}
       suite "Exercise - whereIs" do
         test "locates a file"
           $ Assert.equal (Just ("/bin/"))
+          $ map filename
           $ whereIs root "ls"
         test "doesn't locate a file"
           $ Assert.equal (Nothing)
+          $ map filename
           $ whereIs root "cat"
 
 {- Note to reader: Delete this line to expand comment block

--- a/exercises/chapter4/test/no-peeking/Solutions.purs
+++ b/exercises/chapter4/test/no-peeking/Solutions.purs
@@ -127,12 +127,12 @@ allSizes paths =
     )
     paths
 
-whereIs :: Path -> String -> Maybe String
+whereIs :: Path -> String -> Maybe Path
 whereIs path fileName = head $ whereIs' $ allFiles path
   where
-  whereIs' :: Array Path -> Array String
+  whereIs' :: Array Path -> Array Path
   whereIs' paths = do
     path <- paths
     child <- ls path
     guard $ eq fileName $ fromMaybe "" $ last $ split (Pattern "/") $ filename child
-    pure $ filename path
+    pure path


### PR DESCRIPTION
This PR changes the return type of the `whereIs` function from `Maybe String` to `Maybe Path` in the `chapter4` `Solutions.purs` file and updates the relevant test accordingly.

This fixes #222.