### PR TITLE
Add anchor for `square` JavaScript function.

### DIFF
--- a/exercises/chapter10/test/Examples.js
+++ b/exercises/chapter10/test/Examples.js
@@ -1,9 +1,10 @@
 "use strict";
 
+// ANCHOR: square
 exports.square = function (n) {
   return n * n;
 };
-
+// ANCHOR_END: square
 
 exports.diagonal = function (w, h) {
   return Math.sqrt(w * w + h * h);


### PR DESCRIPTION
Fix #294 by surrounding the `square` function in an mdbook anchor labeled `square`