### PR TITLE
Ch5 - Convert unnecessary ADTs to type synonyms and add anchors

### DIFF
--- a/exercises/chapter5/src/ChapterExamples.purs
+++ b/exercises/chapter5/src/ChapterExamples.purs
@@ -1,0 +1,129 @@
+module ChapterExamples where
+
+import Prelude hiding (gcd)
+-- ANCHOR: lzsImport
+import Data.Array (tail)
+import Data.Foldable (sum)
+import Data.Maybe (fromMaybe)
+-- ANCHOR_END: lzsImport
+-- ANCHOR: unsafePartialImport
+import Partial.Unsafe (unsafePartial)
+-- ANCHOR_END: unsafePartialImport
+
+-- ANCHOR: gcd
+gcd :: Int -> Int -> Int
+gcd n 0 = n
+gcd 0 m = m
+gcd n m = if n > m
+            then gcd (n - m) m
+            else gcd n (m - n)
+-- ANCHOR_END: gcd
+
+-- ANCHOR: fromString
+fromString :: String -> Boolean
+fromString "true" = true
+fromString _      = false
+-- ANCHOR_END: fromString
+
+-- ANCHOR: toString
+toString :: Boolean -> String
+toString true  = "true"
+toString false = "false"
+-- ANCHOR_END: toString
+
+-- ANCHOR: gcdV2
+gcdV2 :: Int -> Int -> Int
+gcdV2 n 0 = n
+gcdV2 0 n = n
+gcdV2 n m | n > m     = gcdV2 (n - m) m
+          | otherwise = gcdV2 n (m - n)
+-- ANCHOR_END: gcdV2
+
+-- ANCHOR: isEmpty
+isEmpty :: forall a. Array a -> Boolean
+isEmpty [] = true
+isEmpty _ = false
+-- ANCHOR_END: isEmpty
+
+-- ANCHOR: takeFive
+takeFive :: Array Int -> Int
+takeFive [0, 1, a, b, _] = a * b
+takeFive _ = 0
+-- ANCHOR_END: takeFive
+
+-- ANCHOR: showPerson
+showPerson :: { first :: String, last :: String } -> String
+showPerson { first: x, last: y } = y <> ", " <> x
+-- ANCHOR_END: showPerson
+
+-- ANCHOR: showPersonV2
+showPersonV2 :: { first :: String, last :: String } -> String
+showPersonV2 { first, last } = last <> ", " <> first
+-- ANCHOR_END: showPersonV2
+
+-- ANCHOR: unknownPerson
+unknownPerson :: { first :: String, last :: String }
+unknownPerson = { first, last }
+  where
+    first = "Jane"
+    last  = "Doe"
+-- ANCHOR_END: unknownPerson
+
+-- ANCHOR: livesInLA
+type Address = { street :: String, city :: String }
+
+type Person = { name :: String, address :: Address }
+
+livesInLA :: Person -> Boolean
+livesInLA { address: { city: "Los Angeles" } } = true
+livesInLA _ = false
+-- ANCHOR_END: livesInLA
+
+-- ANCHOR: sortPair
+sortPair :: Array Int -> Array Int
+sortPair arr@[x, y]
+  | x <= y = arr
+  | otherwise = [y, x]
+sortPair arr = arr
+-- ANCHOR_END: sortPair
+
+-- ANCHOR: lzs
+lzs :: Array Int -> Array Int
+lzs [] = []
+lzs xs = case sum xs of
+           0 -> xs
+           _ -> lzs (fromMaybe [] $ tail xs)
+-- ANCHOR_END: lzs
+
+-- ANCHOR: partialFunction
+partialFunction :: Boolean -> Boolean
+partialFunction = unsafePartial \true -> true
+-- ANCHOR_END: partialFunction
+
+-- ANCHOR: electricalUnits
+newtype Volt = Volt Number
+newtype Ohm = Ohm Number
+newtype Amp = Amp Number
+-- ANCHOR_END: electricalUnits
+
+-- ANCHOR: calculateCurrent
+calculateCurrent :: Volt -> Ohm -> Amp
+calculateCurrent (Volt v) (Ohm r) = Amp (v / r)
+
+battery :: Volt
+battery = Volt 1.5
+
+lightbulb :: Ohm
+lightbulb = Ohm 500.0
+
+current :: Amp
+current = calculateCurrent battery lightbulb
+-- ANCHOR_END: calculateCurrent
+
+-- These are to enable testing. Will be explained in Ch6.
+derive newtype instance eqAmp :: Eq Amp
+derive newtype instance showAmp :: Show Amp
+
+-- ANCHOR: Watt
+newtype Watt = MakeWatt Number
+-- ANCHOR_END: Watt

--- a/exercises/chapter5/src/Data/Picture.purs
+++ b/exercises/chapter5/src/Data/Picture.purs
@@ -1,26 +1,36 @@
+-- ANCHOR: module_picture
 module Data.Picture where
 
 import Prelude
-
 import Data.Foldable (foldl)
+-- ANCHOR_END: module_picture
+-- ANCHOR: picture_import_as
 import Global as Global
 import Math as Math
+-- ANCHOR_END: picture_import_as
 
+-- ANCHOR: Point
 type Point =
   { x :: Number
   , y :: Number
   }
+-- ANCHOR_END: Point
 
+-- ANCHOR: showPoint
 showPoint :: Point -> String
 showPoint { x, y } =
   "(" <> show x <> ", " <> show y <> ")"
+-- ANCHOR_END: showPoint
 
+-- ANCHOR: Shape
 data Shape
   = Circle Point Number
   | Rectangle Point Number Number
   | Line Point Point
   | Text Point String
+-- ANCHOR_END: Shape
 
+-- ANCHOR: showShape
 showShape :: Shape -> String
 showShape (Circle c r) =
   "Circle [center: " <> showPoint c <> ", radius: " <> show r <> "]"
