### PR TITLE
Fix nonEmptyRegex implementation

### DIFF
--- a/exercises/chapter7/test/Main.purs
+++ b/exercises/chapter7/test/Main.purs
@@ -119,6 +119,8 @@ Note to reader: Delete this line to expand comment block -}
         nonEmptyTest "Houston" true
         nonEmptyTest "My Street" true
         nonEmptyTest "Ñóñá" true
+        nonEmptyTest " Start with whitespace" true
+        nonEmptyTest "End with whitespace " true
         nonEmptyTest "" false
         nonEmptyTest " " false
         nonEmptyTest "\t" false

--- a/exercises/chapter7/test/no-peeking/Solutions.purs
+++ b/exercises/chapter7/test/no-peeking/Solutions.purs
@@ -54,7 +54,7 @@ stateRegex = regex "^[a-zA-Z]{2}$" noFlags
 
 -- Exercise 2
 nonEmptyRegex :: Either String Regex
-nonEmptyRegex = regex "(^[^\\s])|([^\\s]$)" noFlags
+nonEmptyRegex = regex "\\S" noFlags
 
 -- Exercise 3
 validateAddressImproved :: Address -> V Errors Address

--- a/exercises/chapter7/test/no-peeking/Solutions.purs
+++ b/exercises/chapter7/test/no-peeking/Solutions.purs
@@ -54,7 +54,7 @@ stateRegex = regex "^[a-zA-Z]{2}$" noFlags
 
 -- Exercise 2
 nonEmptyRegex :: Either String Regex
-nonEmptyRegex = regex "[^\\s]$" noFlags
+nonEmptyRegex = regex "(^[^\\s])|([^\\s]$)" noFlags
 
 -- Exercise 3
 validateAddressImproved :: Address -> V Errors Address


### PR DESCRIPTION
Any string ending with a whitespace was considered as an empty string.

Fix #268 