### PR TITLE
Move Test.NoPeeking.Solutions outside of compilation path during solutions reset

### DIFF
--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -2,7 +2,7 @@ module Test.Main where
 
 import Prelude hiding (gcd)
 import Test.MySolutions
-import Test.NoPeeking.Solutions
+import Test.NoPeeking.Solutions  -- Note to reader: Delete this line
 
 import ChapterExamples (Amp(..), current, fromString, gcd, gcdV2, isEmpty, livesInLA, lzs, partialFunction, showPerson, showPersonV2, sortPair, takeFive, toString, unknownPerson)
 import Data.Int (round)

--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -121,6 +121,8 @@ Note to reader: Delete this line to expand comment block -}
           $ round $ area $ Text origin "Text has no area!"
       test "Exercise - Clipped shapeBounds" do
         Assert.equal { top: -2.0, left: -2.0, right: 2.0, bottom: 2.0 }
+          -- Note to users: You'll need to manually import shapeBounds
+          -- from Data.Picture. Don't import from Test.NoPeeking.Solutions.
           $ shapeBounds (Clipped samplePicture { x: 0.0, y: 0.0 } 4.0 4.0)
         Assert.equal { top: 3.0, left: 3.0, right: 7.0, bottom: 7.0 }
           $ shapeBounds (Clipped samplePicture { x: 5.0, y: 5.0 } 4.0 4.0)

--- a/scripts/resetSolutions.sh
+++ b/scripts/resetSolutions.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
 # This script automatically resets exercises so they are ready to be solved.
-# It just removes lines with a note to delete them.
+#  - Removes lines with a note to delete them.
+#  - Moves the no-peeking directory outside of the compilation path.
 
 # For all chapters
 for d in exercises/*; do
   # if directory (excludes LICENSE file)
   if [ -d $d ]; then
     perl -ni -e 'print if !/Note to reader: Delete this line/' $d/test/Main.purs
+  fi
+  # if there's a no-peeking directory
+  if [ -d $d/test/no-peeking ]; then
+    mv $d/test/no-peeking $d/no-peeking
   fi
 done

--- a/text/chapter2.md
+++ b/text/chapter2.md
@@ -20,6 +20,7 @@ The book repo contains PureScript example code and unit tests for the exercises 
 cd purescript-book
 ./scripts/resetSolutions.sh
 ./scripts/removeAnchors.sh
+git add .
 git commit --all --message "Exercises ready to be solved"
 ```
 


### PR DESCRIPTION
Fixes #274

This also prevents solutions from appearing as IDE autocompletion suggestions.