### PR TITLE
Ch6 - reorganize/rename exercise tests.

### DIFF
--- a/exercises/chapter6/test/Main.purs
+++ b/exercises/chapter6/test/Main.purs
@@ -89,7 +89,7 @@ Note to reader: Delete this line to expand comment block -}
             $ NonEmpty 1 [ 2, 3 ]
             <> NonEmpty 4 [ 5, 6 ]
       suite "Exercise - Functor for NonEmpty" do
-        test "NonEmpty append" do
+        test "NonEmpty map" do
           Assert.equal (NonEmpty 10 [ 20, 30 ])
             $ map (_ * 10)
             $ NonEmpty 1 [ 2, 3 ]

--- a/exercises/chapter6/test/Main.purs
+++ b/exercises/chapter6/test/Main.purs
@@ -19,23 +19,23 @@ main =
     runChapterExamples
     {-  Move this block comment starting point to enable more tests
 Note to reader: Delete this line to expand comment block -}
-    suite "Exercise Group - Show Me" do
-      test "Exercise - Show Point" do
+    suite "Show Me!" do
+      test "Show Point" do
         Assert.equal "(1.0, 2.0)"
           $ show
           $ Point {x: 1.0, y: 2.0}
-    suite "Exercise Group - Common Type Classes" do
+    suite "Common Type Classes" do
       let cpx real imaginary = Complex {real, imaginary}
-      suite "Exercise - Show Complex" do
-        test "Show" do
+      suite "Show Complex" do
+        test "possitve imaginary" do
           Assert.equal "1.0+2.0i"
             $ show
             $ cpx 1.0 2.0
-        test "Show Negative" do
+        test "negative imaginary" do
           Assert.equal "1.0-2.0i"
             $ show
             $ cpx 1.0 (-2.0)
-      suite "Exercise - Eq Complex" do
+      suite "Eq Complex" do
         test "equal" do
           Assert.equal (cpx 1.0 2.0)
             $ cpx 1.0 2.0
@@ -43,7 +43,7 @@ Note to reader: Delete this line to expand comment block -}
           Assert.expectFailure "should not be equal"
             $ Assert.equal (cpx 5.0 2.0)
               $ cpx 1.0 2.0
-      suite "Exercise - Semiring Complex" do
+      suite "Semiring Complex" do
         test "add" do
           Assert.equal (cpx 4.0 6.0)
             $ add (cpx 1.0 2.0) (cpx 3.0 4.0)
@@ -57,11 +57,11 @@ Note to reader: Delete this line to expand comment block -}
         test "multiply one" do
           Assert.equal v
             $ mul v one
-      suite "Exercise - Ring Complex" do
+      suite "Ring Complex" do
         test "subtract" do
           Assert.equal (cpx 2.0 3.0)
             $ sub (cpx 3.0 5.0) (cpx 1.0 2.0)
-      suite "Exercise - Show Shape" do
+      suite "Show Shape" do
         test "circle" do
           Assert.equal "(Circle (1.0, 2.0) 3.0)"
             $ show $ Circle (Point {x: 1.0, y: 2.0}) 3.0
@@ -74,72 +74,72 @@ Note to reader: Delete this line to expand comment block -}
         test "text" do
           Assert.equal "(Text (1.0, 2.0) \"Hello\")"
             $ show $ Text (Point {x: 1.0, y: 2.0}) "Hello"
-    suite "Exercise Group - Constraints and Dependencies" do
-      suite "Exercise - Eq for NonEmpty" do
-        test "NonEmpty equals" do
+    suite "Type Class Constraints" do
+      suite "Eq NonEmpty" do
+        test "equals" do
           Assert.equal (NonEmpty 1 [ 2, 3 ])
             $ NonEmpty 1 [ 2, 3 ]
-        test "NonEmpty not equals" do
+        test "not equals" do
           Assert.expectFailure "should not be equal"
             $ Assert.equal (NonEmpty 1 [ 2, 3 ])
             $ NonEmpty 2 [ 2, 3 ]
-      suite "Exercise - Semigroup for NonEmpty" do
-        test "NonEmpty append" do
+      suite "Semigroup NonEmpty" do
+        test "append" do
           Assert.equal (NonEmpty 1 [ 2, 3, 4, 5, 6 ])
             $ NonEmpty 1 [ 2, 3 ]
             <> NonEmpty 4 [ 5, 6 ]
-      suite "Exercise - Functor for NonEmpty" do
-        test "NonEmpty map" do
+      suite "Functor NonEmpty" do
+        test "map" do
           Assert.equal (NonEmpty 10 [ 20, 30 ])
             $ map (_ * 10)
             $ NonEmpty 1 [ 2, 3 ]
