### PR TITLE
FIx: test-unit version not compatible with latest spago on chapter 3 

### DIFF
--- a/exercises/chapter3/test/Main.purs
+++ b/exercises/chapter3/test/Main.purs
@@ -2,7 +2,7 @@ module Test.Main where
 
 import Prelude
 import Test.MySolutions
-import Test.NoPeeking.Solutions  -- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.
+-- import Test.NoPeeking.Solutions  -- This line should have been automatically deleted by resetSolutions.sh. See Chapter 2 for instructions.
 import Data.AddressBook (AddressBook, Entry, emptyBook, findEntry, insertEntry)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)

--- a/exercises/chapter3/test/MySolutions.purs
+++ b/exercises/chapter3/test/MySolutions.purs
@@ -1,5 +1,38 @@
-module Test.MySolutions where
+module Test.MySolutions  where
 
 import Prelude
-
+import Data.AddressBook (AddressBook,Entry)
+import Data.List (filter,head,null,nubByEq)
+import Data.Maybe (Maybe)
 -- Note to reader: Add your solutions to this file
+
+findEntryByStreet :: String -> AddressBook -> Maybe Entry
+findEntryByStreet street addressBook = head (filter filterEntry addressBook)
+  where
+    filterEntry :: Entry -> Boolean
+    filterEntry entry = entry.address.street == street
+
+findEntryByStreet2 :: String -> AddressBook -> Maybe Entry
+findEntryByStreet2 street = 
+  filter (_.address.street >>> eq street) 
+  >>> head
+
+isInBook :: String -> String -> AddressBook -> Boolean
+isInBook firstName lastName = 
+  filter filterFirstName 
+  >>> filter filterLastName 
+  >>> null 
+  >>> not
+  where 
+    filterFirstName :: Entry -> Boolean
+    filterFirstName = _.firstName >>> eq firstName
+
+    filterLastName :: Entry -> Boolean
+    filterLastName = _.lastName >>> eq lastName
+
+removeDuplicates :: AddressBook -> AddressBook
+removeDuplicates = 
+  nubByEq filterByName
+  where
+    filterByName :: Entry -> Entry -> Boolean
+    filterByName entry1 entry2 = entry1.firstName == entry2.firstName && entry1.lastName == entry2.lastName

--- a/exercises/chapter4/test/Main.purs
+++ b/exercises/chapter4/test/Main.purs
@@ -1,4 +1,8 @@
-module Test.Main where
+module Test.Main
+  ( allFileAndDirectoryNames
+  , runChapterExamples
+  )
+  where
 
 import Prelude
 import Test.Examples

--- a/exercises/chapter4/test/MySolutions.purs
+++ b/exercises/chapter4/test/MySolutions.purs
@@ -1,5 +1,24 @@
 module Test.MySolutions where
 
 import Prelude
+import Data.Array (head,tail,null)
+import Data.Maybe (fromMaybe)
 
 -- Note to reader: Add your solutions to this file
+-- isEven :: Int -> Boolean
+-- isEven n =
+--   if n == 0 then
+--     true
+--   else
+--     not isEven(n - 1)
+
+-- countEven :: Array Int -> Int
+-- countEven arr =
+--   if null arr then
+--     0
+--   else
+--     (boolToInt $ isEven $ fromMaybe 0 $ head arr) + countEven(fromMaybe [] $ tail arr)
+--   where
+--     boolToInt :: Boolean -> Int
+--     boolToInt x = if x then 1 else 0
+    


### PR DESCRIPTION
TLDR; this PR includes the dependency bump-up.

Hi, I'm new to the purescript world and trying some examples on the purescript-book website. Unfortunately, while I was installing these exercises, I got an issue that the version from a week ago couldn't execute on my machine. The problem was from chapter 3, as below.

```
❯ spago test
[1 of 7] Compiling Test.Unit.Console
Error found:
at .spago/test-unit/stackless-default/src/Test/Unit/Console.purs:1:1 - 32:50 (line 1, column 1 - line 32, column 50)

  A CommonJS foreign module implementation was provided for module Test.Unit.Console:

    .spago/test-unit/stackless-default/src/Test/Unit/Console.js

  CommonJS foreign modules are no longer supported. Use native JavaScript/ECMAScript module syntax instead.


See https://github.com/purescript/documentation/blob/master/errors/DeprecatedFFICommonJSModule.md for more information,
or to contribute content related to this error.


[error] Failed to build.
```

Luckily, I found a [discussion thread](https://discourse.purescript.org/t/after-upgrading-to-purs-spago-to-0-15-i-get-error-a-commonjs-foreign-module-implementation-was-provided/3001/4) talking about this issue, and a fixed version of the [equivalent repo](https://github.com/bodil/purescript-test-unit.git) (actually, this seems the original package that this repository supposed to have). 
