### PR TITLE
fix: example not working without import

### DIFF
--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -369,6 +369,7 @@ Let's also test `showEntry` by creating an address book entry record containing 
 Now let's write some utility functions for working with address books. We will need a value which represents an empty address book: an empty list.
 
 ```haskell
+import Control.Plus (empty)
 emptyBook :: AddressBook
 emptyBook = empty
 ```


### PR DESCRIPTION
I try this book and stuck on this example
https://book.purescript.org/chapter3.html#creating-address-books
```
emptyBook :: AddressBook
emptyBook = empty
```
when I input these in spago repl
I got this
```
> :paste
… emptyBook :: AddressBook
… emptyBook = empty
…
Error found:
in module $PSCI
at :2:13 - 2:18 (line 2, column 13 - line 2, column 18)

  Unknown value empty


See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
or to contribute content related to this error.
```
fix by adding `import Control.Plus (empty)`
<img width="985" alt="Screen Shot 2021-06-06 at 16 32 11" src="https://user-images.githubusercontent.com/6429197/120920256-24f9e000-c6e8-11eb-9a69-497ba6ac62c5.png">
