### PR TITLE
Ch10 - rewrite functions with multiple arguments

### DIFF
--- a/exercises/chapter10/test/Examples.js
+++ b/exercises/chapter10/test/Examples.js
@@ -6,11 +6,7 @@ exports.square = function (n) {
 };
 // ANCHOR_END: square
 
-exports.diagonal = function (w, h) {
-  return Math.sqrt(w * w + h * h);
-};
-
-exports.diagonalNested = function (w) {
+exports.diagonal = function (w) {
   return function (h) {
     return Math.sqrt(w * w + h * h);
   };
@@ -19,6 +15,9 @@ exports.diagonalNested = function (w) {
 exports.diagonalArrow = w => h =>
   Math.sqrt(w * w + h * h);
 
+exports.diagonalUncurried = function (w, h) {
+  return Math.sqrt(w * w + h * h);
+};
 
 exports.cumulativeSums = arr => {
   let sum = 0

--- a/exercises/chapter10/test/Examples.js
+++ b/exercises/chapter10/test/Examples.js
@@ -6,18 +6,24 @@ exports.square = function (n) {
 };
 // ANCHOR_END: square
 
+// ANCHOR: diagonal
 exports.diagonal = function (w) {
   return function (h) {
     return Math.sqrt(w * w + h * h);
   };
 };
+// ANCHOR_END: diagonal
 
+// ANCHOR: diagonal_arrow
 exports.diagonalArrow = w => h =>
   Math.sqrt(w * w + h * h);
+// ANCHOR_END: diagonal_arrow
 
+// ANCHOR: diagonal_uncurried
 exports.diagonalUncurried = function (w, h) {
   return Math.sqrt(w * w + h * h);
 };
+// ANCHOR_END: diagonal_uncurried
 
 exports.cumulativeSums = arr => {
   let sum = 0

--- a/exercises/chapter10/test/Examples.purs
+++ b/exercises/chapter10/test/Examples.purs
@@ -14,11 +14,11 @@ import Effect.Uncurried (EffectFn2)
 
 foreign import square :: Number -> Number
 
-foreign import diagonal :: Fn2 Number Number Number
-
-foreign import diagonalNested :: Number -> Number -> Number
+foreign import diagonal :: Number -> Number -> Number
 
 foreign import diagonalArrow :: Number -> Number -> Number
+
+foreign import diagonalUncurried :: Fn2 Number Number Number
 
 uncurriedAdd :: Fn2 Int Int Int
 uncurriedAdd = mkFn2 \n m -> m + n

--- a/exercises/chapter10/test/Examples.purs
+++ b/exercises/chapter10/test/Examples.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Promise (Promise, toAffE)
 import Data.Argonaut (Json, JsonDecodeError, decodeJson, encodeJson)
 import Data.Either (Either)
-import Data.Function.Uncurried (Fn2, mkFn2)
+import Data.Function.Uncurried (Fn2, mkFn2, runFn2)
 import Data.Map (Map)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
@@ -14,17 +14,35 @@ import Effect.Uncurried (EffectFn2)
 
 foreign import square :: Number -> Number
 
+-- ANCHOR: diagonal
 foreign import diagonal :: Number -> Number -> Number
+-- ANCHOR_END: diagonal
 
+-- ANCHOR: diagonal_arrow
 foreign import diagonalArrow :: Number -> Number -> Number
+-- ANCHOR_END: diagonal_arrow
 
+-- ANCHOR: diagonal_uncurried
 foreign import diagonalUncurried :: Fn2 Number Number Number
+-- ANCHOR_END: diagonal_uncurried
 
+-- ANCHOR: uncurried_add
 uncurriedAdd :: Fn2 Int Int Int
 uncurriedAdd = mkFn2 \n m -> m + n
+-- ANCHOR_END: uncurried_add
 
+-- ANCHOR: uncurried_sum
+uncurriedSum :: Int
+uncurriedSum = runFn2 uncurriedAdd 3 10
+-- ANCHOR_END: uncurried_sum
+
+-- ANCHOR: curried_add
 curriedAdd :: Int -> Int -> Int
 curriedAdd n m = m + n
+
+curriedSum :: Int
+curriedSum = curriedAdd 3 10
+-- ANCHOR_END: curried_add
 
 foreign import cumulativeSums :: Array Int -> Array Int
 

--- a/exercises/chapter10/test/Main.purs
+++ b/exercises/chapter10/test/Main.purs
@@ -231,13 +231,13 @@ runChapterExamples =
         $ square 5.0
     test "diagonal" do
       Assert.equal 5.0
-        $ runFn2 diagonal 3.0 4.0
-    test "diagonalNested" do
-      Assert.equal 5.0
-        $ diagonalNested 3.0 4.0
+        $ diagonal 3.0 4.0
     test "diagonalArrow" do
       Assert.equal 5.0
         $ diagonalArrow 3.0 4.0
+    test "diagonalUncurried" do
+      Assert.equal 5.0
+        $ runFn2 diagonalUncurried 3.0 4.0
     test "uncurriedAdd" do
       Assert.equal 13
         $ runFn2 uncurriedAdd 3 10

--- a/exercises/chapter10/test/Main.purs
+++ b/exercises/chapter10/test/Main.purs
@@ -240,8 +240,14 @@ runChapterExamples =
         $ runFn2 diagonalUncurried 3.0 4.0
     test "uncurriedAdd" do
       Assert.equal 13
+        $ runFn2 uncurriedAdd 3 10
+    test "uncurriedSum" do
+      Assert.equal 13
         $ uncurriedSum
     test "curriedAdd" do
+      Assert.equal 13
+        $ curriedAdd 3 10
+    test "curriedSum" do
       Assert.equal 13
         $ curriedSum
     test "cumulativeSums" do

--- a/exercises/chapter10/test/Main.purs
+++ b/exercises/chapter10/test/Main.purs
@@ -240,10 +240,10 @@ runChapterExamples =
         $ runFn2 diagonalUncurried 3.0 4.0
     test "uncurriedAdd" do
       Assert.equal 13
-        $ runFn2 uncurriedAdd 3 10
+        $ uncurriedSum
     test "curriedAdd" do
       Assert.equal 13
-        $ curriedAdd 3 10
+        $ curriedSum
     test "cumulativeSums" do
       Assert.equal [ 1, 3, 6 ]
         $ cumulativeSums [ 1, 2, 3 ]

--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -103,49 +103,26 @@ $ spago repl
 
 ## Functions of Multiple Arguments
 
-Let's rewrite our `diagonal` function from Chapter 2 in a foreign module to demonstrate how to call functions of multiple arguments. Recall that this function calculates the diagonal of a right-angled triangle:
+Let's rewrite our `diagonal` function from Chapter 2 in a foreign module. This function calculates the diagonal of a right-angled triangle.
 
-```js
-exports.diagonal = function(w, h) {
-  return Math.sqrt(w * w + h * h);
-};
-```
-
-Because PureScript uses curried functions of *single arguments*, we cannot directly import the `diagonal` function of *two arguments* like so:
 
 ```hs
--- This will not work with above uncurried definition of diagonal
 foreign import diagonal :: Number -> Number -> Number
 ```
 
-However, there are a few solutions to this dilemma:
+Recall that functions in PureScript are _curried_. `diagonal` is a function that takes a `Number` and returns a _function_, that takes a `Number` and returns a `Number`.
 
-The first option is to import and run the function with an `Fn` wrapper from `Data.Function.Uncurried` (`Fn` and uncurried functions are discussed in more detail later):
-
-```hs
-foreign import diagonal :: Fn2 Number Number Number
-```
-
-```text
-$ spago repl
-
-> import Test.Examples
-> import Data.Function.Uncurried
-> runFn2 diagonal 3.0 4.0
-5.0
-```
-
-The second option is to wrap or rewrite the function as curried JavaScript:
 
 ```js
-exports.diagonalNested = function(w) {
-  return function (h) {
+exports.diagonal = function(w) {
+  return function(h) {
     return Math.sqrt(w * w + h * h);
-  };
+  }
 };
 ```
 
-or equivalently with arrow functions (see ES6 note below):
+Or with ES6 arrow syntax (see ES6 note below).
+
 
 ```js
 exports.diagonalArrow = w => h =>
@@ -153,52 +130,75 @@ exports.diagonalArrow = w => h =>
 ```
 
 ```hs
-foreign import diagonalNested :: Number -> Number -> Number
-foreign import diagonalArrow  :: Number -> Number -> Number
+foreign import diagonalArrow :: Number -> Number -> Number
 ```
 
 ```text
 $ spago repl
 
 > import Test.Examples
-> diagonalNested 3.0 4.0
+> diagonal 3.0 4.0
 5.0
 > diagonalArrow 3.0 4.0
 5.0
 ```
 
-## A Note About Uncurried Functions
+## Uncurried Functions
 
-PureScript's Prelude contains an interesting set of examples of foreign types. As we have covered already, PureScript's function types only take a single argument, and can be used to simulate functions of multiple arguments via _currying_. This has certain advantages - we can partially apply functions, and give type class instances for function types - but it comes with a performance penalty. For performance critical code, it is sometimes necessary to define genuine JavaScript functions which accept multiple arguments. The Prelude defines foreign types which allow us to work safely with such functions.
+Writing curried functions in JavaScript isn't always feasible, despite being scarcely idiomatic. A typical multi-argument JavaScript function would be of the _uncurried_ form:
 
-For example, the following foreign type declaration is taken from the `Data.Function.Uncurried` module:
-
-```haskell
-foreign import data Fn2 :: Type -> Type -> Type -> Type
+```js
+exports.diagonalUncurried = function(w, h) {
+  return Math.sqrt(w * w + h * h);
+}
 ```
 
-This defines the type constructor `Fn2` which takes three type arguments. `Fn2 a b c` is a type representing JavaScript functions of two arguments of types `a` and `b`, and with return type `c`.
+The module `Data.Function.Uncurried` exports _wrapper_ types and utility functions to work with uncurried functions.
 
-The `functions` package defines similar type constructors for function arities from 0 to 10.
-
-We can create a function of two arguments by using the `mkFn2` function, as follows:
-
-```haskell
-import Data.Function.Uncurried
-
-uncurriedAdd :: Fn2 Int Int Int
-uncurriedAdd = mkFn2 \n m -> m + n
+```hs
+foreign import diagonalUncurried :: Fn2 Number Number Number
 ```
 
-and we can apply a function of two arguments by using the `runFn2` function:
+Inspecting the type constructor `Fn2`:
+
+```text
+$ spago repl
+
+> import Data.Function.Uncurried 
+> :kind Fn2
+Type -> Type -> Type -> Type
+```
+
+`Fn2` takes three type arguments. `Fn2 a b c` is a type representing an uncurried function of two arguments of types `a` and `b`, that returns a value of type `c`. We used it to import `diagonalUncurried` from the foriegn module.
+
+We can then call it with `runFn2` which takes the uncurried function then the arguments.
 
 ```text
 $ spago repl
 
 > import Test.Examples
 > import Data.Function.Uncurried
-> runFn2 uncurriedAdd 3 10
-13
+> runFn2 diagonalUncurried 3.0 4.0
+5.0
+```
+
+The `functions` package defines similar type constructors for function arities from 0 to 10.
+
+## A Note About Uncurried Functions
+
+PureScript's curried functions has certain advantages. It allows us to partially apply functions, and to give type class instances for function types - but it comes with a performance penalty. For performance critical code, it is sometimes necessary to define uncurried JavaScript functions which accept multiple arguments.
+
+We can also create uncurried functions from PureScript. For a function of two arguments, we can use the `mkFn2` function.
+
+```haskell
+uncurriedAdd :: Fn2 Int Int Int
+uncurriedAdd = mkFn2 \n m -> m + n
+```
+
+We can apply the uncurried function of two arguments by using `runFn2` as before:
+
+```haskell
+uncurriedSum = runFn2 uncurriedAdd 3 10
 ```
 
 The key here is that the compiler _inlines_ the `mkFn2` and `runFn2` functions whenever they are fully applied. The result is that the generated code is very compact:
@@ -207,6 +207,8 @@ The key here is that the compiler _inlines_ the `mkFn2` and `runFn2` functions w
 var uncurriedAdd = function (n, m) {
   return m + n | 0;
 };
+
+var uncurriedSum = uncurriedAdd(3, 10);
 ```
 
 For contrast, here is a traditional curried function:
@@ -214,6 +216,8 @@ For contrast, here is a traditional curried function:
 ```haskell
 curriedAdd :: Int -> Int -> Int
 curriedAdd n m = m + n
+
+curriedSum = curriedAdd 3 10
 ```
 
 and the resulting generated code, which is less compact due to the nested functions:
@@ -224,6 +228,8 @@ var curriedAdd = function (n) {
     return m + n | 0;
   };
 };
+
+var curriedSum = curriedAdd(3)(10);
 ```
 
 ## A Note About Modern JavaScript Syntax

--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -107,30 +107,25 @@ Let's rewrite our `diagonal` function from Chapter 2 in a foreign module. This f
 
 
 ```hs
-foreign import diagonal :: Number -> Number -> Number
+{{#include ../exercises/chapter10/test/Examples.purs:diagonal}}
 ```
 
 Recall that functions in PureScript are _curried_. `diagonal` is a function that takes a `Number` and returns a _function_, that takes a `Number` and returns a `Number`.
 
 
 ```js
-exports.diagonal = function(w) {
-  return function(h) {
-    return Math.sqrt(w * w + h * h);
-  }
-};
+{{#include ../exercises/chapter10/test/Examples.js:diagonal}}
 ```
 
 Or with ES6 arrow syntax (see ES6 note below).
 
 
 ```js
-exports.diagonalArrow = w => h =>
-  Math.sqrt(w * w + h * h);
+{{#include ../exercises/chapter10/test/Examples.js:diagonal_arrow}}
 ```
 
 ```hs
-foreign import diagonalArrow :: Number -> Number -> Number
+{{#include ../exercises/chapter10/test/Examples.purs:diagonal_arrow}}
 ```
 
 ```text
@@ -148,15 +143,13 @@ $ spago repl
 Writing curried functions in JavaScript isn't always feasible, despite being scarcely idiomatic. A typical multi-argument JavaScript function would be of the _uncurried_ form:
 
 ```js
-exports.diagonalUncurried = function(w, h) {
-  return Math.sqrt(w * w + h * h);
-}
+{{#include ../exercises/chapter10/test/Examples.js:diagonal_uncurried}}
 ```
 
 The module `Data.Function.Uncurried` exports _wrapper_ types and utility functions to work with uncurried functions.
 
 ```hs
-foreign import diagonalUncurried :: Fn2 Number Number Number
+{{#include ../exercises/chapter10/test/Examples.purs:diagonal_uncurried}}
 ```
 
 Inspecting the type constructor `Fn2`:
@@ -191,14 +184,13 @@ PureScript's curried functions has certain advantages. It allows us to partially
 We can also create uncurried functions from PureScript. For a function of two arguments, we can use the `mkFn2` function.
 
 ```haskell
-uncurriedAdd :: Fn2 Int Int Int
-uncurriedAdd = mkFn2 \n m -> m + n
+{{#include ../exercises/chapter10/test/Examples.purs:uncurried_add}}
 ```
 
 We can apply the uncurried function of two arguments by using `runFn2` as before:
 
 ```haskell
-uncurriedSum = runFn2 uncurriedAdd 3 10
+{{#include ../exercises/chapter10/test/Examples.purs:uncurried_sum}}
 ```
 
 The key here is that the compiler _inlines_ the `mkFn2` and `runFn2` functions whenever they are fully applied. The result is that the generated code is very compact:
@@ -214,10 +206,7 @@ var uncurriedSum = uncurriedAdd(3, 10);
 For contrast, here is a traditional curried function:
 
 ```haskell
-curriedAdd :: Int -> Int -> Int
-curriedAdd n m = m + n
-
-curriedSum = curriedAdd 3 10
+{{#include ../exercises/chapter10/test/Examples.purs:curried_add}}
 ```
 
 and the resulting generated code, which is less compact due to the nested functions:


### PR DESCRIPTION
  - Curried functions are explained first. Use of `Fn2` is more involved and is easier to make sense of once curried JavaScript functions are out of the way.
  - Rewrite use of `Fn2`. Make new section: Uncurried Functions.
  - Note about uncurried functions norrowed down to code generation. Detials of `Fn2` moved to previous section.
  - Include generated code of `runFn2`.
  - Fix example code to match text
  - Replace code snippets with {{#include...}}