-      suite "Exercise - Ord for Extended" do
+      suite "Ord Extended" do
         -- Type annotation necessary to ensure there is an Ord instance for inner type (Int in this case)
-        test "Extended compare inf inf" do
+        test "infinity equals infinity" do
           Assert.equal EQ
             $ compare Infinite (Infinite :: Extended Int)
-        test "Extended compare inf 5" do
+        test "infinity > finite" do
           Assert.equal GT
             $ compare Infinite
             $ Finite 5
-        test "Extended compare 5 inf" do
+        test "finite < infinity" do
           Assert.equal LT
             $ compare (Finite 5) Infinite
-        test "Extended compare 5 5" do
+        test "finite equals finite" do
           Assert.equal EQ
             $ compare (Finite 5)
             $ Finite 5
-        test "Extended compare 6 5" do
+        test "finite > finite" do
           Assert.equal GT
             $ compare (Finite 6)
             $ Finite 5
-        test "Extended compare 5 6" do
+        test "finite < finite" do
           Assert.equal LT
             $ compare (Finite 5)
             $ Finite 6
-      suite "Exercise - Foldable for NonEmpty" do
-        test "NonEmpty foldl" do
+      suite "Foldable NonEmpty" do
+        test "foldl" do
           Assert.equal 123
             $ foldl (\acc x -> acc * 10 + x) 0
             $ NonEmpty 1 [ 2, 3 ]
-        test "NonEmpty foldr" do
+        test "foldr" do
           Assert.equal 321
             $ foldr (\x acc -> acc * 10 + x) 0
             $ NonEmpty 1 [ 2, 3 ]
-        test "NonEmpty foldMap" do
+        test "foldMap" do
           Assert.equal "123"
             $ foldMap (\x -> show x)
             $ NonEmpty 1 [ 2, 3 ]
-      suite "Exercise - Foldable for OneMore" do
-        test "OneMore foldl" do
+      suite "Foldable OneMore" do
+        test "foldl" do
           Assert.equal 123
             $ foldl (\acc x -> acc * 10 + x) 0
             $ OneMore 1 (2 : 3 : Nil)
-        test "OneMore foldr" do
+        test "foldr" do
           Assert.equal 321
             $ foldr (\x acc -> acc * 10 + x) 0
             $ OneMore 1 (2 : 3 : Nil)
-        test "OneMore foldMap" do
+        test "foldMap" do
           Assert.equal "123"
             $ foldMap (\x -> show x)
             $ OneMore 1 (2 : 3 : Nil)
@@ -155,106 +155,104 @@ Note to reader: Delete this line to expand comment block -}
           , Circle (Point {x: 3.0, y: 2.0}) 3.0
           , Circle (Point {x: 2.0, y: 2.0}) 3.0
           ]
-      test "Exercise - dedupShapes" do
+      test "dedupShapes" do
         Assert.equal noDups
           $ dedupShapes withDups
-      test "Exercise - dedupShapesFast" do
+      test "dedupShapesFast" do
         Assert.equal noDups
           $ dedupShapesFast withDups
-    suite "Exercise Group - More or less than one Type argument" do
-      test "Exercise - unsafeMaximum" do
+    suite "Multi Parameter Type Classes " do
+      test "unsafeMaximum" do
         Assert.equal 42
           $ unsafePartial
           $ unsafeMaximum [ 1, 2, 42, 3 ]
       let
         m1 = Multiply 3
-
         m2 = Multiply 4
