### PR TITLE
Remove reference to memoize library

### DIFF
--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -667,7 +667,7 @@ The `ST` effect is a good way to generate short JavaScript when working with loc
 
 1. (Medium) Rewrite the `safeDivide` function as `exceptionDivide` and throw an exception using `throwException` if the denominator is zero. _Note:_ There is no unit test for this exercise because it's tricky to check for an expected exception within our unit test framework. Feel free to work on adding this test.
 1. (Medium) Write a function `estimatePi :: Int -> Number` that uses `n` terms of the [Gregory Series](https://mathworld.wolfram.com/GregorySeries.html) to calculate an approximation of `pi`. _Hints:_ You can pattern your answer like the definition of `simulate` above. You might need to convert an `Int` into a `Number` using `toNumber :: Int -> Number` from `Data.Int`.
-1. (Medium) Write a function `fibonacci :: Int -> Int` to compute the `n`th Fibonacci number, using `ST` to track the values of the previous two Fibonacci numbers. Using PSCi, compare the speed of your new `ST`-based implementation against the recursive implementation (`fib`) from Chapter 4. (As an aside, for easier memoization, see [`Data.Function.Memoize`](https://pursuit.purescript.org/packages/purescript-memoize/5.0.0) and the [`MemoizeFibonacci`](https://github.com/JordanMartinez/purescript-cookbook/tree/master/recipes/MemoizeFibonacci) recipe in the [PureScript cookbook](https://github.com/JordanMartinez/purescript-cookbook/blob/master/README.md#recipes).)
+1. (Medium) Write a function `fibonacci :: Int -> Int` to compute the `n`th Fibonacci number, using `ST` to track the values of the previous two Fibonacci numbers. Using PSCi, compare the speed of your new `ST`-based implementation against the recursive implementation (`fib`) from Chapter 4.
 
 ## DOM Effects
 


### PR DESCRIPTION
Fixes #324

It would be nice to eventually restore the `memoize` library. Perhaps by moving it to `puresccript-contrib`.