### PR TITLE
Refactor Ch6 actionMultiplyInt to generalize the operation

### DIFF
--- a/exercises/chapter6/test/no-peeking/Solutions.purs
+++ b/exercises/chapter6/test/no-peeking/Solutions.purs
@@ -198,16 +198,23 @@ instance monoidMultiply :: Monoid Multiply where
   mempty = Multiply 1
 
 instance actionMultiplyInt :: Action Multiply Int where
-  act (Multiply n) m = n * m
+  act (Multiply n) 1 = n
+  act m1 a           = act (m1 <> Multiply a) 1
 
 {-
 -- Alternative solution #1
+instance actionMultiplyInt :: Action Multiply Int where
+  act (Multiply n) m = n * m
+-}
+
+{-
+-- Alternative solution #2
 instance actionMultiplyInt :: Action Multiply Int where
   act (Multiply n) m = m / n
 -}
 
 {-
--- Alternative solution #2
+-- Alternative solution #3
 -- The module `Data.Int` is from the package `integers`.
 -- You can run `spago install integers` to use it.
 import Data.Int (pow)

--- a/exercises/chapter6/test/no-peeking/Solutions.purs
+++ b/exercises/chapter6/test/no-peeking/Solutions.purs
@@ -198,29 +198,29 @@ instance monoidMultiply :: Monoid Multiply where
   mempty = Multiply 1
 
 instance actionMultiplyInt :: Action Multiply Int where
-  act (Multiply n) 1 = n
-  act m1 a           = act (m1 <> Multiply a) 1
+  act (Multiply n) m = n * m
 
 {-
 -- Alternative solution #1
-instance actionMultiplyInt :: Action Multiply Int where
-  act (Multiply n) m = n * m
--}
-
-{-
--- Alternative solution #2
 instance actionMultiplyInt :: Action Multiply Int where
   act (Multiply n) m = m / n
 -}
 
 {-
--- Alternative solution #3
+-- Alternative solution #2
 -- The module `Data.Int` is from the package `integers`.
 -- You can run `spago install integers` to use it.
 import Data.Int (pow)
 
 instance actionMultiplyInt :: Action Multiply Int where
   act (Multiply n) m = pow m n
+-}
+
+{-
+-- Alternative solution #3
+instance actionMultiplyInt :: Action Multiply Int where
+  act (Multiply n) 1 = n
+  act m1 a           = act (m1 <> Multiply a) 1
 -}
 
 {-

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -651,7 +651,7 @@ Another reason to define a superclass relationship is in the case where there is
      
      Remember, your instance must satisfy the laws listed above.
 
-1. (Difficult) There are actually multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of a same instance, so you will have to replace your original implementation. _Note_: the tests cover 3 implementations.
+1. (Difficult) There are actually multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of a same instance, so you will have to replace your original implementation. _Note_: the tests cover 4 implementations.
 
 1. (Medium) Write an `Action` instance which repeats an input string some number of times:
 


### PR DESCRIPTION
Instead of doing math operation inside the act function, use the Semigroup instance of Multiply to do that. This way if one changes the instance operation, there are no side-effects.