### PR TITLE
Update test + example to use MakeWatt

### DIFF
--- a/exercises/chapter5/test/Main.purs
+++ b/exercises/chapter5/test/Main.purs
@@ -112,7 +112,7 @@ Note to reader: Delete this line to expand comment block -}
     suite "Exercise Group - Newtype" do
       test "Exercise - calculateWattage" do
         Assert.equal 60.0
-          $ let (Watt w) = calculateWattage (Amp 0.5) (Volt 120.0)
+          $ let (MakeWatt w) = calculateWattage (Amp 0.5) (Volt 120.0)
             in w
     suite "Exercise Group - Vector Graphics" do
       test "Exercise - area" do

--- a/exercises/chapter5/test/no-peeking/Solutions.purs
+++ b/exercises/chapter5/test/no-peeking/Solutions.purs
@@ -103,7 +103,7 @@ shapeBounds :: ShapeExt -> Bounds
 shapeBounds (Clipped pic pt w h) = intersect (bounds pic) (DataP.shapeBounds (Rectangle pt w h))
 shapeBounds (Shape shape) = DataP.shapeBounds shape
 
-newtype Watt = Watt Number
+newtype Watt = MakeWatt Number
 
 calculateWattage :: Amp -> Volt -> Watt
-calculateWattage (Amp i) (Volt v) = Watt $ i * v
+calculateWattage (Amp i) (Volt v) = MakeWatt $ i * v


### PR DESCRIPTION
The text in the exercise states that we should use MakeWatt as the data constructor. However, the test and the solutions use Watt. This PR updates the test and solutions to instead use MakeWatt as the text suggests.