### PR TITLE
Ch7 - add stateRegex special character test case

### DIFF
--- a/exercises/chapter7/test/Main.purs
+++ b/exercises/chapter7/test/Main.purs
@@ -108,6 +108,7 @@ Note to reader: Delete this line to expand comment block -}
         stateTest "C" false
         stateTest "CAA" false
         stateTest "C3" false
+        stateTest "C$" false
       suite "Exercise - nonEmptyRegex" do
         let
           nonEmptyTest str exp = test str do


### PR DESCRIPTION
The exercise does mention only alphabetic characters are allowed.
The no-peek solutions also reflect this requirement. Therefor tests
should reject input containing special characters.