@@ -30,9 +40,28 @@ showShape (Line start end) =
   "Line [start: " <> showPoint start <> ", end: " <> showPoint end <> "]"
 showShape (Text loc text) =
   "Text [location: " <> showPoint loc <> ", text: " <> show text <> "]"
+-- ANCHOR_END: showShape
 
+-- ANCHOR: exampleLine
+exampleLine :: Shape
+exampleLine = Line p1 p2
+  where
+    p1 :: Point
+    p1 = { x: 0.0, y: 0.0 }
+
+    p2 :: Point
+    p2 = { x: 100.0, y: 50.0 }
+-- ANCHOR_END: exampleLine
+
+-- ANCHOR: origin
 origin :: Point
-origin = { x: 0.0, y: 0.0 }
+origin = { x, y }
+  where
+    x = 0.0
+    y = 0.0
+-- ANCHOR_END: origin
+-- Would generally write it like this instead:
+-- origin = { x: 0.0, y: 0.0 }
 
 getCenter :: Shape -> Point
 getCenter (Circle c r) = c
@@ -40,17 +69,23 @@ getCenter (Rectangle c w h) = c
 getCenter (Line s e) = (s + e) * {x: 0.5, y: 0.5}
 getCenter (Text loc text) = loc
 
+-- ANCHOR: Picture
 type Picture = Array Shape
+-- ANCHOR_END: Picture
 
+-- ANCHOR: showPicture
 showPicture :: Picture -> Array String
 showPicture = map showShape
+-- ANCHOR_END: showPicture
 
+-- ANCHOR: Bounds
 data Bounds = Bounds
   { top    :: Number
   , left   :: Number
   , bottom :: Number
   , right  :: Number
   }
+-- ANCHOR_END: Bounds
 
 showBounds :: Bounds -> String
 showBounds (Bounds b) =
@@ -118,11 +153,13 @@ infiniteBounds = Bounds
   , right:   Global.infinity
   }
 
+-- ANCHOR: bounds
 bounds :: Picture -> Bounds
 bounds = foldl combine emptyBounds
   where
   combine :: Bounds -> Shape -> Bounds
   combine b shape = union (shapeBounds shape) b
