### PR TITLE
add in anchors for chapter 11

### DIFF
--- a/exercises/chapter11/src/Data/GameEnvironment.purs
+++ b/exercises/chapter11/src/Data/GameEnvironment.purs
@@ -1,11 +1,13 @@
 module Data.GameEnvironment where
 
+-- ANCHOR: env
 type PlayerName = String
 
 newtype GameEnvironment = GameEnvironment
   { playerName    :: PlayerName
   , debugMode     :: Boolean
   }
+-- ANCHOR_END: env
 
 gameEnvironment :: PlayerName -> Boolean -> GameEnvironment
 gameEnvironment playerName debugMode = GameEnvironment

--- a/exercises/chapter11/src/Data/GameItem.purs
+++ b/exercises/chapter11/src/Data/GameItem.purs
@@ -4,7 +4,9 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 
+-- ANCHOR: GameItem
 data GameItem = Candle | Matches
+-- ANCHOR_END: GameItem
 
 instance showGameItem :: Show GameItem where
   show Candle         = "Candle"

--- a/exercises/chapter11/src/Data/GameState.purs
+++ b/exercises/chapter11/src/Data/GameState.purs
@@ -4,15 +4,19 @@ import Prelude
 
 import Data.Coords (Coords(..), coords)
 import Data.GameItem (GameItem(..))
+-- ANCHOR: imports
 import Data.Map as M
 import Data.Set as S
+-- ANCHOR_END: imports
 import Data.Tuple (Tuple(..))
 
+-- ANCHOR: GameState
 newtype GameState = GameState
   { items       :: M.Map Coords (S.Set GameItem)
   , player      :: Coords
   , inventory   :: S.Set GameItem
   }
+-- ANCHOR_END: GameState
 
 instance showGameState :: Show GameState where
   show (GameState o) =

--- a/exercises/chapter11/src/Main.purs
+++ b/exercises/chapter11/src/Main.purs
@@ -11,16 +11,25 @@ import Data.String (split)
 import Effect (Effect)
 import Effect.Console (log)
 import Game (game)
+-- ANCHOR: import_RL
 import Node.ReadLine as RL
+-- ANCHOR_END: import_RL
 import Options.Applicative ((<**>))
 import Options.Applicative as OP
 
+-- ANCHOR: runGame_sig
 runGame :: GameEnvironment -> Effect Unit
+-- ANCHOR_END: runGame_sig
+-- ANCHOR: runGame_interface
 runGame env = do
   interface <- RL.createConsoleInterface RL.noCompletion
+-- ANCHOR_END: runGame_interface
+-- ANCHOR: runGame_prompt
   RL.setPrompt "> " interface
+-- ANCHOR_END: runGame_prompt
 
   let
+-- ANCHOR: runGame_lineHandler
     lineHandler :: GameState -> String -> Effect Unit
     lineHandler currentState input = do
       case runRWS (game (split (wrap " ") input)) env currentState of
@@ -29,9 +38,12 @@ runGame env = do
           RL.setLineHandler (lineHandler state) $ interface
       RL.prompt interface
       pure unit
+-- ANCHOR_END: runGame_lineHandler
 
+-- ANCHOR: runGame_attach_handler
   RL.setLineHandler (lineHandler initialGameState) interface
   RL.prompt interface
+-- ANCHOR_END: runGame_attach_handler
 
   pure unit
 

--- a/exercises/chapter11/src/Split.purs
+++ b/exercises/chapter11/src/Split.purs
@@ -18,6 +18,7 @@ type Log = Array String
 
 type Parser = StateT String (WriterT Log (ExceptT Errors Identity))
 
+-- ANCHOR: split
 split :: Parser String
 split = do
   s <- get
@@ -25,8 +26,9 @@ split = do
   case s of
     "" -> throwError ["Empty string"]
     _ -> do
-     put (drop 1 s)
-     pure (take 1 s)
+      put (drop 1 s)
+      pure (take 1 s)
+-- ANCHOR_END: split
 
 eof :: Parser Unit
 eof = do
@@ -36,17 +38,21 @@ eof = do
     "" -> pure unit
     _ -> throwError ["Expected end-of-file"]
 
+-- ANCHOR: upper
 upper :: Parser String
 upper = do
   s <- split
   guard $ toUpper s == s
   pure s
+-- ANCHOR_END: upper
 
+-- ANCHOR: lower
 lower :: Parser String
 lower = do
   s <- split
   guard $ toLower s == s
   pure s
+-- ANCHOR_END: lower
 
 runParser :: forall a. Parser a -> String -> Either Errors (Tuple (Tuple a String) Log)
 runParser p = runExcept <<< runWriterT <<< runStateT p


### PR DESCRIPTION
Follows up #90. (Sorry forgot to link to 90 in other anchor PRs that I've done).

I also removed references to `MonadZero`. 

I've noticed that in some chapters, as a function is improved through multiple implementations, all of the different iterations exist in the source code with slightly different names.  In other chapters, only the final implementation exists in the source code, and prior iterations only exist in the .md text.  This chapter has such a function (`split`), and only the final implementation exists in the source.  Let me know if it would be better to have each successive implementation represented.