### PR TITLE
Remove unsafePartial regex

### DIFF
--- a/exercises/chapter10/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter10/src/Data/AddressBook/Validation.purs
@@ -9,7 +9,6 @@ import Data.String.Regex (Regex, test, regex)
 import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, invalid, toEither)
-import Partial.Unsafe (unsafePartial)
 
 type Errors
   = Array String
@@ -29,16 +28,14 @@ lengthIs field len value | length value /= len =
   invalid [ "Field '" <> field <> "' must have length " <> show len ]
 lengthIs _     _   value = pure value
 
-phoneNumberRegex :: Regex
-phoneNumberRegex =
-  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
-    Right r -> r
+phoneNumberRegex :: Either String Regex
+phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 
-matches :: String -> Regex -> String -> V Errors String
-matches _     regex value | test regex value =
-  pure value
-matches field _     _     =
-  invalid [ "Field '" <> field <> "' did not match the required format" ]
+matches :: String -> Either String Regex -> String -> V Errors String
+matches _    (Right regex) value | test regex value 
+                                 = pure value
+matches _    (Left  error) _     = invalid [ "Malformed regex: " <> error ]
+matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address
 validateAddress a =

--- a/exercises/chapter10/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter10/src/Data/AddressBook/Validation.purs
@@ -34,7 +34,7 @@ phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 matches :: String -> Either String Regex -> String -> V Errors String
 matches _    (Right regex) value | test regex value 
                                  = pure value
-matches _    (Left  error) _     = invalid [ "Malformed regex: " <> error ]
+matches _    (Left  error) _     = invalid [ error ]
 matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address

--- a/exercises/chapter10/test/Main.purs
+++ b/exercises/chapter10/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Prelude
 import Test.Examples
 import Test.MySolutions
+
 import Control.Monad.Free (Free)
 import Data.Argonaut (decodeJson, encodeJson)
 import Data.Either (Either(..), isLeft)

--- a/exercises/chapter7/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter7/src/Data/AddressBook/Validation.purs
@@ -72,7 +72,7 @@ phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 matches :: String -> Either String Regex -> String -> V Errors String
 matches _    (Right regex) value | test regex value 
                                  = pure value
-matches _    (Left  error) _     = invalid [ "Malformed regex: " <> error ]
+matches _    (Left  error) _     = invalid [ error ]
 matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 -- ANCHOR_END: matches
 

--- a/exercises/chapter7/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter7/src/Data/AddressBook/Validation.purs
@@ -8,7 +8,6 @@ import Data.String.Regex (Regex, test, regex)
 import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, invalid)
-import Partial.Unsafe (unsafePartial)
 
 -----------------
 -- Some simple early examples returning `Either` instead of `V`:
@@ -65,18 +64,16 @@ lengthIs _     _   value = pure value
 -- ANCHOR_END: lengthIs
 
 -- ANCHOR: phoneNumberRegex
-phoneNumberRegex :: Regex
-phoneNumberRegex =
-  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
-    Right r -> r
+phoneNumberRegex :: Either String Regex
+phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 -- ANCHOR_END: phoneNumberRegex
 
 -- ANCHOR: matches
-matches :: String -> Regex -> String -> V Errors String
-matches _     regex value | test regex value =
-  pure value
-matches field _     _     =
-  invalid [ "Field '" <> field <> "' did not match the required format" ]
+matches :: String -> Either String Regex -> String -> V Errors String
+matches _    (Right regex) value | test regex value 
+                                 = pure value
+matches _    (Left  error) _     = invalid [ "Malformed regex: " <> error ]
+matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 -- ANCHOR_END: matches
 
 -- ANCHOR: validateAddress

--- a/exercises/chapter7/test/Main.purs
+++ b/exercises/chapter7/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Prelude
 import Test.MySolutions
 import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
+
 import Control.Monad.Writer (runWriter, tell)
 import Data.AddressBook (PhoneType(..), address, phoneNumber)
 import Data.Array ((..))
@@ -102,8 +103,8 @@ Note to reader: Delete this line to expand comment block -}
         let
           stateTest str exp =
             test (show str) do
-              Assert.equal exp
-                $ R.test stateRegex str
+              Assert.equal (Right exp)
+                $ R.test <$> stateRegex <*> Right str
         stateTest "CA" true
         stateTest "Ca" true
         stateTest "C" false
@@ -113,8 +114,8 @@ Note to reader: Delete this line to expand comment block -}
         let
           nonEmptyTest str exp =
             test (show str) do
-              Assert.equal exp
-                $ R.test nonEmptyRegex str
+              Assert.equal (Right exp)
+                $ R.test <$> nonEmptyRegex <*> Right str
         nonEmptyTest "Houston" true
         nonEmptyTest "My Street" true
         nonEmptyTest "Ñóñá" true

