### PR TITLE
Ch11 fixup to remove unused eqGameState

### DIFF
--- a/exercises/chapter11/src/Data/GameState.purs
+++ b/exercises/chapter11/src/Data/GameState.purs
@@ -22,8 +22,6 @@ instance showGameState :: Show GameState where
     ", inventory: " <> show o.inventory <>
     " }"
 
-derive instance eqGameState :: Eq GameState
-
 initialGameState :: GameState
 initialGameState = GameState
   { items      : M.fromFoldable [ Tuple (coords 0 1) (S.singleton Candle)


### PR DESCRIPTION
This instance slipped-in as part of #386, but is unnecessary now.