+-- ANCHOR_END: bounds
 
 {-
 These `instance`s are to enable testing.

--- a/exercises/chapter5/src/Data/Picture.purs
+++ b/exercises/chapter5/src/Data/Picture.purs
@@ -6,13 +6,13 @@ import Data.Foldable (foldl)
 import Global as Global
 import Math as Math
 
-data Point = Point
+type Point =
   { x :: Number
   , y :: Number
   }
 
 showPoint :: Point -> String
-showPoint (Point { x, y }) =
+showPoint { x, y } =
   "(" <> show x <> ", " <> show y <> ")"
 
 data Shape
@@ -32,12 +32,12 @@ showShape (Text loc text) =
   "Text [location: " <> showPoint loc <> ", text: " <> show text <> "]"
 
 origin :: Point
-origin = Point { x: 0.0, y: 0.0 }
+origin = { x: 0.0, y: 0.0 }
 
 getCenter :: Shape -> Point
 getCenter (Circle c r) = c
 getCenter (Rectangle c w h) = c
-getCenter (Line (Point s) (Point e)) = Point { x: (s.x + e.x) / 2.0, y: (s.y + e.y) / 2.0 }
+getCenter (Line s e) = (s + e) * {x: 0.5, y: 0.5}
 getCenter (Text loc text) = loc
 
 type Picture = Array Shape
@@ -61,25 +61,25 @@ showBounds (Bounds b) =
   "]"
 
 shapeBounds :: Shape -> Bounds
-shapeBounds (Circle (Point { x, y }) r) = Bounds
+shapeBounds (Circle { x, y } r) = Bounds
   { top:    y - r
   , left:   x - r
   , bottom: y + r
   , right:  x + r
   }
-shapeBounds (Rectangle (Point { x, y }) w h) = Bounds
+shapeBounds (Rectangle { x, y } w h) = Bounds
   { top:    y - h / 2.0
   , left:   x - w / 2.0
   , bottom: y + h / 2.0
   , right:  x + w / 2.0
   }
-shapeBounds (Line (Point p1) (Point p2)) = Bounds
+shapeBounds (Line p1 p2) = Bounds
   { top:    Math.min p1.y p2.y
   , left:   Math.min p1.x p2.x
   , bottom: Math.max p1.y p2.y
   , right:  Math.max p1.x p2.x
   }
-shapeBounds (Text (Point { x, y }) _) = Bounds
+shapeBounds (Text { x, y } _) = Bounds
   { top:    y
   , left:   x
   , bottom: y
@@ -133,11 +133,6 @@ derive instance boundsEq :: Eq Bounds
 
 instance boundsShow :: Show Bounds where
   show b = showBounds b
-
-derive instance pointEq :: Eq Point
-
-instance pointShow :: Show Point where
-  show p = showPoint p
 
 derive instance shapeEq :: Eq Shape
 

--- a/exercises/chapter5/src/Data/Picture.purs
+++ b/exercises/chapter5/src/Data/Picture.purs
@@ -11,12 +11,6 @@ data Point = Point
   , y :: Number
   }
 
-getX :: Point -> Number
-getX (Point p) = p.x
-
-getY :: Point -> Number
-getY (Point p) = p.y
-
 showPoint :: Point -> String
 showPoint (Point { x, y }) =
   "(" <> show x <> ", " <> show y <> ")"

--- a/exercises/chapter5/src/Data/Picture.purs
+++ b/exercises/chapter5/src/Data/Picture.purs
@@ -79,7 +79,7 @@ showPicture = map showShape
 -- ANCHOR_END: showPicture
 
 -- ANCHOR: Bounds
-data Bounds = Bounds
+type Bounds =
   { top    :: Number
   , left   :: Number
   , bottom :: Number
@@ -88,7 +88,7 @@ data Bounds = Bounds
 -- ANCHOR_END: Bounds
 
 showBounds :: Bounds -> String
-showBounds (Bounds b) =
+showBounds b =
   "Bounds [top: " <> show b.top <>
   ", left: "      <> show b.left <>
   ", bottom: "    <> show b.bottom <>
@@ -96,25 +96,25 @@ showBounds (Bounds b) =
   "]"
 
 shapeBounds :: Shape -> Bounds
-shapeBounds (Circle { x, y } r) = Bounds
+shapeBounds (Circle { x, y } r) =
   { top:    y - r
   , left:   x - r
   , bottom: y + r
   , right:  x + r
   }
-shapeBounds (Rectangle { x, y } w h) = Bounds
+shapeBounds (Rectangle { x, y } w h) =
   { top:    y - h / 2.0
   , left:   x - w / 2.0
   , bottom: y + h / 2.0
   , right:  x + w / 2.0
   }
-shapeBounds (Line p1 p2) = Bounds
+shapeBounds (Line p1 p2) =
   { top:    Math.min p1.y p2.y
   , left:   Math.min p1.x p2.x
   , bottom: Math.max p1.y p2.y
   , right:  Math.max p1.x p2.x
   }
-shapeBounds (Text { x, y } _) = Bounds
+shapeBounds (Text { x, y } _) =
   { top:    y
   , left:   x
   , bottom: y
@@ -122,7 +122,7 @@ shapeBounds (Text { x, y } _) = Bounds
   }
 
 union :: Bounds -> Bounds -> Bounds
-union (Bounds b1) (Bounds b2) = Bounds
+union b1 b2 =
   { top:    Math.min b1.top    b2.top
   , left:   Math.min b1.left   b2.left
   , bottom: Math.max b1.bottom b2.bottom
@@ -130,7 +130,7 @@ union (Bounds b1) (Bounds b2) = Bounds
   }
 
 intersect :: Bounds -> Bounds -> Bounds
-intersect (Bounds b1) (Bounds b2) = Bounds
+intersect b1 b2 =
   { top:    Math.max b1.top    b2.top
   , left:   Math.max b1.left   b2.left
   , bottom: Math.min b1.bottom b2.bottom
@@ -138,7 +138,7 @@ intersect (Bounds b1) (Bounds b2) = Bounds
   }
 
 emptyBounds :: Bounds
-emptyBounds = Bounds
+emptyBounds =
   { top:     Global.infinity
   , left:    Global.infinity
   , bottom: -Global.infinity
@@ -146,7 +146,7 @@ emptyBounds = Bounds
   }
 
 infiniteBounds :: Bounds
-infiniteBounds = Bounds
+infiniteBounds =
   { top:    -Global.infinity
   , left:   -Global.infinity
   , bottom:  Global.infinity
@@ -166,11 +166,6 @@ These `instance`s are to enable testing.
 Feel free to ignore these.
 They'll make more sense in the next chapter.
 -}
-derive instance boundsEq :: Eq Bounds
-
-instance boundsShow :: Show Bounds where
-  show b = showBounds b
-
 derive instance shapeEq :: Eq Shape
 
 instance shapeShow :: Show Shape where

--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -8,7 +8,7 @@ import ChapterExamples (Amp(..), current, fromString, gcd, gcdV2, isEmpty, lives
 import Data.Int (round)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Person (Person)
-import Data.Picture (Shape(..), Picture, Bounds(..), getCenter, origin)
+import Data.Picture (Shape(..), Picture, getCenter, origin)
 import Effect (Effect)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert as Assert
@@ -120,9 +120,9 @@ Note to reader: Delete this line to expand comment block -}
         Assert.equal 0
           $ round $ area $ Text origin "Text has no area!"
       test "Exercise - Clipped shapeBounds" do
-        Assert.equal (Bounds { top: -2.0, left: -2.0, right: 2.0, bottom: 2.0 })
+        Assert.equal { top: -2.0, left: -2.0, right: 2.0, bottom: 2.0 }
           $ shapeBounds (Clipped samplePicture { x: 0.0, y: 0.0 } 4.0 4.0)
-        Assert.equal (Bounds { top: 3.0, left: 3.0, right: 7.0, bottom: 7.0 })
+        Assert.equal { top: 3.0, left: 3.0, right: 7.0, bottom: 7.0 }
           $ shapeBounds (Clipped samplePicture { x: 5.0, y: 5.0 } 4.0 4.0)
 
 {- Note to reader: Delete this line to expand comment block

--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -7,7 +7,7 @@ import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
 import Data.Int(round)
 import Data.Maybe(Maybe(Just, Nothing))
 import Data.Person (Person)
-import Data.Picture (Point(..), Shape(..), Picture, Bounds(..), getCenter, origin)
+import Data.Picture (Shape(..), Picture, Bounds(..), getCenter, origin)
 import Effect (Effect)
 import Test.Unit (suite, test)
 import Test.Unit.Assert as Assert
@@ -24,9 +24,9 @@ amy = { name: "Amy Lopez", address: { street: "10 Purs Street", city: "Omaha" } 
 
 samplePicture :: Picture
 samplePicture =
-  [ (Circle origin 2.0)
-  , (Circle (Point { x: 2.0, y: 2.0 }) 3.0)
-  , (Rectangle (Point { x: 5.0, y: 5.0 }) 4.0 4.0)
+  [ Circle origin 2.0
+  , Circle { x: 2.0, y: 2.0 } 3.0
+  , Rectangle { x: 5.0, y: 5.0 } 4.0 4.0
   ]
 
 main :: Effect Unit
@@ -87,17 +87,17 @@ Note to reader: Delete this line to expand comment block -}
         Assert.equal (Circle origin 10.0)
           $ doubleScaleAndCenter $ Circle origin 5.0
         Assert.equal (Circle origin 10.0)
-          $ doubleScaleAndCenter $ Circle (Point { x: 2.0, y: 2.0 }) 5.0
+          $ doubleScaleAndCenter $ Circle { x: 2.0, y: 2.0 } 5.0
         Assert.equal (Rectangle origin 10.0 10.0)
-          $ doubleScaleAndCenter $ Rectangle (Point { x: 0.0, y: 0.0 }) 5.0 5.0
+          $ doubleScaleAndCenter $ Rectangle { x: 0.0, y: 0.0 } 5.0 5.0
         Assert.equal (Rectangle origin 40.0 40.0)
-          $ doubleScaleAndCenter $ Rectangle (Point { x: 30.0, y: 30.0 }) 20.0 20.0
-        Assert.equal (Line (Point { x: -4.0, y: -4.0 }) (Point { x: 4.0, y: 4.0 }))
-          $ doubleScaleAndCenter $ Line (Point { x: -2.0, y: -2.0 }) (Point { x: 2.0, y: 2.0 })
-        Assert.equal (Line (Point { x: -4.0, y: -4.0 }) (Point { x: 4.0, y: 4.0 }))
-          $ doubleScaleAndCenter $ Line (Point { x: 0.0, y: 4.0 }) (Point { x: 4.0, y: 8.0 })
-        Assert.equal (Text (Point { x: 0.0, y: 0.0 }) "Hello .purs!" )
-          $ doubleScaleAndCenter $ Text (Point { x: 4.0, y: 6.0 }) "Hello .purs!"
+          $ doubleScaleAndCenter $ Rectangle { x: 30.0, y: 30.0 } 20.0 20.0
+        Assert.equal (Line { x: -4.0, y: -4.0 } { x: 4.0, y: 4.0 })
+          $ doubleScaleAndCenter $ Line { x: -2.0, y: -2.0 } { x: 2.0, y: 2.0 }
+        Assert.equal (Line { x: -4.0, y: -4.0 } { x: 4.0, y: 4.0 })
+          $ doubleScaleAndCenter $ Line { x: 0.0, y: 4.0 } { x: 4.0, y: 8.0 }
+        Assert.equal (Text { x: 0.0, y: 0.0 } "Hello .purs!" )
+          $ doubleScaleAndCenter $ Text { x: 4.0, y: 6.0 } "Hello .purs!"
       test "Exercise - shapeText" do
         Assert.equal (Just "Hello .purs!")
           $ shapeText $ Text origin "Hello .purs!"
@@ -106,7 +106,7 @@ Note to reader: Delete this line to expand comment block -}
         Assert.equal Nothing
           $ shapeText $ Rectangle origin 1.0 1.0
         Assert.equal Nothing
-          $ shapeText $ Line origin (Point { x: 1.0, y: 1.0 })
+          $ shapeText $ Line origin { x: 1.0, y: 1.0 }
     suite "Exercise Group - Vector Graphics" do
       test "Exercise - area" do
         Assert.equal 50
@@ -114,13 +114,13 @@ Note to reader: Delete this line to expand comment block -}
         Assert.equal 40
           $ round $ area $ Rectangle origin 4.0 10.0
         Assert.equal 0
-          $ round $ area $ Line origin (Point { x: 2.0, y: 2.0 })
+          $ round $ area $ Line origin { x: 2.0, y: 2.0 }
         Assert.equal 0
           $ round $ area $ Text origin "Text has no area!"
       test "Exercise - Clipped shapeBounds" do
         Assert.equal (Bounds { top: -2.0, left: -2.0, right: 2.0, bottom: 2.0 })
-          $ shapeBounds (Clipped samplePicture (Point { x: 0.0, y: 0.0 }) 4.0 4.0)
+          $ shapeBounds (Clipped samplePicture { x: 0.0, y: 0.0 } 4.0 4.0)
         Assert.equal (Bounds { top: 3.0, left: 3.0, right: 7.0, bottom: 7.0 })
-          $ shapeBounds (Clipped samplePicture (Point { x: 5.0, y: 5.0 }) 4.0 4.0)
+          $ shapeBounds (Clipped samplePicture { x: 5.0, y: 5.0 } 4.0 4.0)
     {- Note to reader: Delete this line to expand comment block
     -}

--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -1,15 +1,16 @@
 module Test.Main where
 
-import Prelude
+import Prelude hiding (gcd)
 import Test.MySolutions
-import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
+import Test.NoPeeking.Solutions
 
-import Data.Int(round)
-import Data.Maybe(Maybe(Just, Nothing))
+import ChapterExamples (Amp(..), current, fromString, gcd, gcdV2, isEmpty, livesInLA, lzs, partialFunction, showPerson, sortPair, takeFive, toString)
+import Data.Int (round)
+import Data.Maybe (Maybe(Just, Nothing))
 import Data.Person (Person)
 import Data.Picture (Shape(..), Picture, Bounds(..), getCenter, origin)
 import Effect (Effect)
-import Test.Unit (suite, test)
+import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
 
@@ -32,6 +33,7 @@ samplePicture =
 main :: Effect Unit
 main =
   runTest do
+    runChapterExamples
     {-  Move this block comment starting point to enable more tests
 Note to reader: Delete this line to expand comment block -}
     suite "Exercise Group - Simple Pattern Matching" do
@@ -122,5 +124,44 @@ Note to reader: Delete this line to expand comment block -}
           $ shapeBounds (Clipped samplePicture { x: 0.0, y: 0.0 } 4.0 4.0)
         Assert.equal (Bounds { top: 3.0, left: 3.0, right: 7.0, bottom: 7.0 })
           $ shapeBounds (Clipped samplePicture { x: 5.0, y: 5.0 } 4.0 4.0)
-    {- Note to reader: Delete this line to expand comment block
-    -}
+
+{- Note to reader: Delete this line to expand comment block
+-}
+runChapterExamples :: TestSuite
+runChapterExamples =
+  suite "Chapter Examples" do
+    test "gcd" do
+      Assert.equal 20
+        $ gcd 60 100
+    test "fromString" do
+      Assert.equal true
+        $ fromString "true"
+    test "toString" do
+      Assert.equal "false"
+        $ toString false
+    test "gcdV2" do
+      Assert.equal 20
+        $ gcdV2 60 100
+    test "isEmpty" do
+      Assert.equal false
+        $ isEmpty [2, 3]
+    test "takeFive" do
+      Assert.equal 6
+        $ takeFive [0, 1, 2, 3, 4]
+    test "showPerson" do
+      Assert.equal "Lovelace, Ada"
+        $ showPerson {first: "Ada", last: "Lovelace"}
+    test "livesInLA" do
+      Assert.equal true
+        $ livesInLA {name: "Suraj", address: {street: "123 Main St", city: "Los Angeles"}}
+    test "sortPair" do
+      Assert.equal [1, 2]
+        $ sortPair [2, 1]
+    test "lzs" do
+      Assert.equal [-1, -2, 3]
+        $ lzs [1, -1, -2, 3]
+    test "partialFunction" do
+      Assert.equal true
+        $ partialFunction true
+    test "current" do
+      Assert.equal (Amp 0.003) current

--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude hiding (gcd)
 import Test.MySolutions
 import Test.NoPeeking.Solutions
 
-import ChapterExamples (Amp(..), current, fromString, gcd, gcdV2, isEmpty, livesInLA, lzs, partialFunction, showPerson, sortPair, takeFive, toString)
+import ChapterExamples (Amp(..), current, fromString, gcd, gcdV2, isEmpty, livesInLA, lzs, partialFunction, showPerson, showPersonV2, sortPair, takeFive, toString, unknownPerson)
 import Data.Int (round)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Person (Person)
@@ -151,6 +151,11 @@ runChapterExamples =
     test "showPerson" do
       Assert.equal "Lovelace, Ada"
         $ showPerson {first: "Ada", last: "Lovelace"}
+    test "showPersonV2" do
+      Assert.equal "Lovelace, Ada"
+        $ showPersonV2 {first: "Ada", last: "Lovelace"}
+    test "unknownPerson" do
+      Assert.equal {first: "Jane", last: "Doe"} unknownPerson
     test "livesInLA" do
       Assert.equal true
         $ livesInLA {name: "Suraj", address: {street: "123 Main St", city: "Los Angeles"}}

--- a/exercises/chapter5/test/no-peeking/Solutions.purs
+++ b/exercises/chapter5/test/no-peeking/Solutions.purs
@@ -62,11 +62,11 @@ centerShape (Circle c r) = Circle origin r
 centerShape (Rectangle c w h) = Rectangle origin w h
 centerShape line@(Line (Point s) (Point e)) =
   (Line
-    (Point { x: s.x - deltaX, y: s.y - deltaY })
-    (Point { x: e.x - deltaX, y: e.y - deltaY })
+    (Point (s - delta))
+    (Point (e - delta))
   )
   where
-  (Point { x: deltaX, y: deltaY}) = getCenter line
+  (Point delta) = getCenter line
 centerShape (Text loc text) = Text origin text
 
 scaleShape :: Number -> Shape -> Shape

--- a/exercises/chapter5/test/no-peeking/Solutions.purs
+++ b/exercises/chapter5/test/no-peeking/Solutions.purs
@@ -7,7 +7,7 @@ import Data.Person (Person)
 import Data.Picture
   ( Bounds
   , Picture
-  , Point(Point)
+  , Point
   , Shape(Circle, Rectangle, Line, Text)
   , bounds
   , getCenter
@@ -60,23 +60,17 @@ circleAtOrigin = Circle origin 10.0
 centerShape :: Shape -> Shape
 centerShape (Circle c r) = Circle origin r
 centerShape (Rectangle c w h) = Rectangle origin w h
-centerShape line@(Line (Point s) (Point e)) =
-  (Line
-    (Point (s - delta))
-    (Point (e - delta))
-  )
+centerShape line@(Line s e) = Line (s - delta) (e - delta)
   where
-  (Point delta) = getCenter line
+  delta = getCenter line
 centerShape (Text loc text) = Text origin text
 
 scaleShape :: Number -> Shape -> Shape
 scaleShape i (Circle c r) = Circle c (r * i)
 scaleShape i (Rectangle c w h) = Rectangle c (w * i) (h * i)
-scaleShape i (Line (Point s) (Point e)) =
-  (Line
-    (Point { x: s.x * i, y: s.y * i })
-    (Point { x: e.x * i, y: e.y * i })
-  )
+scaleShape i (Line s e) = Line (s * scale) (e * scale)
+  where
+  scale = {x: i, y: i}
 scaleShape i text = text
 
 doubleScaleAndCenter :: Shape -> Shape

--- a/exercises/chapter5/test/no-peeking/Solutions.purs
+++ b/exercises/chapter5/test/no-peeking/Solutions.purs
@@ -11,8 +11,6 @@ import Data.Picture
   , Shape(Circle, Rectangle, Line, Text)
   , bounds
   , getCenter
-  , getX
-  , getY
   , intersect
   , origin
   )
@@ -68,9 +66,7 @@ centerShape line@(Line (Point s) (Point e)) =
     (Point { x: e.x - deltaX, y: e.y - deltaY })
   )
   where
