### PR TITLE
remove anchors from .js files as well

### DIFF
--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -3,7 +3,7 @@
 # This script removes all code anchors to improve readability
 
 # All .purs & .js files in the src/ and test/ directories of chapter exercises.
-FILES=$(find . -regextype posix-extended -regex './exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)' -type f)
+FILES=$(find . -regextype posix-extended -regex '\./exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)' -type f)
 
 for f in $FILES; do
   # Delete lines starting with an 'ANCHOR' comment

--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -9,3 +9,11 @@ for f in $ALL_PURS; do
   # Delete lines starting with an '-- ANCHOR' comment
   perl -ni -e 'print if !/^\s*-- ANCHOR/' $f
 done
+
+# All .js files in the exercises directories (excluding hidden files and output/)
+ALL_JS=$(find exercises \( ! -regex '.*/\..*' \) \( ! -regex '.*/output/.*' \) -type f -name '*.js')
+
+for f in $ALL_JS; do
+  # Delete lines starting with an '// ANCHOR' comment
+  perl -ni -e 'print if !/^\s*\/\/ ANCHOR/' $f
+done

--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -7,5 +7,5 @@ FILES=$(find . -regextype posix-extended -regex './exercises/chapter[0-9]{1,2}/(
 
 for f in $FILES; do
   # Delete lines starting with an 'ANCHOR' comment
-  sed -i -E '/^\s*(--|\/\/) ANCHOR/d' $f
+  perl -ni -e 'print if !/^\s*(--|\/\/) ANCHOR/' $f
 done

--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -2,18 +2,10 @@
 
 # This script removes all code anchors to improve readability
 
-# All .purs files in the exercises directories (excluding hidden files)
-ALL_PURS=$(find exercises \( ! -regex '.*/\..*' \) -type f -name '*.purs')
+# All .purs & .js files in the src/ and test/ directories of chapter exercises.
+FILES=$(find . -regextype posix-extended -regex './exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)' -type f)
 
-for f in $ALL_PURS; do
-  # Delete lines starting with an '-- ANCHOR' comment
-  perl -ni -e 'print if !/^\s*-- ANCHOR/' $f
-done
-
-# All .js files in the exercises directories (excluding hidden files and output/)
-ALL_JS=$(find exercises \( ! -regex '.*/\..*' \) \( ! -regex '.*/output/.*' \) -type f -name '*.js')
-
-for f in $ALL_JS; do
-  # Delete lines starting with an '// ANCHOR' comment
-  perl -ni -e 'print if !/^\s*\/\/ ANCHOR/' $f
+for f in $FILES; do
+  # Delete lines starting with an 'ANCHOR' comment
+  sed -i -E '/^\s*(--|\/\/) ANCHOR/d' $f
 done


### PR DESCRIPTION
Chapter10 .js files still contain `// ANCHOR` comments. Current filtering
style will include files in `output/`. So ended up with
  - using positive filtering to find source files
  - using `sed` instead of `perl`