--- a/exercises/chapter7/test/no-peeking/Solutions.purs
+++ b/exercises/chapter7/test/no-peeking/Solutions.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Apply (lift2)
 import Data.AddressBook (Address, PhoneNumber, address)
 import Data.AddressBook.Validation (Errors, matches, nonEmpty, validateAddress, validatePhoneNumbers)
-import Data.Either (Either(..))
+import Data.Either (Either)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
@@ -13,7 +13,6 @@ import Data.String.Regex (Regex, regex)
 import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (class Foldable, class Traversable, foldMap, foldl, foldr, sequence, traverse)
 import Data.Validation.Semigroup (V)
-import Partial.Unsafe (unsafePartial)
 
 {-| Exercise Group 1 -}
 -- Exercise 1
@@ -50,24 +49,20 @@ combineMaybe _ = pure Nothing
 
 {-| Exercise Group 2 -}
 -- Exercise 1
-stateRegex :: Regex
-stateRegex =
-  unsafePartial case regex "^[a-zA-Z]{2}$" noFlags of
-    Right r -> r
+stateRegex :: Either String Regex
+stateRegex = regex "^[a-zA-Z]{2}$" noFlags
 
 -- Exercise 2
-nonEmptyRegex :: Regex
-nonEmptyRegex =
-  unsafePartial case regex "[^\\s]$" noFlags of
-    Right r -> r
+nonEmptyRegex :: Either String Regex
+nonEmptyRegex = regex "[^\\s]$" noFlags
 
 -- Exercise 3
 validateAddressImproved :: Address -> V Errors Address
 validateAddressImproved a =
   address
-    <$> (matches "Street" nonEmptyRegex a.street *> pure a.street)
-    <*> (matches "City" nonEmptyRegex a.city *> pure a.city)
-    <*> (matches "State" stateRegex a.state *> pure a.state)
+    <$> matches "Street" nonEmptyRegex a.street
+    <*> matches "City"   nonEmptyRegex a.city
+    <*> matches "State"  stateRegex    a.state
 
 {-| Exercise Group 3 -}
 -- Exercise 1

--- a/exercises/chapter8/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter8/src/Data/AddressBook/Validation.purs
@@ -9,7 +9,6 @@ import Data.String.Regex (Regex, test, regex)
 import Data.String.Regex.Flags (noFlags)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, invalid, toEither)
-import Partial.Unsafe (unsafePartial)
 
 type Errors
   = Array String
@@ -29,16 +28,14 @@ lengthIs field len value | length value /= len =
   invalid [ "Field '" <> field <> "' must have length " <> show len ]
 lengthIs _     _   value = pure value
 
-phoneNumberRegex :: Regex
-phoneNumberRegex =
-  unsafePartial case regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags of
-    Right r -> r
+phoneNumberRegex :: Either String Regex
+phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 
-matches :: String -> Regex -> String -> V Errors String
-matches _     regex value | test regex value =
-  pure value
-matches field _     _     =
-  invalid [ "Field '" <> field <> "' did not match the required format" ]
+matches :: String -> Either String Regex -> String -> V Errors String
+matches _    (Right regex) value | test regex value 
+                                 = pure value
+matches _    (Left  error) _     = invalid [ "Malformed regex: " <> error ]
+matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address
 validateAddress a =

--- a/exercises/chapter8/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter8/src/Data/AddressBook/Validation.purs
@@ -34,7 +34,7 @@ phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 matches :: String -> Either String Regex -> String -> V Errors String
 matches _    (Right regex) value | test regex value 
                                  = pure value
-matches _    (Left  error) _     = invalid [ "Malformed regex: " <> error ]
+matches _    (Left  error) _     = invalid [ error ]
 matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -537,8 +537,8 @@ invalid (["Field 'Number' did not match the required format"])
 
  ## Exercises
 
- 1. (Easy) Write a regular expression `stateRegex :: Regex` to check that a string only contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
- 1. (Medium) Write a regular expression `nonEmptyRegex :: Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com) which has a great cheatsheet and interactive test environment.
+ 1. (Easy) Write a regular expression `stateRegex :: Either String Regex` to check that a string only contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
+ 1. (Medium) Write a regular expression `nonEmptyRegex :: Either String Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com) which has a great cheatsheet and interactive test environment.
  1. (Medium) Write a function `validateAddressImproved` that is similar to `validateAddress`, but uses the above `stateRegex` to validate the `state` field and `nonEmptyRegex` to validate the `street` and `city` fields. _Hint_: see the source for `validatePhoneNumber` for an example of how to use `matches`.
 
 ## Traversable Functors


### PR DESCRIPTION
Updated ch7, ch8 & ch10 code to work with `Either String Regex` instead of `Regex` so this is a solution to removing `unsafePartial` usage. **By using `Either String Regex` do we need to change anything in text?** - still needs to be investigated.

Also removed remaining `(*>)` usage in ch7 solutions code.

I mistakingly changed the name from Solutions.* to MySolutions.* while
working on the commit that fixed the addressbook applicative.

This commit also fixes this rename issue.

Closes #164 