-  delta = getCenter line
-  deltaX = getX delta
-  deltaY = getY delta
+  (Point { x: deltaX, y: deltaY}) = getCenter line
 centerShape (Text loc text) = Text origin text
 
 scaleShape :: Number -> Shape -> Shape

--- a/exercises/chapter6/test/no-peeking/Solutions.purs
+++ b/exercises/chapter6/test/no-peeking/Solutions.purs
@@ -11,7 +11,7 @@ import Data.Maybe (Maybe(..))
 import Data.Monoid (power)
 import Data.Newtype (class Newtype, over2, wrap)
 
-data Point
+newtype Point
   = Point
   { x :: Number
   , y :: Number

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -184,6 +184,24 @@ Note that we could have also written
 
 and PSCi would have inferred the same type.
 
+## Record Puns
+
+Recall that the `showPerson` function matches a record inside its argument, binding the `first` and `last` fields to values named `x` and `y`. We could alternatively just reuse the field names themselves, and simplify this sort of pattern match as follows:
+
+```haskell
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:showPersonV2}}
+```
+
+Here, we only specify the names of the fields, and we do not need to specify the names of the values we want to introduce. This is called a _record pun_.
+
+It is also possible to use record puns to _construct_ records. For example, if we have values named `first` and `last` in scope, we can construct a person record using `{ first, last }`:
+
+```haskell
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:unknownPerson}}
+```
+
+This may improve readability of code in some circumstances.
+
 ## Nested Patterns
 
 Array patterns and record patterns both combine smaller patterns to build larger patterns. For the most part, the examples above have only used simple patterns inside array patterns and record patterns, but it is important to note that patterns can be arbitrarily _nested_, which allows functions to be defined using conditions on potentially complex data types.
@@ -365,33 +383,10 @@ Let's see an example. Suppose we want to convert a `Shape` into a `String`. We h
 ```haskell
 {{#include ../exercises/chapter5/src/Data/Picture.purs:showShape}}
 
-showPoint :: Point -> String
-showPoint (Point { x: x, y: y }) =
-  "(" <> show x <> ", " <> show y <> ")"
-
-```
-
-Each constructor can be used as a pattern, and the arguments to the constructor can themselves be bound using patterns of their own. Consider the first case of `showShape`: if the `Shape` matches the `Circle` constructor, then we bring the arguments of `Circle` (center and radius) into scope using two variable patterns, `c` and `r`. The other cases are similar.
-
-`showPoint` is another example of record pattern matching.
-
-## Record Puns
-
-The `showPoint` function matches a record inside its argument, binding the `x` and `y` properties to values with the same names. In PureScript, we can simplify this sort of pattern match as follows:
-
-```haskell
 {{#include ../exercises/chapter5/src/Data/Picture.purs:showPoint}}
 ```
 
-Here, we only specify the names of the properties, and we do not need to specify the names of the values we want to introduce. This is called a _record pun_.
-
-It is also possible to use record puns to _construct_ records. For example, if we have values named `x` and `y` in scope, we can construct a `Point` record using `{ x, y }`:
-
-```haskell
-{{#include ../exercises/chapter5/src/Data/Picture.purs:origin}}
-```
-
-This can be useful for improving readability of code in some circumstances.
+Each constructor can be used as a pattern, and the arguments to the constructor can themselves be bound using patterns of their own. Consider the first case of `showShape`: if the `Shape` matches the `Circle` constructor, then we bring the arguments of `Circle` (center and radius) into scope using two variable patterns, `c` and `r`. The other cases are similar.
 
 ## Exercises
 

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -24,17 +24,13 @@ The `Data.Picture` module defines a data type `Shape` for simple shapes, and a t
 The module imports the `Data.Foldable` module, which provides functions for folding data structures:
 
 ```haskell
-module Data.Picture where
-
-import Prelude
-import Data.Foldable (foldl)
+{{#include ../exercises/chapter5/src/Data/Picture.purs:module_picture}}
 ```
 
 The `Data.Picture` module also imports the `Global` and `Math` modules, but this time using the `as` keyword:
 
 ```haskell
-import Global as Global
-import Math as Math
+{{#include ../exercises/chapter5/src/Data/Picture.purs:picture_import_as}}
 ```
 
 This makes the types and functions in those modules available for use, but only by using _qualified names_, like `Global.infinity` and `Math.max`. This can be useful to avoid overlapping imports, or just to make it clearer which modules certain things are imported from.
@@ -46,12 +42,7 @@ _Note_: it is not necessary to use the same module name as the original module f
 Let's begin by looking at an example. Here is a function which computes the greatest common divisor of two integers using pattern matching:
 
 ```haskell
-gcd :: Int -> Int -> Int
-gcd n 0 = n
-gcd 0 m = m
-gcd n m = if n > m
-            then gcd (n - m) m
-            else gcd n (m - n)
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:gcd}}
 ```
 
 This algorithm is called the Euclidean Algorithm. If you search for its definition online, you will likely find a set of mathematical equations which look a lot like the code above. This is one benefit of pattern matching: it allows you to define code by cases, writing simple, declarative code which looks like a specification of a mathematical function.
@@ -81,13 +72,9 @@ There are other types of simple patterns:
 Here are two more examples which demonstrate using these simple patterns:
 
 ```haskell
-fromString :: String -> Boolean
-fromString "true" = true
-fromString _      = false
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:fromString}}
 
-toString :: Boolean -> String
-toString true  = "true"
-toString false = "false"
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:toString}}
 ```
 
 Try these functions in PSCi.
@@ -99,11 +86,7 @@ In the Euclidean algorithm example, we used an `if .. then .. else` expression t
 A guard is a boolean-valued expression which must be satisfied in addition to the constraints imposed by the patterns. Here is the Euclidean algorithm rewritten to use a guard:
 
 ```haskell
-gcd :: Int -> Int -> Int
-gcd n 0 = n
-gcd 0 n = n
-gcd n m | n > m     = gcd (n - m) m
-        | otherwise = gcd n (m - n)
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:gcdV2}}
 ```
 
 In this case, the third line uses a guard to impose the extra condition that the first argument is strictly larger than the second.
@@ -121,17 +104,13 @@ As this example demonstrates, guards appear on the left of the equals symbol, se
 _Array literal patterns_ provide a way to match arrays of a fixed length. For example, suppose we want to write a function `isEmpty` which identifies empty arrays. We could do this by using an empty array pattern (`[]`) in the first alternative:
 
 ```haskell
-isEmpty :: forall a. Array a -> Boolean
-isEmpty [] = true
-isEmpty _ = false
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:isEmpty}}
 ```
 
 Here is another function which matches arrays of length five, binding each of its five elements in a different way:
 
 ```haskell
-takeFive :: Array Int -> Int
-takeFive [0, 1, a, b, _] = a * b
-takeFive _ = 0
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:takeFive}}
 ```
 
 The first pattern only matches arrays with five elements, whose first and second elements are 0 and 1 respectively. In that case, the function returns the product of the third and fourth elements. In every other case, the function returns zero. For example, in PSCi:
@@ -163,8 +142,7 @@ Record patterns look just like record literals, but instead of values on the rig
 For example: this pattern matches any record which contains fields called `first` and `last`, and binds their values to the names `x` and `y` respectively:
 
 ```haskell
-showPerson :: { first :: String, last :: String } -> String
-showPerson { first: x, last: y } = y <> ", " <> x
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:showPerson}}
 ```
 
 Record patterns provide a good example of an interesting feature of the PureScript type system: _row polymorphism_. Suppose we had defined `showPerson` without a type signature above. What would its inferred type have been? Interestingly, it is not the same as the type we gave:
@@ -213,13 +191,7 @@ Array patterns and record patterns both combine smaller patterns to build larger
 For example, this code combines two record patterns:
 
 ```haskell
-type Address = { street :: String, city :: String }
-
-type Person = { name :: String, address :: Address }
-
-livesInLA :: Person -> Boolean
-livesInLA { address: { city: "Los Angeles" } } = true
-livesInLA _ = false
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:livesInLA}}
 ```
 
 ## Named Patterns
@@ -229,11 +201,7 @@ Patterns can be _named_ to bring additional names into scope when using nested p
 For example, this function sorts two-element arrays, naming the two elements, but also naming the array itself:
 
 ```haskell
-sortPair :: Array Int -> Array Int
-sortPair arr@[x, y]
-  | x <= y = arr
-  | otherwise = [y, x]
-sortPair arr = arr
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:sortPair}}
 ```
 
 This way, we save ourselves from allocating a new array if the pair is already sorted. Note that if the input array does not contain _exactly_ two elements, then this function simply returns it unchanged, even if it's unsorted.
@@ -251,15 +219,9 @@ Patterns do not only appear in top-level function declarations. It is possible t
 Here is an example. This function computes "longest zero suffix" of an array (the longest suffix which sums to zero):
 
 ```haskell
-import Data.Array (tail)
-import Data.Foldable (sum)
-import Data.Maybe (fromMaybe)
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:lzsImport}}
 
-lzs :: Array Int -> Array Int
-lzs [] = []
-lzs xs = case sum xs of
-           0 -> xs
-           _ -> lzs (fromMaybe [] $ tail xs)
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:lzs}}
 ```
 
 For example:
@@ -281,10 +243,9 @@ If patterns in a case expression are tried in order, then what happens in the ca
 We can see this behavior with a simple example:
 
 ```haskell
-import Partial.Unsafe (unsafePartial)
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:unsafePartialImport}}
 
-partialFunction :: Boolean -> Boolean
-partialFunction = unsafePartial \true -> true
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:partialFunction}}
 ```
 
 This function contains only a single case, which only matches a single input, `true`. If we compile this file, and test in PSCi with any other argument, we will see an error at runtime:
@@ -360,16 +321,9 @@ Algebraic data types provide a type-safe way to solve this sort of problem, if t
 Here is how `Shape` might be represented as an algebraic data type:
 
 ```haskell
-data Shape
-  = Circle Point Number
-  | Rectangle Point Number Number
-  | Line Point Point
-  | Text Point String
+{{#include ../exercises/chapter5/src/Data/Picture.purs:Shape}}
 
-type Point =
-  { x :: Number
-  , y :: Number
-  }
+{{#include ../exercises/chapter5/src/Data/Picture.purs:Point}}
 ```
 
 This declaration defines `Shape` as a sum of different constructors, and for each constructor identifies the data that is included. A `Shape` is either a `Circle` which contains a center `Point` and a radius (a number), or a `Rectangle`, or a `Line`, or `Text`. There are no other ways to construct a value of type `Shape`.
@@ -399,14 +353,7 @@ It is simple enough to use the constructors of an algebraic data type to constru
 For example, the `Line` constructor defined above required two `Point`s, so to construct a `Shape` using the `Line` constructor, we have to provide two arguments of type `Point`:
 
 ```haskell
-exampleLine :: Shape
-exampleLine = Line p1 p2
-  where
-    p1 :: Point
-    p1 = Point { x: 0.0, y: 0.0 }
-
-    p2 :: Point
-    p2 = Point { x: 100.0, y: 50.0 }
+{{#include ../exercises/chapter5/src/Data/Picture.purs:exampleLine}}
 ```
 
 To construct the points `p1` and `p2`, we apply the `Point` constructor to its single argument, which is a record.
@@ -416,40 +363,32 @@ So, constructing values of algebraic data types is simple, but how do we use the
 Let's see an example. Suppose we want to convert a `Shape` into a `String`. We have to use pattern matching to discover which constructor was used to construct the `Shape`. We can do this as follows:
 
 ```haskell
+{{#include ../exercises/chapter5/src/Data/Picture.purs:showShape}}
+
 showPoint :: Point -> String
 showPoint (Point { x: x, y: y }) =
   "(" <> show x <> ", " <> show y <> ")"
 
-showShape :: Shape -> String
-showShape (Circle c r)      = ...
-showShape (Rectangle c w h) = ...
-showShape (Line start end)  = ...
-showShape (Text p text) = ...
 ```
 
 Each constructor can be used as a pattern, and the arguments to the constructor can themselves be bound using patterns of their own. Consider the first case of `showShape`: if the `Shape` matches the `Circle` constructor, then we bring the arguments of `Circle` (center and radius) into scope using two variable patterns, `c` and `r`. The other cases are similar.
 
-`showPoint` is another example of pattern matching. In this case, there is only a single case, but we use a nested pattern to match the fields of the record contained inside the `Point` constructor.
+`showPoint` is another example of record pattern matching.
 
 ## Record Puns
 
 The `showPoint` function matches a record inside its argument, binding the `x` and `y` properties to values with the same names. In PureScript, we can simplify this sort of pattern match as follows:
 
 ```haskell
-showPoint :: Point -> String
-showPoint (Point { x, y }) = ...
+{{#include ../exercises/chapter5/src/Data/Picture.purs:showPoint}}
 ```
 
 Here, we only specify the names of the properties, and we do not need to specify the names of the values we want to introduce. This is called a _record pun_.
 
-It is also possible to use record puns to _construct_ records. For example, if we have values named `x` and `y` in scope, we can construct a `Point` using `Point { x, y }`:
+It is also possible to use record puns to _construct_ records. For example, if we have values named `x` and `y` in scope, we can construct a `Point` record using `{ x, y }`:
 
 ```haskell
-origin :: Point
-origin = Point { x, y }
-  where
-    x = 0.0
-    y = 0.0
+{{#include ../exercises/chapter5/src/Data/Picture.purs:origin}}
 ```
 
 This can be useful for improving readability of code in some circumstances.
@@ -469,25 +408,13 @@ Newtypes must define _exactly one_ constructor, and that constructor must take _
 As an example, we might want to define newtypes as type-level aliases for `Number`, to ascribe units like volts, amps, and ohms:
 
 ```haskell
-newtype Volt = Volt Number
-newtype Ohm = Ohm Number
-newtype Amp = Amp Number
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:electricalUnits}}
 ```
 
 Then we define functions and values using these types:
 
 ```haskell
-calculateCurrent :: Volt -> Ohm -> Amp
-calculateCurrent (Volt v) (Ohm r) = Amp (v / r)
-
-battery :: Volt
-battery = Volt 1.5
-
-lightbulb :: Ohm
-lightbulb = Ohm 500.0
-
-current :: Amp
-current = calculateCurrent battery lightbulb
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:calculateCurrent}}
 ```
 
 This prevents us from making silly mistakes, such as attempting to calculate the current produced by _two_ lightbulbs _without_ a voltage source.
@@ -527,7 +454,7 @@ This design principle is perhaps better [communicated visually](https://twitter.
 
 Note that the constructor of a newtype often has the same name as the newtype itself, but this is not a requirement. For example, unique names are also valid:
 ```haskell
-newtype Watt = MakeWatt Number
+{{#include ../exercises/chapter5/src/ChapterExamples.purs:Watt}}
 ```
 
 In this case, `Watt` is the _type constructor_ and `MakeWatt` is the _data constructor_. These constructors live in different namespaces, even when the names are identical, such as with the `Volt` example. This is true for all ADTs.
@@ -541,14 +468,13 @@ Let's use the data types we have defined above to create a simple library for us
 Define a type synonym for a `Picture` - just an array of `Shape`s:
 
 ```haskell
-type Picture = Array Shape
+{{#include ../exercises/chapter5/src/Data/Picture.purs:Picture}}
 ```
 
 For debugging purposes, we'll want to be able to turn a `Picture` into something readable. The `showPicture` function lets us do that:
 
 ```haskell
-showPicture :: Picture -> Array String
-showPicture = map showShape
+{{#include ../exercises/chapter5/src/Data/Picture.purs:showPicture}}
 ```
 
 Let's try it out. Compile your module with `spago build` and open PSCi with `spago repl`:
@@ -559,12 +485,7 @@ $ spago repl
 
 > import Data.Picture
 
-> :paste
-… showPicture
-…   [ Line (Point { x: 0.0, y: 0.0 })
-…          (Point { x: 1.0, y: 1.0 })
-…   ]
-… ^D
+> showPicture [ Line { x: 0.0, y: 0.0 } { x: 1.0, y: 1.0 } ]
 
 ["Line [start: (0.0, 0.0), end: (1.0, 1.0)]"]
 ```
@@ -576,22 +497,13 @@ The example code for this module contains a function `bounds` which computes the
 The `Bounds` data type defines a bounding rectangle. It is also defined as an algebraic data type with a single constructor:
 
 ```haskell
-data Bounds = Bounds
-  { top    :: Number
-  , left   :: Number
-  , bottom :: Number
-  , right  :: Number
-  }
+{{#include ../exercises/chapter5/src/Data/Picture.purs:Bounds}}
 ```
 
 `bounds` uses the `foldl` function from `Data.Foldable` to traverse the array of `Shapes` in a `Picture`, and accumulate the smallest bounding rectangle:
 
 ```haskell
-bounds :: Picture -> Bounds
-bounds = foldl combine emptyBounds
-  where
-    combine :: Bounds -> Shape -> Bounds
-    combine b shape = union (shapeBounds shape) b
+{{#include ../exercises/chapter5/src/Data/Picture.purs:bounds}}
 ```
 
 In the base case, we need to find the smallest bounding rectangle of an empty `Picture`, and the empty bounding rectangle defined by `emptyBounds` suffices.

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -489,7 +489,7 @@ $ spago repl
 
 The example code for this module contains a function `bounds` which computes the smallest bounding rectangle for a `Picture`.
 
-The `Bounds` data type defines a bounding rectangle. It is also defined as an algebraic data type with a single constructor:
+The `Bounds` type defines a bounding rectangle.
 
 ```haskell
 {{#include ../exercises/chapter5/src/Data/Picture.purs:Bounds}}

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -125,10 +125,10 @@ No type class instance was found for
 
  ## Exercises
 
-1. (Easy) Define a `Show` instance for `Point`. Match the same output as the `showPoint` function from the previous chapter.
+1. (Easy) Define a `Show` instance for `Point`. Match the same output as the `showPoint` function from the previous chapter. _Note:_ Point is now a `newtype` (instead of a `type` synonym), which allows us to customize how to `show` it. Otherwise, we'd be stuck with the default `Show` instance for records.
 
     ```haskell
-    data Point
+    newtype Point
       = Point
       { x :: Number
       , y :: Number


### PR DESCRIPTION
A type synonym seems more appropriate than an ADT for `Point`. This proposal was discussed at the end of [this post](https://discourse.purescript.org/t/purescript-by-example-chapter-pattern-matching-exercise-doublescaleandcenter/1895/3).

Follow-up to #253, but might replace that PR entirely.

Remaining todos are to update the Ch5 text and part of Ch6