### PR TITLE
Add github link to mdbook

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,5 @@ language = "en"
 multilingual = false
 src = "text"
 title = "PureScript by Example"
+[output.html]
+git-repository-url = "https://github.com/purescript-contrib/purescript-book"


### PR DESCRIPTION
Adds a button that links to the book's repo in the upper right corner of each page.

![image](https://user-images.githubusercontent.com/3578681/98275551-994d8480-1f49-11eb-8755-2002327ed670.png)
