### PR TITLE
Add a couple extra tests for chapter 11

### DIFF
--- a/exercises/chapter11/src/Data/GameState.purs
+++ b/exercises/chapter11/src/Data/GameState.purs
@@ -22,6 +22,8 @@ instance showGameState :: Show GameState where
     ", inventory: " <> show o.inventory <>
     " }"
 
+derive instance eqGameState :: Eq GameState
+
 initialGameState :: GameState
 initialGameState = GameState
   { items      : M.fromFoldable [ Tuple (coords 0 1) (S.singleton Candle)

--- a/exercises/chapter11/test/Main.purs
+++ b/exercises/chapter11/test/Main.purs
@@ -2,7 +2,7 @@ module Test.Main where
 
 import Prelude (Unit, discard, negate, ($), (*>), (<>), (==))
 import Test.MySolutions
-import Game 
+import Game
 import Test.NoPeeking.Solutions  -- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.
 
 import Control.Monad.Except (runExceptT)
@@ -150,28 +150,29 @@ This line should have been automatically deleted by resetSolutions.sh. See Chapt
         runGame testGame = runRWS testGame env initialGameState
         env = GameEnvironment { debugMode: false, playerName: "Phil" }
 
-        playerHasAllItems inventory = inventory == S.fromFoldable [Candle, Matches]  
+        playerHasAllItems (GameState {inventory}) = inventory == S.fromFoldable [Candle, Matches]  
+        mapIsEmpty (GameState {items}) = M.isEmpty items
         expectedLogs = ("You now have the Candle" : "You now have the Matches" : L.Nil)
 
       test "adds all items to your inventory when cheating" do 
-        let (RWSResult (GameState actualState) _ log) = runGame cheat 
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState.inventory
-        Assert.assert "Expected map to no longer have any items" $ M.isEmpty actualState.items
+        let (RWSResult actualState _ log) = runGame cheat 
+        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
+        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
         Assert.equal expectedLogs $ L.sort log
 
-        let (RWSResult (GameState actualState) _ log) = runGame (move 0 (-1) *> move 0 1 *> cheat)
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState.inventory
-        Assert.assert "Expected map to no longer have any items" $ M.isEmpty actualState.items
+        let (RWSResult actualState _ log) = runGame (move 0 (-1) *> move 0 1 *> cheat)
+        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
+        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
         Assert.equal expectedLogs $ L.sort log
 
-        let (RWSResult (GameState actualState) _ log) = runGame (pickUp Matches *> cheat)
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState.inventory
-        Assert.assert "Expected map to no longer have any items" $ M.isEmpty actualState.items
+        let (RWSResult actualState _ log) = runGame (pickUp Matches *> cheat)
+        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
+        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
         Assert.equal expectedLogs $ L.sort log
 
-        let (RWSResult (GameState actualState) _ log) = runGame (pickUp Matches *> move 0 1 *> pickUp Candle *> move 0 (-1) *> cheat)
-        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState.inventory
-        Assert.assert "Expected map to no longer have any items" $ M.isEmpty actualState.items
+        let (RWSResult actualState _ log) = runGame (pickUp Matches *> move 0 1 *> pickUp Candle *> cheat)
+        Assert.assert "Expected player to have both Candle and Matches" $ playerHasAllItems actualState
+        Assert.assert "Expected map to no longer have any items" $ mapIsEmpty actualState
         Assert.equal expectedLogs $ L.sort log
 
 {- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.

--- a/exercises/chapter11/test/Main.purs
+++ b/exercises/chapter11/test/Main.purs
@@ -1,18 +1,27 @@
 module Test.Main where
 
-import Prelude (Unit, discard, ($), (<>))
-
+import Prelude (Unit, discard, negate, ($), (*>), (<>))
 import Test.MySolutions
 import Test.NoPeeking.Solutions  -- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.
 
-import Effect (Effect)
-import Control.Monad.Writer (runWriterT, execWriter)
 import Control.Monad.Except (runExceptT)
+import Control.Monad.RWS (RWSResult(..), runRWS)
 import Control.Monad.State (runStateT)
+import Control.Monad.Writer (runWriterT, execWriter)
+import Data.Coords (Coords(..))
 import Data.Either (Either(..))
+import Data.GameEnvironment (GameEnvironment(..))
+import Data.GameItem (GameItem(..))
+import Data.GameState (GameState(..), initialGameState)
+import Data.List (List, (:))
+import Data.List as L
+import Data.Map as M
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (unwrap)
+import Data.Set as S
 import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Game (Game, move, pickUp)
 import Test.Unit (TestSuite, success, suite, test)
 import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
@@ -76,6 +85,12 @@ This line should have been automatically deleted by resetSolutions.sh. See Chapt
           Assert.equal expected_15
             $ collatz 15
     suite "Exercises Group - Monad Transformers" do
+      suite "safeDivide" do
+        test "should fail when dividing by zero" do
+          Assert.equal (Left "Divide by zero!") 
+            $ unwrap $ runExceptT $ safeDivide 5 0 
+        test "should successfully divide for any other input" do 
+          Assert.equal (Right 2) $ unwrap $ runExceptT $ safeDivide 6 3 
       suite "parser" do
         let
           runParser p s = unwrap $ runExceptT $ runWriterT $ runStateT p s
@@ -129,5 +144,37 @@ This line should have been automatically deleted by resetSolutions.sh. See Chapt
         test "should fail if first is not a or b" do
           Assert.equal (Left ["Could not parse","Could not parse"])
             $ runParser asOrBs "foobar"
+
+    suite "Exercises Group - The RWS Monad" do
+      let 
+        runGame :: Game Unit -> RWSResult GameState Unit (List String)
+        runGame testGame = runRWS testGame env initialGameState
+        env = GameEnvironment { debugMode: false, playerName: "Phil" }
+
+        expectedCheaterState = GameState 
+          { inventory: S.fromFoldable [Candle, Matches] 
+          , items: M.empty
+          , player: Coords { x: 0, y: 0 } 
+          }
+
+        expectedLogs = ("You now have the Candle" : "You now have the Matches" : L.Nil)
+
+      test "adds all items to your inventory when cheating" do 
+        let (RWSResult actualState _ log) = runGame cheat 
+        Assert.equal expectedCheaterState actualState
+        Assert.equal expectedLogs $ L.sort log
+
+        let (RWSResult actualState _ log) = runGame (move 0 (-1) *> move 0 1 *> cheat)
+        Assert.equal expectedCheaterState actualState
+        Assert.equal expectedLogs $ L.sort log
+
+        let (RWSResult actualState _ log) = runGame (pickUp Matches *> cheat)
+        Assert.equal expectedCheaterState actualState
+        Assert.equal expectedLogs $ L.sort log
+
+        let (RWSResult actualState _ log) = runGame (pickUp Matches *> move 0 1 *> pickUp Candle *> move 0 (-1) *> cheat)
+        Assert.equal expectedCheaterState actualState
+        Assert.equal expectedLogs $ L.sort log
+
 {- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.
 -}

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -965,7 +965,7 @@ The `runGame` function finally attaches the initial line handler to the console 
 
  ## Exercises
 
- 1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory. Create a function `cheat :: RWS GameEnvironment (L.List String) GameState Unit` in the `MySolutions` module, and use this function from `game`.
+ 1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory. Create a function `cheat :: Game Unit` in the `Game` module, and use this function from `game`.
  1. (Difficult) The `Writer` component of the `RWS` monad is currently used for two types of messages: error messages and informational messages. Because of this, several parts of the code use case statements to handle error cases.
 
      Refactor the code to use the `ExceptT` monad transformer to handle the error messages, and `RWS` to handle informational messages. _Note:_ There are no tests for this exercise.

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -545,7 +545,7 @@ Fortunately, as we will see, we can use the automatic code generation provided b
 
  ## Exercises
 
- 1. (Easy) Use the `ExceptT` monad transformer over the `Identity` functor to write a function `safeDivide` which divides two numbers, throwing an error if the denominator is zero.
+ 1. (Easy) Use the `ExceptT` monad transformer over the `Identity` functor to write a function `safeDivide` which divides two numbers, throwing an error (as the String "Divide by zero!") if the denominator is zero.
  1. (Medium) Write a parser
 
      ```haskell
@@ -564,7 +564,7 @@ Fortunately, as we will see, we can use the automatic code generation provided b
      _Hint_: you can use the implementation of `split` as a starting point. You might find the `stripPrefix` function useful.
  1. (Difficult) Use the `ReaderT` and `WriterT` monad transformers to reimplement the document printing library which we wrote earlier using the `Reader` monad.
 
-     Instead of using `line` to emit strings and `cat` to concatenate strings, use the `Array String` monoid with the `WriterT` monad transformer, and `tell` to append a line to the result.
+     Instead of using `line` to emit strings and `cat` to concatenate strings, use the `Array String` monoid with the `WriterT` monad transformer, and `tell` to append a line to the result. Use the same names as in the original implementation but ending with an apostrophe (`'`).
 
 ## Type Classes to the Rescue!
 
@@ -731,7 +731,7 @@ Again, this illustrates the power of reusability that monad transformers bring -
  ## Exercises
 
  1. (Easy) Remove the calls to the `lift` function from your implementation of the `string` parser. Verify that the new implementation type checks, and convince yourself that it should.
- 1. (Medium) Use your `string` parser with the `many` combinator to write a parser `asFollowedByBs` which recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
+ 1. (Medium) Use your `string` parser with the `some` combinator to write a parser `asFollowedByBs` which recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
  1. (Medium) Use the `<|>` operator to write a parser `asOrBs` which recognizes strings of the letters `a` or `b` in any order.
  1. (Difficult) The `Parser` monad might also be defined as follows:
 
@@ -965,10 +965,10 @@ The `runGame` function finally attaches the initial line handler to the console 
 
  ## Exercises
 
- 1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory.
+ 1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory. Create a function `cheat :: RWS GameEnvironment (L.List String) GameState Unit` in the `MySolutions` module, and use this function from `game`.
  1. (Difficult) The `Writer` component of the `RWS` monad is currently used for two types of messages: error messages and informational messages. Because of this, several parts of the code use case statements to handle error cases.
 
-     Refactor the code to use the `ExceptT` monad transformer to handle the error messages, and `RWS` to handle informational messages.
+     Refactor the code to use the `ExceptT` monad transformer to handle the error messages, and `RWS` to handle informational messages. _Note:_ There are no tests for this exercise.
 
 ## Handling Command Line Options
 


### PR DESCRIPTION
I'm proposing we add a test for the `cheat` functionality (well, and the `safeDivide` function). In order to make it testable though, I had to make a questionable design decision, so I wanted to throw it out there for consideration/discussion on if it's worth it.  The issue is that to be testable the `cheat` function needs to be defined in MySolutions.purs, but `cheat` would normally be `:: Game Unit`.  `Game` is defined in Game.purs, along with `game`, the function that would use `cheat`.  So we get a circular reference if MySolutions.purs is trying to reference the type `Game` but Game.purs is trying to reference `cheat :: Game Unit`.  Now since `Game` is just an alias, MySolutions.purs can just use the full type instead of the `Game` alias and break the literal dependency on Game.purs, but of course that would be a terrible solution in practice.  In my opinion, it's worth it to be able to add a test for the user for their `cheat` function (possibly with an added explanation that in a real application, `cheat` should be defined in Game.purs?), but that's up for debate. 

Another solution could be to move `type Game` somewhere else that could be referenced by both MySolutions.purs and Game.purs. That also seems undesirable though. 

Feel free to close this PR if it does not seem worth it to have the user build `cheat` in MySolutions.purs instead of in Game.purs where it actually belongs. 