-      suite "Exercise - Action Class - repeatAction instance" do
-        -- Getting Multiply Int to work is a warm-up
-        suite "Multiply Int" do
-          let
-            a = 5
-          test "Multiply Int mempty" do
-            Assert.equal a
-              $ act (mempty :: Multiply) a
-          test "Multiply Int append" do
-            Assert.equal (act m1 (act m2 a))
-              $ act (m1 <> m2) a
-          test "Multiply Int concrete" do
-            Assert.equal 15
-              $ act m1 a
-        -- Multiply String is the actual exercise question
-        suite "Multiply String" do
-          let
-            a = "foo"
-          test "Multiply String mempty" do
-            Assert.equal a
-              $ act (mempty :: Multiply) a
-          test "Multiply String append" do
-            Assert.equal (act m1 (act m2 a))
-              $ act (m1 <> m2) a
-          test "Multiply String concrete" do
-            Assert.equal "foofoofoo"
-              $ act m1 a
-      suite "Exercise - Action Class - actionArray instance" do
-        suite "Multiply Array Int" do
+      -- Getting Multiply Int to work is a warm-up
+      suite "Action Multiply Int" do
+        let
+          a = 5
+        test "act mempty" do
+          Assert.equal a
+            $ act (mempty :: Multiply) a
+        test "act appended" do
+          Assert.equal (act m1 (act m2 a))
+            $ act (m1 <> m2) a
+        test "concrete" do
+          Assert.equal 15
+            $ act m1 a
+      -- Multiply String is the actual exercise question
+      suite "Action Multiply String" do
+        let
+          a = "foo"
+        test "act mempty" do
+          Assert.equal a
+            $ act (mempty :: Multiply) a
+        test "act appended" do
+          Assert.equal (act m1 (act m2 a))
+            $ act (m1 <> m2) a
+        test "concrete" do
+          Assert.equal "foofoofoo"
+            $ act m1 a
+      suite "Action m (Array a)" do
+        suite "Action Multiply (Array Int)" do
           let
             a = [ 1, 2, 3 ]
-          test "Multiply Array Int mempty" do
+          test "act mempty" do
             Assert.equal a
               $ act (mempty :: Multiply) a
-          test "Multiply Array Int append" do
+          test "act appended" do
             Assert.equal (act m1 (act m2 a))
               $ act (m1 <> m2) a
-          test "Multiply Array Int concrete" do
+          test "concrete" do
             Assert.equal [ 3, 6, 9 ]
               $ act m1 a
-        suite "Multiply Array String" do
+        suite "Action Multiply (Array String)" do
           let
             a = [ "foo", "bar", "baz" ]
-          test "Multiply Array String mempty" do
+          test "act mempty" do
             Assert.equal a
               $ act (mempty :: Multiply) a
-          test "Multiply Array String append" do
+          test "act appended" do
             Assert.equal (act m1 (act m2 a))
               $ act (m1 <> m2) a
-          test "Multiply Array String concrete" do
+          test "concrete" do
             Assert.equal
               [ "foofoofoo"
               , "barbarbar"
               , "bazbazbaz"
               ]
               $ act m1 a
-      suite "Exercise - Action Class - actionSelf instance" do
+      suite "Action m (Self m)" do
         let
           a = Self m1
-        test "Multiply Self mempty" do
+        test "act mempty" do
           Assert.equal a
             $ act (mempty :: Multiply) a
-        test "Multiply Self append" do
+        test "act appended" do
           Assert.equal (act m1 (act m2 a))
             $ act (m1 <> m2) a
-        test "Multiply Self concrete" do
+        test "concrete" do
           Assert.equal (Self (Multiply 12))
             $ act m2 a
-    suite "Exercise Group - Hashes" do
-      suite "Exercise - arrayHasDuplicates" do
-        test "No dupe" do
+    suite "A Type Class for Hashes" do
+      suite "arrayHasDuplicates" do
+        test "no dupe" do
           Assert.equal false
             $ arrayHasDuplicates [ 1, 2, 3 ]
-        test "Dupe" do
+        test "dupe" do
           Assert.equal true
             $ arrayHasDuplicates [ 1, 1, 3 ]
-        test "Only hash dupe" do
+        test "only hash dupe" do
           Assert.equal false
             $ arrayHasDuplicates [ 65536, 1, 2, 3 ]
-      suite "Exercise - hashHour instance" do
-        test "Match" do
+      suite "Hashable Hour" do
+        test "match" do
           Assert.equal (hash $ Hour 1)
             $ hash
             $ Hour 13
-        test "Mismatch" do
+        test "mismatch" do
           Assert.expectFailure "should not be equal"
             $ Assert.equal (hash $ Hour 1)
             $ hash


### PR DESCRIPTION
This PR supersedes #138. Turns out less nesting is needed for simple naming. I came up with this scheme.
  - Each top level item is a *suite* corresponding to an *exercise group*. The name is taken from the first *header* in the book preceding the exercise after the pervious exercise group.
  - Each second level item (nested) corresponds to an *exercise* of the group. This may be a sigle *test* or a *suite* depending on number of tests needed. The name should capture the goal of the exercise. E.g. the name of the function/instance to be implemented.
  - Exercise suits may logically contain nested suits when tests are logically grouped.
  - Sub-test names exetend the suit name(s). This maybe a property, a part or a case.
  - Names use all small caps except for words taken from the code or book headers. Don't use peroid/full-stop. Don't use the words "exercise" "exercise group"
Suite names set the context for nested items, thus nested item names can be short and precise.