### PR TITLE
Ch6 - remove concrete test Action Multiply Int

### DIFF
--- a/exercises/chapter6/test/Main.purs
+++ b/exercises/chapter6/test/Main.purs
@@ -181,9 +181,6 @@ Note to reader: Delete this line to expand comment block -}
           test "Multiply Int append" do
             Assert.equal (act m1 (act m2 a))
               $ act (m1 <> m2) a
-          test "Multiply Int concrete" do
-            Assert.equal 15
-              $ act m1 a
         -- Multiply String is the actual exercise question
         suite "Multiply String" do
           let


### PR DESCRIPTION
There exists an alternative solution
```haskell
import Data.Int (pow)

instance actionMultiplyInt :: Action Multiply Int where
  act (Multiply m) i = pow i m
```
The concrete test is not significant here. We only need to test that the laws are upheld.
