### PR TITLE
Fix ch4 largestSmallest

### DIFF
--- a/exercises/chapter4/src/Data/Path.purs
+++ b/exercises/chapter4/src/Data/Path.purs
@@ -1,5 +1,5 @@
 module Data.Path
-  ( Path()
+  ( Path(..)
   , root
   , ls
   , filename

--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -155,6 +155,15 @@ Note to reader: Delete this line to expand comment block -}
           ]
           $ map filename
           $ onlyFiles root
+      suite "Exercise - whereIs" do
+        test "locates a file"
+          $ Assert.equal (Just ("/bin/"))
+          $ map filename
+          $ whereIs root "ls"
+        test "doesn't locate a file"
+          $ Assert.equal (Nothing)
+          $ map filename
+          $ whereIs root "cat"
       suite "Exercise - largestSmallest for root" do
         test "has length of 2" do
           Assert.equal 2
@@ -170,15 +179,6 @@ Note to reader: Delete this line to expand comment block -}
             $ map filename
             $ find (\p -> filename p == "/etc/hosts")
             $ largestSmallest root
-      suite "Exercise - whereIs" do
-        test "locates a file"
-          $ Assert.equal (Just ("/bin/"))
-          $ map filename
-          $ whereIs root "ls"
-        test "doesn't locate a file"
-          $ Assert.equal (Nothing)
-          $ map filename
-          $ whereIs root "cat"
 
 {- Note to reader: Delete this line to expand comment block
 -}

--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 import Test.Examples
 import Test.MySolutions
 import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
-import Data.Array (sort)
+import Data.Array (filter, find, sort)
 import Data.Maybe (Maybe(..))
 import Data.Path (filename, root)
 import Data.Tuple (fst)
@@ -155,10 +155,21 @@ Note to reader: Delete this line to expand comment block -}
           ]
           $ map filename
           $ onlyFiles root
-      test "Exercise - largestSmallest for root" do
-        Assert.equal [ "/home/user/code/js/test.js", "/etc/hosts" ]
-          $ map fst
-          $ largestSmallest root
+      suite "Exercise - largestSmallest for root" do
+        test "has length of 2" do
+          Assert.equal 2
+            $ length 
+            $ largestSmallest root
+        test "includes /home/user/code/js/test.js" do
+          Assert.equal (Just "/home/user/code/js/test.js")
+            $ map filename 
+            $ find (\p -> filename p == "/home/user/code/js/test.js")
+            $ largestSmallest root
+        test "includes /etc/hosts" do
+          Assert.equal (Just "/etc/hosts")
+            $ map filename
+            $ find (\p -> filename p == "/etc/hosts")
+            $ largestSmallest root
       suite "Exercise - whereIs" do
         test "locates a file"
           $ Assert.equal (Just ("/bin/"))

--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -6,7 +6,7 @@ import Test.MySolutions
 import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
 import Data.Array (filter, find, sort)
 import Data.Maybe (Maybe(..))
-import Data.Path (filename, root)
+import Data.Path (Path(..), filename, root)
 import Data.Tuple (fst)
 import Effect (Effect)
 import Test.Unit (TestSuite, suite, test)
@@ -165,11 +165,20 @@ Note to reader: Delete this line to expand comment block -}
           $ map filename
           $ whereIs root "cat"
       suite "Exercise - largestSmallest" do
-        test "for root" do
-          Assert.equal ["/etc/hosts", "/home/user/code/js/test.js"]
-            $ sort
-            $ map filename
-            $ largestSmallest root
+        let
+          testls :: String -> Array String -> Path -> TestSuite
+          testls label expected path =
+            test label do
+              Assert.equal expected
+              -- Sorting to allow any ordering
+                $ sort
+                $ map filename
+                $ largestSmallest path
+          oneFileDir = Directory "/etc/" [ File "/etc/hosts" 300 ]
+          emptyDir = Directory "/etc/" []
+        testls "works for root" ["/etc/hosts", "/home/user/code/js/test.js"] root
+        testls "works for a directory with one file" ["/etc/hosts"] oneFileDir
+        testls "works for an empty directory" [] emptyDir
 
 {- Note to reader: Delete this line to expand comment block
 -}

--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 import Test.Examples
 import Test.MySolutions
 import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
