### PR TITLE
Ch9 - increase getWithTimeout time in test

### DIFF
--- a/exercises/chapter9/test/Main.purs
+++ b/exercises/chapter9/test/Main.purs
@@ -112,7 +112,7 @@ Note to reader: Delete this line to expand comment block -}
       test "valid site" do
         let
           expectedOutFile = Path.concat [ inDir, "user.txt" ]
-        actual <- getWithTimeout 1000.0 reqUrl
+        actual <- getWithTimeout 10000.0 reqUrl
         expected <- Just <$> readTextFile UTF8 expectedOutFile
         Assert.equal expected actual
       test "no response" do


### PR DESCRIPTION
Sometimes valid responses can take longer that 1 second. Bumped to 10 seconds.