### PR TITLE
Update import of Test.HTTP module

### DIFF
--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -137,7 +137,7 @@ $ spago repl
 … import Prelude
 … import Effect.Aff (launchAff_)
 … import Effect.Class.Console (log)
-… import Test.ExamplesHTTP (getUrl)
+… import Test.HTTP (getUrl)
 …
 … launchAff_ do
 …   str <- getUrl "https://reqres.in/api/users/1"


### PR DESCRIPTION
Looks like this module was always `Test.HTTP` not `Test.ExampleHTTP` (https://github.com/purescript-contrib/purescript-book/blame/master/exercises/chapter9/test/HTTP.purs)