### PR TITLE
Handle addressbook regex with unsafeRegex

### DIFF
--- a/exercises/chapter10/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter10/src/Data/AddressBook/Validation.purs
@@ -3,10 +3,11 @@ module Data.AddressBook.Validation where
 import Prelude
 
 import Data.AddressBook (Address, Person, PhoneNumber, address, person, phoneNumber)
-import Data.Either (Either(..))
+import Data.Either (Either)
 import Data.String (length)
-import Data.String.Regex (Regex, test, regex)
+import Data.String.Regex (Regex, test)
 import Data.String.Regex.Flags (noFlags)
+import Data.String.Regex.Unsafe (unsafeRegex)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, invalid, toEither)
 
@@ -28,14 +29,13 @@ lengthIs field len value | length value /= len =
   invalid [ "Field '" <> field <> "' must have length " <> show len ]
 lengthIs _     _   value = pure value
 
-phoneNumberRegex :: Either String Regex
-phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
+phoneNumberRegex :: Regex
+phoneNumberRegex = unsafeRegex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 
-matches :: String -> Either String Regex -> String -> V Errors String
-matches _    (Right regex) value | test regex value 
-                                 = pure value
-matches _    (Left  error) _     = invalid [ error ]
-matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
+matches :: String -> Regex -> String -> V Errors String
+matches _     regex value | test regex value 
+                          = pure value
+matches field _     _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address
 validateAddress a =

--- a/exercises/chapter7/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter7/src/Data/AddressBook/Validation.purs
@@ -75,16 +75,19 @@ lengthIs _     _   value = pure value
 -- | regex :: String -> RegexFlags -> Either String Regex
 -- | ```
 -- |
--- | which can fail if we pass an invalid regex `String`. Since we construct the string ourselves
--- | the only reason it would fail is if we were careless. Even in this case it's safe for us to use:
+-- | which can fail if passed an invalid regex `String`. This potential failure is worth
+-- | checking for at runtime when working with a user-provided regex `String`.
+-- | But in our case, we hardcode a literal regex string, so it's not as problematic
+-- | to use this more convenient "unsafe" version that may throw an exception:
 -- |
 -- | ```purescript
 -- | unsafeRegex :: String -> RegexFlags -> Regex
 -- | ```
 -- |
--- | instead because the error would be cought at compile time. That's because `phoneNumberRegex` is
--- | defined as a top level binidng and so it's resolve at compile time. This wouldn't be the case
--- | if we for example would pass in a `String` that we get from use input.
+-- | We can achieve a bit more safety by binding our `Regex` values at the top level,
+-- | so any potential runtime exceptions are thrown as soon as our application starts.
+-- | This is better than defining these values in a local context, where the error may
+-- | not be encountered until later on during application execution.
 phoneNumberRegex :: Regex
 phoneNumberRegex = unsafeRegex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 -- ANCHOR_END: phoneNumberRegex

--- a/exercises/chapter7/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter7/src/Data/AddressBook/Validation.purs
@@ -66,8 +66,8 @@ lengthIs _     _   value = pure value
 -- ANCHOR_END: lengthIs
 
 -- ANCHOR: phoneNumberRegex
--- | We use `Data.String.Regex.Unsafe.unsafeRegex` here instead of `Data.String.Regex.regex` in order
--- | to simplify the code.
+-- | We use `Data.String.Regex.Unsafe.unsafeRegex` here instead of `Data.String.Regex.regex`
+-- | in order to simplify the code.
 -- |
 -- | The safe function has this signature:
 -- |
@@ -77,7 +77,7 @@ lengthIs _     _   value = pure value
 -- |
 -- | which can fail if passed an invalid regex `String`. This potential failure is worth
 -- | checking for at runtime when working with a user-provided regex `String`.
--- | But in our case, we hardcode a literal regex string, so it's not as problematic
+-- | But in our case, we hardcode a literal regex `String`, so it's not as problematic
 -- | to use this more convenient "unsafe" version that may throw an exception:
 -- |
 -- | ```purescript

--- a/exercises/chapter7/test/Main.purs
+++ b/exercises/chapter7/test/Main.purs
@@ -101,10 +101,8 @@ Note to reader: Delete this line to expand comment block -}
     suite "Exercise Group - Applicative Validation" do
       suite "Exercise - stateRegex" do
         let
-          stateTest str exp =
-            test (show str) do
-              Assert.equal (Right exp)
-                $ R.test <$> stateRegex <*> Right str
+          stateTest str exp = test str do
+             Assert.equal exp $ R.test stateRegex str
         stateTest "CA" true
         stateTest "Ca" true
         stateTest "C" false
@@ -112,10 +110,8 @@ Note to reader: Delete this line to expand comment block -}
         stateTest "C3" false
       suite "Exercise - nonEmptyRegex" do
         let
