### PR TITLE
Ch6 Action exercises - clarify typeclass law reminder

### DIFF
--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -661,7 +661,7 @@ Another reason to define a superclass relationship is in the case where there is
      
      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
       
-      Remember, your instance must satisfy the laws listed above. 
+     Remember, your instance must satisfy the laws listed above. 
 
  1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently. Remember, your instance must satisfy the laws listed above.
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -648,7 +648,7 @@ Another reason to define a superclass relationship is in the case where there is
      ```haskell
      instance actionMultiplyInt :: Action Multiply Int
      ```
-     Verify that this instance satisfies the laws listed above.
+     _Note_: Your instance must satisfy the type class laws listed above in order to pass the tests.
 
 1. (Difficult) There are actually multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of a same instance, so you will have to replace your original implementation. _Note_: the tests cover 3 implementations.
 
@@ -658,8 +658,6 @@ Another reason to define a superclass relationship is in the case where there is
      instance actionMultiplyString :: Action Multiply String
      ```
      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
-
-     Verify that this instance satisfies the laws listed above.
 
  1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -661,9 +661,9 @@ Another reason to define a superclass relationship is in the case where there is
      
      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
       
-     Remember, your instance must satisfy the laws listed above. 
+     Does this instance satisfy the laws listed above? 
 
- 1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently. Remember, your instance must satisfy the laws listed above.
+ 1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
 
  1. (Difficult) Given the following newtype, write an instance for `Action m (Self m)`, where the monoid `m` acts on itself using `append`:
 
@@ -672,8 +672,6 @@ Another reason to define a superclass relationship is in the case where there is
      ```
 
      _Note_: The testing framework requires `Show` and `Eq` instances for the `Self` and `Multiply` types. You may either write these instances manually, or let the compiler handle this for you with [`derive newtype instance`](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#derive-from-newtype) shorthand.
-     
-     Remember, your instance must satisfy the laws listed above. 
 
  1. (Difficult) Should the arguments of the multi-parameter type class `Action` be related by some functional dependency? Why or why not? _Note_: There is no test for this exercise.
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -659,7 +659,9 @@ Another reason to define a superclass relationship is in the case where there is
      instance actionMultiplyString :: Action Multiply String
      ```
      
-      Remember, your instance must satisfy the laws listed above. _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
+      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
+      
+      Remember, your instance must satisfy the laws listed above. 
 
  1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently. Remember, your instance must satisfy the laws listed above.
 
@@ -669,7 +671,9 @@ Another reason to define a superclass relationship is in the case where there is
      newtype Self m = Self m
      ```
 
-     Remember, your instance must satisfy the laws listed above. _Note_: The testing framework requires `Show` and `Eq` instances for the `Self` and `Multiply` types. You may either write these instances manually, or let the compiler handle this for you with [`derive newtype instance`](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#derive-from-newtype) shorthand.
+     _Note_: The testing framework requires `Show` and `Eq` instances for the `Self` and `Multiply` types. You may either write these instances manually, or let the compiler handle this for you with [`derive newtype instance`](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#derive-from-newtype) shorthand.
+     
+     Remember, your instance must satisfy the laws listed above. 
 
  1. (Difficult) Should the arguments of the multi-parameter type class `Action` be related by some functional dependency? Why or why not? _Note_: There is no test for this exercise.
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -659,7 +659,7 @@ Another reason to define a superclass relationship is in the case where there is
      ```
      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
 
-     Does this instance satisfy the laws listed above?
+     Verify that this instance satisfies the laws listed above.
 
  1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -648,7 +648,8 @@ Another reason to define a superclass relationship is in the case where there is
      ```haskell
      instance actionMultiplyInt :: Action Multiply Int
      ```
-     _Note_: Your instance must satisfy the type class laws listed above in order to pass the tests.
+     
+     Remember, your instance must satisfy the laws listed above.
 
 1. (Difficult) There are actually multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of a same instance, so you will have to replace your original implementation. _Note_: the tests cover 3 implementations.
 
@@ -657,9 +658,10 @@ Another reason to define a superclass relationship is in the case where there is
      ```haskell
      instance actionMultiplyString :: Action Multiply String
      ```
-     _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
+     
+      Remember, your instance must satisfy the laws listed above. _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
 
- 1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
+ 1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently. Remember, your instance must satisfy the laws listed above.
 
  1. (Difficult) Given the following newtype, write an instance for `Action m (Self m)`, where the monoid `m` acts on itself using `append`:
 
@@ -667,7 +669,7 @@ Another reason to define a superclass relationship is in the case where there is
      newtype Self m = Self m
      ```
 
-     _Note_: The testing framework requires `Show` and `Eq` instances for the `Self` and `Multiply` types. You may either write these instances manually, or let the compiler handle this for you with [`derive newtype instance`](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#derive-from-newtype) shorthand.
+     Remember, your instance must satisfy the laws listed above. _Note_: The testing framework requires `Show` and `Eq` instances for the `Self` and `Multiply` types. You may either write these instances manually, or let the compiler handle this for you with [`derive newtype instance`](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#derive-from-newtype) shorthand.
 
  1. (Difficult) Should the arguments of the multi-parameter type class `Action` be related by some functional dependency? Why or why not? _Note_: There is no test for this exercise.
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -659,7 +659,7 @@ Another reason to define a superclass relationship is in the case where there is
      instance actionMultiplyString :: Action Multiply String
      ```
      
-      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
+     _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
       
       Remember, your instance must satisfy the laws listed above. 
 

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -660,8 +660,8 @@ Another reason to define a superclass relationship is in the case where there is
      ```
      
      _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
-      
-     Does this instance satisfy the laws listed above? 
+
+     Does this instance satisfy the laws listed above?
 
  1. (Medium) Write an instance `Action m a => Action m (Array a)`, where the action on arrays is defined by acting on each array element independently.
 


### PR DESCRIPTION
Follow-up to #338

This phrasing is also used in the previous exercise. This PR simply makes the phrasing consistent, but I think we should actually eliminate these lines from both exercises.

These lines don't contribute much for the student, since we have tests to verify the student's solution satisfies the laws. Including these lines might even add confusion, since this could seem like an extra step that we're asking. Really, every exercise could include a similar "Verify that your solution meets the exercise requirements", which I think is equally unnecessary here.