-import Data.Array (filter, find, sort)
+import Data.Array (sort)
 import Data.Maybe (Maybe(..))
 import Data.Path (Path(..), filename, root)
 import Data.Tuple (fst)

--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -164,20 +164,11 @@ Note to reader: Delete this line to expand comment block -}
           $ Assert.equal (Nothing)
           $ map filename
           $ whereIs root "cat"
-      suite "Exercise - largestSmallest for root" do
-        test "has length of 2" do
-          Assert.equal 2
-            $ length 
-            $ largestSmallest root
-        test "includes /home/user/code/js/test.js" do
-          Assert.equal (Just "/home/user/code/js/test.js")
-            $ map filename 
-            $ find (\p -> filename p == "/home/user/code/js/test.js")
-            $ largestSmallest root
-        test "includes /etc/hosts" do
-          Assert.equal (Just "/etc/hosts")
+      suite "Exercise - largestSmallest" do
+        test "for root" do
+          Assert.equal ["/etc/hosts", "/home/user/code/js/test.js"]
+            $ sort
             $ map filename
-            $ find (\p -> filename p == "/etc/hosts")
             $ largestSmallest root
 
 {- Note to reader: Delete this line to expand comment block

--- a/exercises/chapter4/test/no-peeking/Solutions.purs
+++ b/exercises/chapter4/test/no-peeking/Solutions.purs
@@ -2,7 +2,7 @@ module Test.NoPeeking.Solutions where
 
 import Prelude
 import Control.MonadZero (guard)
-import Data.Array (catMaybes, cons, filter, find, head, last, length, nubBy, tail, (..))
+import Data.Array (catMaybes, cons, filter, find, head, last, length, nub, tail, (..))
 import Data.Foldable (foldl)
 import Data.Int (rem, quot)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
@@ -118,11 +118,11 @@ whereIs path fileName = head $ whereIs' $ allFiles path
 
 largestSmallest :: Path -> Array Path
 largestSmallest path = 
-  let files = allFiles path
+  let files = onlyFiles path
       maybeSizes = map size files
       maybeMax = foldl (outlier (>)) Nothing maybeSizes
       maybeMin = foldl (outlier (<)) Nothing maybeSizes
-  in nubBy compareNames $ catMaybes $ map (findFileBySize files) $ [maybeMax, maybeMin]
+  in catMaybes $ map (findFileBySize files) $ nub $ [maybeMax, maybeMin]
   where
   outlier :: (Int -> Int -> Boolean) -> Maybe Int -> Maybe Int -> Maybe Int
   outlier criteria Nothing Nothing = Nothing
@@ -131,5 +131,3 @@ largestSmallest path =
   outlier criteria (Just x1) (Just x2) = if criteria x1 x2 then Just x1 else Just x2
   findFileBySize :: Array Path -> Maybe Int -> Maybe Path
   findFileBySize files maybeSize = find (\file -> size file == maybeSize) files
-  compareNames :: Path -> Path -> Ordering
-  compareNames file1 file2 = compare (filename file1) (filename file2)

--- a/exercises/chapter4/test/no-peeking/Solutions.purs
+++ b/exercises/chapter4/test/no-peeking/Solutions.purs
@@ -97,25 +97,6 @@ reverse = foldl (\xs x -> [ x ] <> xs) []
 onlyFiles :: Path -> Array Path
 onlyFiles p = filter (\p' -> not $ isDirectory p') $ allFiles p
 
-largestSmallest :: Path -> Array Path
-largestSmallest path = 
-  let files = allFiles path
-      maybeSizes = map size files
-      maybeMax = foldl (outlier (>)) Nothing maybeSizes
-      maybeMin = foldl (outlier (<)) Nothing maybeSizes
-  in nubBy compareNames $ catMaybes $ map (findFileBySize files) $ [maybeMax, maybeMin]
-  where
-  outlier :: (Int -> Int -> Boolean) -> Maybe Int -> Maybe Int -> Maybe Int
-  outlier criteria Nothing Nothing = Nothing
-  outlier criteria (Just x) Nothing = Just x
-  outlier criteria Nothing (Just x) = Just x
-  outlier criteria (Just x1) (Just x2) = if criteria x1 x2 then Just x1 else Just x2
-  findFileBySize :: Array Path -> Maybe Int -> Maybe Path
-  findFileBySize files maybeSize = find (\file -> size file == maybeSize) files
-  compareNames :: Path -> Path -> Ordering
-  compareNames file1 file2 = compare (filename file1) (filename file2)
-   
-
 allSizes :: Array Path -> Array (Tuple String Int)
 allSizes paths =
   map
@@ -134,3 +115,21 @@ whereIs path fileName = head $ whereIs' $ allFiles path
     child <- ls path
     guard $ eq fileName $ fromMaybe "" $ last $ split (Pattern "/") $ filename child
     pure path
+
+largestSmallest :: Path -> Array Path
+largestSmallest path = 
+  let files = allFiles path
+      maybeSizes = map size files
+      maybeMax = foldl (outlier (>)) Nothing maybeSizes
+      maybeMin = foldl (outlier (<)) Nothing maybeSizes
+  in nubBy compareNames $ catMaybes $ map (findFileBySize files) $ [maybeMax, maybeMin]
+  where
+  outlier :: (Int -> Int -> Boolean) -> Maybe Int -> Maybe Int -> Maybe Int
+  outlier criteria Nothing Nothing = Nothing
+  outlier criteria (Just x) Nothing = Just x
+  outlier criteria Nothing (Just x) = Just x
+  outlier criteria (Just x1) (Just x2) = if criteria x1 x2 then Just x1 else Just x2
+  findFileBySize :: Array Path -> Maybe Int -> Maybe Path
+  findFileBySize files maybeSize = find (\file -> size file == maybeSize) files
+  compareNames :: Path -> Path -> Ordering
+  compareNames file1 file2 = compare (filename file1) (filename file2)

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -654,7 +654,7 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
      ```
 
      _Hint_: Try to write this function as an array comprehension using do notation.
- 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the filesystem. 
+ 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. NOTE: consider the cases where there are zero or one files in the `Path` (by returning an empty array or one-element array).
 
 ## Conclusion
 

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -654,7 +654,7 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
      ```
 
      _Hint_: Try to write this function as an array comprehension using do notation.
- 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. NOTE: consider the cases where there are zero or one files in the `Path` by returning an empty array or a one-element array respectively.
+ 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. _Note_: consider the cases where there are zero or one files in the `Path` by returning an empty array or a one-element array respectively.
 
 ## Conclusion
 

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -643,8 +643,7 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
  ## Exercises
 
  1. (Easy) Write a function `onlyFiles` which returns all _files_ (not directories) in all subdirectories of a directory.
- 1. (Medium) Write a function `largestSmallest` which returns an array containing the single largest and single smallest files in the filesystem.
- 1. (Difficult) Write a function `whereIs` to search for a file by name. The function should return a value of type `Maybe Path`, indicating the directory containing the file, if it exists. It should behave as follows:
+ 2. (Medium) Write a function `whereIs` to search for a file by name. The function should return a value of type `Maybe Path`, indicating the directory containing the file, if it exists. It should behave as follows:
 
      ```text
      > whereIs root "ls"
@@ -655,6 +654,7 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
      ```
 
      _Hint_: Try to write this function as an array comprehension using do notation.
+ 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the filesystem. 
 
 ## Conclusion
 

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -654,7 +654,7 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
      ```
 
      _Hint_: Try to write this function as an array comprehension using do notation.
- 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. NOTE: consider the cases where there are zero or one files in the `Path` (by returning an empty array or one-element array).
+ 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. NOTE: consider the cases where there are zero or one files in the `Path` by returning an empty array or a one-element array respectively.
 
 ## Conclusion
 


### PR DESCRIPTION
This PR fixes #221 by doing the following:

1. Replaces the existing solution to `largestSmallest` with one that does not use `Tuple` and handles the corner cases of when there are zero or one file in the provided `Path`.
2. Updates the exercise instructions for `largestSmallest` to explicitly mention that the function takes a `Path` as an argument and makes a note about corner cases.
3. Makes tests flexible enough to allow any ordering of the returned array.
4. Swaps the instruction/difficulty/solution/test ordering of `largestSmallest` with `whereIs` as I feel this is a much harder problem.

I'm open to any feedback on ways to improve my solution 😀