-          nonEmptyTest str exp =
-            test (show str) do
-              Assert.equal (Right exp)
-                $ R.test <$> nonEmptyRegex <*> Right str
+          nonEmptyTest str exp = test str do
+              Assert.equal exp $ R.test nonEmptyRegex str
         nonEmptyTest "Houston" true
         nonEmptyTest "My Street" true
         nonEmptyTest "Ñóñá" true

--- a/exercises/chapter7/test/no-peeking/Solutions.purs
+++ b/exercises/chapter7/test/no-peeking/Solutions.purs
@@ -1,16 +1,16 @@
 module Test.NoPeeking.Solutions where
 
 import Prelude
+
 import Control.Apply (lift2)
 import Data.AddressBook (Address, PhoneNumber, address)
 import Data.AddressBook.Validation (Errors, matches, nonEmpty, validateAddress, validatePhoneNumbers)
-import Data.Either (Either)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
-import Data.String.Regex (Regex, regex)
+import Data.String.Regex (Regex)
 import Data.String.Regex.Flags (noFlags)
+import Data.String.Regex.Unsafe (unsafeRegex)
 import Data.Traversable (class Foldable, class Traversable, foldMap, foldl, foldr, sequence, traverse)
 import Data.Validation.Semigroup (V)
 
@@ -49,12 +49,12 @@ combineMaybe _ = pure Nothing
 
 {-| Exercise Group 2 -}
 -- Exercise 1
-stateRegex :: Either String Regex
-stateRegex = regex "^[a-zA-Z]{2}$" noFlags
+stateRegex :: Regex
+stateRegex = unsafeRegex "^[a-zA-Z]{2}$" noFlags
 
 -- Exercise 2
-nonEmptyRegex :: Either String Regex
-nonEmptyRegex = regex "\\S" noFlags
+nonEmptyRegex :: Regex
+nonEmptyRegex = unsafeRegex "\\S" noFlags
 
 -- Exercise 3
 validateAddressImproved :: Address -> V Errors Address

--- a/exercises/chapter8/src/Data/AddressBook/Validation.purs
+++ b/exercises/chapter8/src/Data/AddressBook/Validation.purs
@@ -3,10 +3,11 @@ module Data.AddressBook.Validation where
 import Prelude
 
 import Data.AddressBook (Address, Person, PhoneNumber, address, person, phoneNumber)
-import Data.Either (Either(..))
+import Data.Either (Either)
 import Data.String (length)
-import Data.String.Regex (Regex, test, regex)
+import Data.String.Regex (Regex, test)
 import Data.String.Regex.Flags (noFlags)
+import Data.String.Regex.Unsafe (unsafeRegex)
 import Data.Traversable (traverse)
 import Data.Validation.Semigroup (V, invalid, toEither)
 
@@ -28,14 +29,13 @@ lengthIs field len value | length value /= len =
   invalid [ "Field '" <> field <> "' must have length " <> show len ]
 lengthIs _     _   value = pure value
 
-phoneNumberRegex :: Either String Regex
-phoneNumberRegex = regex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
+phoneNumberRegex :: Regex
+phoneNumberRegex = unsafeRegex "^\\d{3}-\\d{3}-\\d{4}$" noFlags
 
-matches :: String -> Either String Regex -> String -> V Errors String
-matches _    (Right regex) value | test regex value 
-                                 = pure value
-matches _    (Left  error) _     = invalid [ error ]
-matches field _            _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
+matches :: String -> Regex -> String -> V Errors String
+matches _     regex value | test regex value 
+                          = pure value
+matches field _     _     = invalid [ "Field '" <> field <> "' did not match the required format" ]
 
 validateAddress :: Address -> V Errors Address
 validateAddress a =

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -537,8 +537,8 @@ invalid (["Field 'Number' did not match the required format"])
 
  ## Exercises
 
- 1. (Easy) Write a regular expression `stateRegex :: Either String Regex` to check that a string only contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
- 1. (Medium) Write a regular expression `nonEmptyRegex :: Either String Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com) which has a great cheatsheet and interactive test environment.
+ 1. (Easy) Write a regular expression `stateRegex :: Regex` to check that a string only contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
+ 1. (Medium) Write a regular expression `nonEmptyRegex :: Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com) which has a great cheatsheet and interactive test environment.
  1. (Medium) Write a function `validateAddressImproved` that is similar to `validateAddress`, but uses the above `stateRegex` to validate the `state` field and `nonEmptyRegex` to validate the `street` and `city` fields. _Hint_: see the source for `validatePhoneNumber` for an example of how to use `matches`.
 
 ## Traversable Functors


### PR DESCRIPTION
Reverts #248 in favor of `unsafeRegex`.

I've also added some doc comments for `phoneNumberRegex` since it's reference in Ch7 for exercises. Please let me know if it's clear enough.

Closes #287