### PR TITLE
Describe prefix/infix functions and record field accessors in Chapter 3

### DIFF
--- a/exercises/chapter3/test/no-peeking/Solutions.purs
+++ b/exercises/chapter3/test/no-peeking/Solutions.purs
@@ -12,6 +12,10 @@ findEntryByStreet streetName = filter filterEntry >>> head
   filterEntry :: Entry -> Boolean
   filterEntry e = e.address.street == streetName
 
+-- Example alternative implementation using property accessor and composition
+findEntryByStreet' :: String -> AddressBook -> Maybe Entry
+findEntryByStreet' streetName = filter (_.address.street >>> ((==) streetName)) >>> head
+
 isInBook :: String -> String -> AddressBook -> Boolean
 isInBook firstName lastName book = not null $ filter filterEntry book
   where

--- a/exercises/chapter3/test/no-peeking/Solutions.purs
+++ b/exercises/chapter3/test/no-peeking/Solutions.purs
@@ -14,7 +14,7 @@ findEntryByStreet streetName = filter filterEntry >>> head
 
 -- Example alternative implementation using property accessor and composition
 findEntryByStreet' :: String -> AddressBook -> Maybe Entry
-findEntryByStreet' streetName = filter (_.address.street >>> ((==) streetName)) >>> head
+findEntryByStreet' streetName = filter (_.address.street >>> eq streetName) >>> head
 
 isInBook :: String -> String -> AddressBook -> Boolean
 isInBook firstName lastName book = not null $ filter filterEntry book

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -547,7 +547,19 @@ Note that, just like for top-level declarations, it was not necessary to specify
 
 ## Infix Function Application
 
-In the code for `findEntry` above, we used a different form of function application: the `head` function was applied to the expression `filter filterEntry book` by using the infix `$` symbol.
+Most of the functions discussed so far used _prefix_ function application, where the function name was put _before_ the arguments. For example, when using the `findEntry` function to search an `AddressBook`, one might write:
+
+```text
+> findEntry "John" "Smith" addressBook
+```
+
+However, this chapter has also included examples of _infix_ functions, such as  the `==` function in the definition of `filterEntry`, where the function is put _between_ the arguments. These infix operators are actually defined in the PureScript source as infix aliases for their underlying implementations. For example, `==` is defined as an alias for the prefix `eq` function with the line:
+
+```haskell
+infix 4 eq as ==
+```
+
+Likewise, in the code for `findEntry` above, we used a different form of function application: the `head` function was applied to the expression `filter filterEntry book` by using the infix `$` symbol.
 
 This is equivalent to the usual application `head (filter filterEntry book)`
 
@@ -560,7 +572,7 @@ apply f x = f x
 infixr 0 apply as $
 ```
 
-So `apply` takes a function and a value and applies the function to the value. The `infixr` keyword is used to define `($)` as an alias for `apply`.
+So `apply` takes a function and a value and applies the function to the value. The `infixr` keyword is used to define `$` as an alias for `apply`.
 
 But why would we want to use `$` instead of regular function application? The reason is that `$` is a right-associative, low precedence operator. This means that `$` allows us to remove sets of parentheses for deeply-nested applications.
 
@@ -574,6 +586,35 @@ becomes (arguably) easier to read when expressed using `$`:
 
 ```haskell
 street $ address $ boss employee
+There are situations where putting a prefix function in an infix position as an operator leads to more readable code. One example is the `mod` function:
+```text
+> mod 8 3
+2
+```
+This is fine, but doesn't line up with common usage. Wrapping a prefix function in backticks (\`) lets you use a prefix function in infix position as an operator, e.g.,
+```text
+> 8 `mod` 3
+2
+```
+Likewise, wrapping an operator in parentheses lets you use it as a function in prefix position:
+```text
+> 8 + 3
+11
+
+> (+) 8 3
+11
+```
+This allows for compact definitions of curried (or partially applied) functions based on infix operator functions, such as the `add2` function below:
+```text
+> add2 = (+) 2
+> add2 4
+6
+```
+Alternatively, operators can be partially applied by surrounding them with parentheses and using `_` as an operand:
+```text
+> add3 = (3 + _)
+> add3 2
+5
 ```
 
 ## Function Composition

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -653,7 +653,7 @@ This allows for compact definitions of curried (or partially applied) functions 
 > add2 4
 6
 ```
-Alternatively, operators can be partially applied by surrounding them with parentheses and using `_` as an operand:
+Alternatively, operators can be partially applied by surrounding them with parentheses and using `_` as an operand in an [operator section](https://github.com/purescript/documentation/blob/master/language/Syntax.md#operator-sections):
 ```text
 > add3 = (3 + _)
 > add3 2

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -595,7 +595,7 @@ Likewise, in the code for `findEntry` above, we used a different form of functio
 
 This is equivalent to the usual application `head (filter filterEntry book)`
 
-`$` is just an alias for a regular function called `apply`, which is defined in the Prelude. It is defined as follows:
+`($)` is just an alias for a regular function called `apply`, which is defined in the Prelude. It is defined as follows:
 
 ```haskell
 apply :: forall a b. (a -> b) -> a -> b

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -487,7 +487,7 @@ One common pattern is to use a function to access an individual fields (or "prop
 \entry -> entry.address
 ```
 
-PureScript provides an equivalent shorthand, where an underscore is followed by a field name, so the inline function above is equivalent to:
+PureScript provides an equivalent [_property accessor_](https://github.com/purescript/documentation/blob/master/language/Syntax.md#property-accessors) shorthand, where an underscore is followed by a field name, so the inline function above is equivalent to:
 
 ```haskell
 _.address

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -604,7 +604,7 @@ apply f x = f x
 infixr 0 apply as $
 ```
 
-So `apply` takes a function and a value and applies the function to the value. The `infixr` keyword is used to define `$` as an alias for `apply`.
+So `apply` takes a function and a value and applies the function to the value. The `infixr` keyword is used to define `($)` as an alias for `apply`.
 
 But why would we want to use `$` instead of regular function application? The reason is that `$` is a right-associative, low precedence operator. This means that `$` allows us to remove sets of parentheses for deeply-nested applications.
 


### PR DESCRIPTION
Fixes #281 and fixes #282 as proposed.

Also provides a preview of operator sections before @milesfrain's [proposed changes](https://github.com/purescript-contrib/purescript-book/issues/260#issuecomment-753440750) to Chapter 4 for the exploration of `flip`.