### PR TITLE
Ch6: Small text fix-ups to be consistent with tests + example

### DIFF
--- a/exercises/chapter6/test/Main.purs
+++ b/exercises/chapter6/test/Main.purs
@@ -67,24 +67,6 @@ Note to reader: Delete this line to expand comment block -}
         test "text" do
           Assert.equal "(Text (1.0, 2.0) \"Hello\")"
             $ show $ Text (Point {x: 1.0, y: 2.0}) "Hello"
-      let
-        withDups =
-          [ Circle (Point {x: 1.0, y: 2.0}) 3.0
-          , Circle (Point {x: 3.0, y: 2.0}) 3.0
-          , Circle (Point {x: 1.0, y: 2.0}) 3.0
-          , Circle (Point {x: 2.0, y: 2.0}) 3.0
-          ]
-        noDups =
-          [ Circle (Point {x: 1.0, y: 2.0}) 3.0
-          , Circle (Point {x: 3.0, y: 2.0}) 3.0
-          , Circle (Point {x: 2.0, y: 2.0}) 3.0
-          ]
-      test "Exercise - dedupShapes" do
-        Assert.equal noDups
-          $ dedupShapes withDups
-      test "Exercise - dedupShapesFast" do
-        Assert.equal noDups
-          $ dedupShapesFast withDups
     suite "Exercise Group - Constraints and Dependencies" do
       suite "Exercise - Eq for NonEmpty" do
         test "NonEmpty equals" do
@@ -154,6 +136,24 @@ Note to reader: Delete this line to expand comment block -}
           Assert.equal "123"
             $ foldMap (\x -> show x)
             $ OneMore 1 (2 : 3 : Nil)
+      let
+        withDups =
+          [ Circle (Point {x: 1.0, y: 2.0}) 3.0
+          , Circle (Point {x: 3.0, y: 2.0}) 3.0
+          , Circle (Point {x: 1.0, y: 2.0}) 3.0
+          , Circle (Point {x: 2.0, y: 2.0}) 3.0
+          ]
+        noDups =
+          [ Circle (Point {x: 1.0, y: 2.0}) 3.0
+          , Circle (Point {x: 3.0, y: 2.0}) 3.0
+          , Circle (Point {x: 2.0, y: 2.0}) 3.0
+          ]
+      test "Exercise - dedupShapes" do
+        Assert.equal noDups
+          $ dedupShapes withDups
+      test "Exercise - dedupShapesFast" do
+        Assert.equal noDups
+          $ dedupShapesFast withDups
     suite "Exercise Group - More or less than one Type argument" do
       test "Exercise - unsafeMaximum" do
         Assert.equal 42

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -348,11 +348,6 @@ data Shape
 
 5. (Medium) Derive (via `Generic`) a `Show` instance for `Shape`. How does the amount of code written and `String` output compare to `showShape` from the previous chapter? _Note_: You may instead write this instance manually, but you'll need to pay close attention to the output format expected by the tests.
 
-6. (Medium) Write a `dedupShapes :: Array Shape -> Array Shape` function which removes duplicate `Shape`s from an array using the `nubEq` function.
-
-7. (Medium) Write a `dedupShapesFast` function which is the same as `dedupShapes`, but uses the more efficient `nub` function.
-
-
 ## Type Class Constraints
 
 Types of functions can be constrained by using type classes. Here is an example: suppose we want to write a function which tests if three values are equal, by using equality defined using an `Eq` type class instance.
@@ -457,6 +452,10 @@ When the program is compiled, the correct type class instance for `Show` is chos
     instance foldableOneMore :: Foldable f => Foldable (OneMore f) where
     ...
     ```
+
+1. (Medium) Write a `dedupShapes :: Array Shape -> Array Shape` function which removes duplicate `Shape`s from an array using the `nubEq` function.
+
+1. (Medium) Write a `dedupShapesFast` function which is the same as `dedupShapes`, but uses the more efficient `nub` function.
 
 ## Multi Parameter Type Classes
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -348,6 +348,11 @@ data Shape
 
 5. (Medium) Derive (via `Generic`) a `Show` instance for `Shape`. How does the amount of code written and `String` output compare to `showShape` from the previous chapter? _Note_: You may instead write this instance manually, but you'll need to pay close attention to the output format expected by the tests.
 
+6. (Medium) Write a `dedupShapes :: Array Shape -> Array Shape` function which removes duplicate `Shape`s from an array using the `nubEq` function.
+
+7. (Medium) Write a `dedupShapesFast` function which is the same as `dedupShapes`, but uses the more efficient `nub` function.
+
+
 ## Type Class Constraints
 
 Types of functions can be constrained by using type classes. Here is an example: suppose we want to write a function which tests if three values are equal, by using equality defined using an `Eq` type class instance.
@@ -452,10 +457,6 @@ When the program is compiled, the correct type class instance for `Show` is chos
     instance foldableOneMore :: Foldable f => Foldable (OneMore f) where
     ...
     ```
-
-1. (Medium) Write a `dedupShapes :: Array Shape -> Array Shape` function which removes duplicate `Shape`s from an array using the `nubEq` function.
-
-1. (Medium) Write a `dedupShapesFast` function which is the same as `dudupShapes`, but uses the more efficient `nub` function.
 
 ## Multi Parameter Type Classes
 
@@ -591,7 +592,15 @@ We've already seen the `unsafePartial` function, which allows us to treat a part
 unsafePartial :: forall a. (Partial => a) -> a
 ```
 
-Note that the `Partial` constraint appears _inside the parentheses_ on the left of the function arrow, but not in the outer `forall`. That is, `unsafePartial` is a function from partial values to regular values.
+Note that the `Partial` constraint appears _inside the parentheses_ on the left of the function arrow, but not in the outer `forall`. That is, `unsafePartial` is a function from partial values to regular values:
+
+```text
+> unsafePartial head [1, 2, 3]
+1
+
+> unsafePartial secondElement [1, 2, 3]
+2
+```
 
 ## Superclasses
 


### PR DESCRIPTION
This PR does 3 things:

1. Fixes a typo: s/dudupShapes/dedupShapes/

1. Moves the exercises to an earlier section, to align both with content of the section and the order of the tests to be uncommented

1. Adds an example invocation of a Partial function with unsafePartial