### PR TITLE
[Ch8] Make one-liner for `ctr` less gross

### DIFF
--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -751,7 +751,9 @@ ctr <- getElementById "container" $ toNonElementParentNode doc
 Or consolidated even further to:
 
 ```hs
-ctr <- getElementById "container" =<< (map toNonElementParentNode $ document =<< window)
+ctr <- getElementById "container" <<< toNonElementParentNode =<< document =<< window
+-- or, equivalently:
+ctr <- window >>= document >>= toNonElementParentNode >>> getElementById "container"
 ```
 
 It is a matter of personal preference whether the intermediate `w` and `doc` variables aid in readability.


### PR DESCRIPTION
The original (for my reference) is:

```hs
ctr <- getElementById "container" =<< (map toNonElementParentNode $ document =<< window)
```

This almost seems purposefully designed to discourage `do`-avoidance. I don't have a horse in the race really, but a less-ugly version seems more objective. Some parens in my proposal would probably make things more clear to a beginner too.