### PR TITLE
Introduce markdownlint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install NPM dependencies
-        run: npm install purescript spago
+        run: npm install purescript spago markdownlint-cli
 
       - name: Run Build
         run: ./scripts/buildAll.sh
@@ -60,3 +60,6 @@ jobs:
 
       - name: Run tests again
         run: ./scripts/testAll.sh
+
+      - name: Run Markdown lint
+        run: npx markdownlint **/*.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "line-length": false,
+  "no-duplicate-heading": false,
+  "no-trailing-punctuation": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "line-length": false,
   "no-duplicate-heading": false,
-  "no-trailing-punctuation": false
+  "no-trailing-punctuation": false,
+  "commands-show-output": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,15 @@
+# Contributing
+
 Please open PRs or Issues if you find anything to improve in the book.
 
 We appreciate your feedback.
 
-### Editing chapter text:
+## Editing chapter text
 
 To test changes to the text locally, install [mdbook](https://github.com/rust-lang/mdBook), then run this command from repo root:
 
 ```sh
 mdbook serve -o
 ```
+
 The rendered webpage will automatically refresh with any changes to readme files.

--- a/text/SUMMARY.md
+++ b/text/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Foreword](../README.md)
+
 * [Introduction](chapter1.md)
 * [Getting Started](chapter2.md)
 * [Functions and Records](chapter3.md)

--- a/text/chapter1.md
+++ b/text/chapter1.md
@@ -115,7 +115,7 @@ main = log "Hello, World!"
 Commands which should be typed at the command line will be preceded by a dollar symbol:
 
 ```text
-$ spago build
+spago build
 ```
 
 Usually, these commands will be tailored to Linux/Mac OS users, so Windows users may need to make small changes such as modifying the file separator, or replacing shell built-ins with their Windows equivalents.

--- a/text/chapter1.md
+++ b/text/chapter1.md
@@ -115,7 +115,7 @@ main = log "Hello, World!"
 Commands which should be typed at the command line will be preceded by a dollar symbol:
 
 ```text
-spago build
+$ spago build
 ```
 
 Usually, these commands will be tailored to Linux/Mac OS users, so Windows users may need to make small changes such as modifying the file separator, or replacing shell built-ins with their Windows equivalents.

--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -106,20 +106,17 @@ $ spago repl
 
 Let's rewrite our `diagonal` function from Chapter 2 in a foreign module. This function calculates the diagonal of a right-angled triangle.
 
-
 ```hs
 {{#include ../exercises/chapter10/test/Examples.purs:diagonal}}
 ```
 
 Recall that functions in PureScript are _curried_. `diagonal` is a function that takes a `Number` and returns a _function_, that takes a `Number` and returns a `Number`.
 
-
 ```js
 {{#include ../exercises/chapter10/test/Examples.js:diagonal}}
 ```
 
 Or with ES6 arrow syntax (see ES6 note below).
-
 
 ```js
 {{#include ../exercises/chapter10/test/Examples.js:diagonal_arrow}}
@@ -403,7 +400,7 @@ which returns `Just 1000` for any array input.
 This vulnerability is allowed because `(\_ -> Just 1000)` and `Just 1000` match the signatures of `(a -> Maybe a)` and `Maybe a` respectively when `a` is `Int` (based on input array).
 
 In the more secure type signature, even when `a` is determined to be `Int` based on the input array, we still need to provide valid functions matching the signatures involving `forall x`.
-The *only* option for `(forall x. Maybe x)` is `Nothing`, since a `Just` value would assume a type for `x` and will no longer be valid for all `x`. The only options for `(forall x. x -> Maybe x)` are `Just` (our desired argument) and `(\_ -> Nothing)`, which is the only remaining vulnerability.
+The _only_ option for `(forall x. Maybe x)` is `Nothing`, since a `Just` value would assume a type for `x` and will no longer be valid for all `x`. The only options for `(forall x. x -> Maybe x)` are `Just` (our desired argument) and `(\_ -> Nothing)`, which is the only remaining vulnerability.
 
 ## Defining Foreign Types
 
@@ -488,7 +485,7 @@ export const unsafeHead = arr => {
     }
     ```
 
-    Write a JavaScript function `quadraticRootsImpl` and a wrapper `quadraticRoots :: Quadratic -> Pair Complex` that uses the quadratic formula to find the roots of this polynomial. Return the two roots as a `Pair` of `Complex` numbers. *Hint:* Use the `quadraticRoots` wrapper to pass a constructor for `Pair` to `quadraticRootsImpl`.
+    Write a JavaScript function `quadraticRootsImpl` and a wrapper `quadraticRoots :: Quadratic -> Pair Complex` that uses the quadratic formula to find the roots of this polynomial. Return the two roots as a `Pair` of `Complex` numbers. _Hint:_ Use the `quadraticRoots` wrapper to pass a constructor for `Pair` to `quadraticRootsImpl`.
 
 1. (Medium) Write the function `toMaybe :: forall a. Undefined a -> Maybe a`. This function converts `undefined` to `Nothing` and `a` values to `Just`s.
 
@@ -675,7 +672,7 @@ unit
 done waiting
 ```
 
-Note that asynchronous logging in the repl just waits to print until the entire block has finished executing. This code behaves more predictably when run with `spago test` where there is a slight delay *between* prints.
+Note that asynchronous logging in the repl just waits to print until the entire block has finished executing. This code behaves more predictably when run with `spago test` where there is a slight delay _between_ prints.
 
 Let's look at another example where we return a value from a promise. This function is written with `async` and `await`, which is just syntactic sugar for promises.
 
@@ -715,6 +712,7 @@ unit
 ```
 
 ## Exercises
+
 Exercises for the above sections are still on the ToDo list. If you have any ideas for good exercises, please make a suggestion.
 
 ## JSON
@@ -1073,7 +1071,7 @@ Left errs -> alert $ "There are " <> show (length errs) <> " validation errors."
 alert $ "Error: " <> err <> ". Loading examplePerson"
 ```
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a wrapper for the `removeItem` method on the `localStorage` object, and add your foreign function to the `Effect.Storage` module.
  1. (Medium) Add a "Reset" button that, when clicked, calls the newly-created `removeItem` function to delete the "person" entry from local storage.
@@ -1090,9 +1088,9 @@ In this chapter, we've learned how to work with foreign JavaScript code from Pur
 
 For more examples, the `purescript`, `purescript-contrib` and `purescript-node` GitHub organizations provide plenty of examples of libraries which use the FFI. In the remaining chapters, we will see some of these libraries put to use to solve real-world problems in a type-safe way.
 
-# Addendum
+## Addendum
 
-## Calling PureScript from JavaScript
+### Calling PureScript from JavaScript
 
 Calling a PureScript function from JavaScript is very simple, at least for functions with simple types.
 
@@ -1127,7 +1125,7 @@ var Test = PS.Test;
 Test.gcd(15)(20);
 ```
 
-## Understanding Name Generation
+### Understanding Name Generation
 
 PureScript aims to preserve names during code generation as much as possible. In particular, most identifiers which are neither PureScript nor JavaScript keywords can be expected to be preserved, at least for names of top-level declarations.
 
@@ -1157,7 +1155,7 @@ var example$prime = 100;
 
 Where compiled PureScript code is intended to be called from JavaScript, it is recommended that identifiers only use alphanumeric characters, and avoid JavaScript keywords. If user-defined operators are provided for use in PureScript code, it is good practice to provide an alternative function with an alphanumeric name for use in JavaScript.
 
-## Runtime Data Representation
+### Runtime Data Representation
 
 Types allow us to reason at compile-time that our programs are "correct" in some sense - that is, they will not break at runtime. But what does that mean? In PureScript, it means that the type of an expression should be compatible with its representation at runtime.
 
@@ -1179,7 +1177,7 @@ As you might expect, PureScript's arrays correspond to JavaScript arrays. But re
 
 We've already seen that PureScript's records evaluate to JavaScript objects. Just as for functions and arrays, we can reason about the runtime representation of data in a record's fields by considering the types associated with its labels. Of course, the fields of a record are not required to be of the same type.
 
-## Representing ADTs
+### Representing ADTs
 
 For every constructor of an algebraic data type, the PureScript compiler creates a new JavaScript object type by defining a function. Its constructors correspond to functions which create new JavaScript objects based on those prototypes.
 
@@ -1243,7 +1241,7 @@ newtype PhoneNumber = PhoneNumber String
 
 is actually represented as a JavaScript string at runtime. This is useful for designing libraries, since newtypes provide an additional layer of type safety, but without the runtime overhead of another function call.
 
-## Representing Quantified Types
+### Representing Quantified Types
 
 Expressions with quantified (polymorphic) types have restrictive representations at runtime. In practice, this means that there are relatively few expressions with a given quantified type, but that we can reason about them quite effectively.
 
@@ -1282,7 +1280,7 @@ Without being able to inspect the runtime type of our function argument, our onl
 
 A full discussion of _parametric polymorphism_ and _parametricity_ is beyond the scope of this book. Note however, that since PureScript's types are _erased_ at runtime, a polymorphic function in PureScript _cannot_ inspect the runtime representation of its arguments (without using the FFI), and so this representation of polymorphic data is appropriate.
 
-## Representing Constrained Types
+### Representing Constrained Types
 
 Functions with a type class constraint have an interesting representation at runtime. Because the behavior of the function might depend on the type class instance chosen by the compiler, the function is given an additional argument, called a _type class dictionary_, which contains the implementation of the type class functions provided by the chosen instance.
 
@@ -1313,7 +1311,7 @@ import { showNumber } from 'Data.Show'
 shout(showNumber)(42);
 ```
 
- ## Exercises
+### Exercises
 
  1. (Easy) What are the runtime representations of these types?
 
@@ -1326,7 +1324,7 @@ shout(showNumber)(42);
      What can you say about the expressions which have these types?
  1. (Medium) Try using the functions defined in the `arrays` package, calling them from JavaScript, by compiling the library using `spago build` and importing modules using the `import` function in NodeJS. _Hint_: you may need to configure the output path so that the generated ES modules are available on the NodeJS module path.
 
-## Representing Side Effects
+### Representing Side Effects
 
 The `Effect` monad is also defined as a foreign type. Its runtime representation is quite simple - an expression of type `Effect a` should evaluate to a JavaScript function of **no arguments**, which performs any side-effects and returns a value with the correct runtime representation for type `a`.
 

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -39,6 +39,7 @@ For example, to provide the player name using the `-p` option:
 $ spago run -a "-p Phil"
 >
 ```
+
 ```text
 $ spago bundle-app 
 $ node index.js -p Phil
@@ -136,7 +137,7 @@ Given the `sumArray` function above, we could use `execState` in PSCi to sum the
 21
 ```
 
- ## Exercises
+## Exercises
 
  1. (Easy) What is the result of replacing `execState` with `runState` or `evalState` in our example above?
  1. (Medium) A string of parentheses is _balanced_ if it is obtained by either concatenating zero-or-more shorter balanced
@@ -220,7 +221,7 @@ To run a computation in the `Reader` monad, the `runReader` function can be used
 runReader :: forall r a. Reader r a -> r -> a
 ```
 
- ## Exercises
+## Exercises
 
  In these exercises, we will use the `Reader` monad to build a small library for rendering documents with indentation. The "global configuration" will be a number indicating the current indentation level:
 
@@ -339,7 +340,7 @@ We can test our modified function in PSCi:
 Tuple 3 ["gcdLog 21 15","gcdLog 6 15","gcdLog 6 9","gcdLog 6 3","gcdLog 3 3"]
 ```
 
- ## Exercises
+## Exercises
 
  1. (Medium) Rewrite the `sumArray` function above using the `Writer` monad and the `Additive Int` monoid from the `monoid` package.
  1. (Medium) The _Collatz_ function is defined on natural numbers `n` as `n / 2` when `n` is even, and `3 * n + 1` when `n` is odd. For example, the iterated Collatz sequence starting at `10` is as follows:
@@ -545,7 +546,7 @@ One problem with this code is that we have to use the `lift` function multiple t
 
 Fortunately, as we will see, we can use the automatic code generation provided by type class inference to do most of this "heavy lifting" for us.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Use the `ExceptT` monad transformer over the `Identity` functor to write a function `safeDivide` which divides two numbers, throwing an error (as the String "Divide by zero!") if the denominator is zero.
  1. (Medium) Write a parser
@@ -712,7 +713,7 @@ We can even use `many` to fully split a string into its lower and upper case com
 
 Again, this illustrates the power of reusability that monad transformers bring - we were able to write a backtracking parser in a declarative style with only a few lines of code, by reusing standard abstractions!
 
- ## Exercises
+## Exercises
 
  1. (Easy) Remove the calls to the `lift` function from your implementation of the `string` parser. Verify that the new implementation type checks, and convince yourself that it should.
  1. (Medium) Use your `string` parser with the `some` combinator to write a parser `asFollowedByBs` which recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
@@ -911,7 +912,7 @@ The `runGame` function finally attaches the initial line handler to the console 
 {{#include ../exercises/chapter11/src/Main.purs:runGame_attach_handler}}
 ```
 
- ## Exercises
+## Exercises
 
  1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory. Create a function `cheat :: Game Unit` in the `Game` module, and use this function from `game`.
  1. (Difficult) The `Writer` component of the `RWS` monad is currently used for two types of messages: error messages and informational messages. Because of this, several parts of the code use case statements to handle error cases.
@@ -937,13 +938,14 @@ This is best illustrated by example. The application's `main` function is define
 The first argument is used to configure the `optparse` library. In our case, we simply configure it to show the help message when the application is run without any arguments (instead of showing a "missing argument" error) by using `OP.prefs OP.showHelpOnEmpty`, but the `Options.Applicative.Builder` module provides several other options.
 
 The second argument is the complete description of our parser program:
-```haskell 
+
+```haskell
 {{#include ../exercises/chapter11/src/Main.purs:argParser}}
 
 {{#include ../exercises/chapter11/src/Main.purs:parserOptions}}
 ```
 
-Here `OP.info` combines a `Parser` with a set of options for how the help message is formatted. `env <**> OP.helper` takes any command line argument `Parser` named `env` and adds a `--help` option to it automatically. Options for the help message are of type `InfoMod`, which is a monoid, so we can use the `fold` function to add several options together. 
+Here `OP.info` combines a `Parser` with a set of options for how the help message is formatted. `env <**> OP.helper` takes any command line argument `Parser` named `env` and adds a `--help` option to it automatically. Options for the help message are of type `InfoMod`, which is a monoid, so we can use the `fold` function to add several options together.
 
 The interesting part of our parser is constructing the `GameEnvironment`:
 
@@ -955,7 +957,7 @@ The interesting part of our parser is constructing the `GameEnvironment`:
 
 Notice how we were able to use the notation afforded by the applicative operators to give a compact, declarative specification of our command line interface. In addition, it is simple to add new command line arguments, simply by adding a new function argument to `runGame`, and then using `<*>` to lift `runGame` over an additional argument in the definition of `env`.
 
- ## Exercises
+## Exercises
 
  1. (Medium) Add a new Boolean-valued property `cheatMode` to the `GameEnvironment` record. Add a new command line flag `-c` to the `optparse` configuration which enables cheat mode. The `cheat` command from the previous exercise should be disallowed if cheat mode is not enabled.
 
@@ -968,4 +970,3 @@ Because we separated our implementation from the user interface, it would be pos
 We have seen how monad transformers allow us to write safe code in an imperative style, where effects are tracked by the type system. In addition, type classes provide a powerful way to abstract over the actions provided by a monad, enabling code reuse. We were able to use standard abstractions like `Alternative` and `MonadPlus` to build useful monads by combining standard monad transformers.
 
 Monad transformers are an excellent demonstration of the sort of expressive code that can be written by relying on advanced type system features such as higher-kinded polymorphism and multi-parameter type classes.
-

--- a/text/chapter12.md
+++ b/text/chapter12.md
@@ -64,7 +64,7 @@ fillPath :: forall a. Context2D -> Effect a -> Effect a
 Build the rectangle example, providing `Example.Rectangle` as the name of the main module:
 
 ```text
-spago bundle-app --main Example.Rectangle --to dist/Main.js
+$ spago bundle-app --main Example.Rectangle --to dist/Main.js
 ```
 
 Now, open the `html/index.html` file and verify that this code renders a blue rectangle in the center of the canvas.
@@ -145,7 +145,7 @@ The result of this code snippet is to fill an isosceles triangle.
 Build the example by specifying `Example.Shapes` as the main module:
 
 ```text
-spago bundle-app --main Example.Shapes --to dist/Main.js
+$ spago bundle-app --main Example.Shapes --to dist/Main.js
 ```
 
 and open `html/index.html` again to see the result. You should see the three different types of shapes rendered to the canvas.
@@ -210,7 +210,7 @@ Next, for each circle, the code creates an `Arc` based on these parameters and f
 Build this example by specifying the `Example.Random` module as the main module:
 
 ```text
-spago bundle-app --main Example.Random --to dist/Main.js
+$ spago bundle-app --main Example.Random --to dist/Main.js
 ```
 
 and view the result by opening `html/index.html`.
@@ -353,7 +353,7 @@ This action uses `withContext` to preserve the original transformation, and then
 Build the example:
 
 ```text
-spago bundle-app --main Example.Refs --to dist/Main.js
+$ spago bundle-app --main Example.Refs --to dist/Main.js
 ```
 
 and open the `html/index.html` file. If you click the canvas repeatedly, you should see a green rectangle rotating around the center of the canvas.
@@ -547,7 +547,7 @@ To render this L-system, we can simply use the `strokePath` action:
 Compile the L-system example using
 
 ```text
-spago bundle-app --main Example.LSystem --to dist/Main.js
+$ spago bundle-app --main Example.LSystem --to dist/Main.js
 ```
 
 and open `html/index.html`. You should see the Koch curve rendered to the canvas.

--- a/text/chapter12.md
+++ b/text/chapter12.md
@@ -64,7 +64,7 @@ fillPath :: forall a. Context2D -> Effect a -> Effect a
 Build the rectangle example, providing `Example.Rectangle` as the name of the main module:
 
 ```text
-$ spago bundle-app --main Example.Rectangle --to dist/Main.js
+spago bundle-app --main Example.Rectangle --to dist/Main.js
 ```
 
 Now, open the `html/index.html` file and verify that this code renders a blue rectangle in the center of the canvas.
@@ -145,12 +145,12 @@ The result of this code snippet is to fill an isosceles triangle.
 Build the example by specifying `Example.Shapes` as the main module:
 
 ```text
-$ spago bundle-app --main Example.Shapes --to dist/Main.js
+spago bundle-app --main Example.Shapes --to dist/Main.js
 ```
 
 and open `html/index.html` again to see the result. You should see the three different types of shapes rendered to the canvas.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Experiment with the `strokePath` and `setStrokeStyle` functions in each of the examples so far.
  1. (Easy) The `fillPath` and `strokePath` functions can be used to render complex paths with a common style by using a do notation block inside the function argument. Try changing the `Rectangle` example to render two rectangles side-by-side using the same call to `fillPath`. Try rendering a sector of a circle by using a combination of a piecewise-linear path and an arc segment.
@@ -210,7 +210,7 @@ Next, for each circle, the code creates an `Arc` based on these parameters and f
 Build this example by specifying the `Example.Random` module as the main module:
 
 ```text
-$ spago bundle-app --main Example.Random --to dist/Main.js
+spago bundle-app --main Example.Random --to dist/Main.js
 ```
 
 and view the result by opening `html/index.html`.
@@ -353,12 +353,12 @@ This action uses `withContext` to preserve the original transformation, and then
 Build the example:
 
 ```text
-$ spago bundle-app --main Example.Refs --to dist/Main.js
+spago bundle-app --main Example.Refs --to dist/Main.js
 ```
 
 and open the `html/index.html` file. If you click the canvas repeatedly, you should see a green rectangle rotating around the center of the canvas.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a higher-order function which strokes and fills a path simultaneously. Rewrite the `Random.purs` example using your function.
  1. (Medium) Use `Random` and `Dom` to create an application which renders a circle with random position, color and radius to the canvas when the mouse is clicked.
@@ -547,12 +547,12 @@ To render this L-system, we can simply use the `strokePath` action:
 Compile the L-system example using
 
 ```text
-$ spago bundle-app --main Example.LSystem --to dist/Main.js
+spago bundle-app --main Example.LSystem --to dist/Main.js
 ```
 
 and open `html/index.html`. You should see the Koch curve rendered to the canvas.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Modify the L-system example above to use `fillPath` instead of `strokePath`. _Hint_: you will need to include a call to `closePath`, and move the call to `moveTo` outside of the `interpret` function.
  1. (Easy) Try changing the various numerical constants in the code, to understand their effect on the rendered system.

--- a/text/chapter13.md
+++ b/text/chapter13.md
@@ -87,7 +87,7 @@ not equal to expected:
 
 Notice how the input `xs` and `ys` were generated as arrays of randomly-selected integers.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a property which asserts that merging an array with the empty array does not modify the original array. _Note_: This new property is redundant, since this situation is already covered by our existing property. We're just trying to give you readers a simple way to practice using quickCheck.
  1. (Easy) Add an appropriate error message to the remaining property for `merge`.
@@ -134,7 +134,7 @@ quickCheck \xs ys ->
 
 Here, `xs` and `ys` both have type `Array Int`, since the `ints` function has been used to disambiguate the unknown type.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a function `bools` which forces the types of `xs` and `ys` to be `Array Boolean`, and add additional properties which test `mergePoly` at that type.
  1. (Medium) Choose a pure function from the core libraries (for example, from the `arrays` package), and write a QuickCheck property for it, including an appropriate error message. Your property should use a helper function to fix any polymorphic type arguments to either `Int` or `Boolean`.
@@ -241,7 +241,7 @@ quickCheck \t a ->
 
 Here, the argument `t` is a randomly-generated tree of type `Tree Int`, where the type argument disambiguated by the identity function `treeOfInt`.
 
- ## Exercises
+## Exercises
 
  1. (Medium) Create a newtype for `String` with an associated `Arbitrary` instance which generates collections of randomly-selected characters in the range `a-z`. _Hint_: use the `elements` and `arrayOf` functions from the `Test.QuickCheck.Gen` module.
  1. (Difficult) Write a property which asserts that a value inserted into a tree is still a member of that tree after arbitrarily many more insertions.
@@ -384,7 +384,7 @@ Success : Success : ...
 
 `quickCheckPure` might be useful in other situations, such as generating random input data for performance benchmarks, or generating sample form data for web applications.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write `Coarbitrary` instances for the `Byte` and `Sorted` type constructors.
  1. (Medium) Write a (higher-order) property which asserts associativity of the `mergeWith f` function for any function `f`. Test your property in PSCi using `quickCheckPure`.

--- a/text/chapter14.md
+++ b/text/chapter14.md
@@ -81,9 +81,9 @@ As it stands, there are several problems with this library:
 
 - Creating HTML documents is difficult - every new element requires at least one record and one data constructor.
 - It is possible to represent invalid documents:
-    - The developer might mistype the element name
-    - The developer can associate an attribute with the wrong type of element
-    - The developer can use a closed element when an open element is correct
+  - The developer might mistype the element name
+  - The developer can associate an attribute with the wrong type of element
+  - The developer can use a closed element when an open element is correct
 
 In the remainder of the chapter, we will apply certain techniques to solve these problems and turn our library into a usable domain-specific language for creating HTML documents.
 
@@ -246,7 +246,7 @@ unit
 
 Note, however, that no changes had to be made to the `render` function, because the underlying data representation never changed. This is one of the benefits of the smart constructors approach - it allows us to separate the internal data representation for a module from the representation which is perceived by users of its external API.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Use the `Data.DOM.Smart` module to experiment by creating new HTML documents using `render`.
  1. (Medium) Some HTML attributes such as `checked` and `disabled` do not require values, and may be rendered as _empty attributes_:
@@ -349,7 +349,7 @@ Now we find it is impossible to represent these invalid HTML documents, and we a
 unit
 ```
 
- ## Exercises
+## Exercises
 
  1. (Easy) Create a data type which represents either pixel or percentage lengths. Write an instance of `IsValue` for your type. Modify the `width` and `height` attributes to use your new type.
  1. (Difficult) By defining type-level representatives for the Boolean values `true` and `false`, we can use a phantom type to encode whether an `AttributeKey` represents an _empty attribute_ such as `disabled` or `checked`.
@@ -566,7 +566,7 @@ That's it! We can test our new monadic API in PSCi, as follows:
 unit
 ```
 
- ## Exercises
+## Exercises
 
  1. (Medium) Add a new data constructor to the `ContentF` type to support a new action `comment`, which renders a comment in the generated HTML. Implement the new action using `liftF`. Update the interpretation `renderContentItem` to interpret your new constructor appropriately.
 
@@ -701,10 +701,9 @@ unit
 
 You can verify that multiple calls to `newName` do in fact result in unique names.
 
- ## Exercises
+## Exercises
 
  1. (Medium) We can simplify the API further by hiding the `Element` type from its users. Make these changes in the following steps:
-     
      - Combine functions like `p` and `img` (with return type `Element`) with the `elem` action to create new actions with return type `Content Unit`.
      - Change the `render` function to accept an argument of type `Content Unit` instead of `Element`.
  1. (Medium) Hide the implementation of the `Content` monad by using a `newtype` instead of a type synonym. You should not export the data

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -27,8 +27,8 @@ Notice that the imports for these modules are listed explicitly in parentheses. 
 Assuming you have cloned the book's source code repository, the project for this chapter can be built using Spago, with the following commands:
 
 ```text
-cd chapter3
-spago build
+$ cd chapter3
+$ spago build
 ```
 
 ## Simple Types
@@ -311,7 +311,7 @@ The PSCi interactive mode allows for rapid prototyping with immediate feedback, 
 First, build the code you've written:
 
 ```text
-spago build
+$ spago build
 ```
 
 Next, load PSCi, and use the `import` command to import your new module:

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -27,8 +27,8 @@ Notice that the imports for these modules are listed explicitly in parentheses. 
 Assuming you have cloned the book's source code repository, the project for this chapter can be built using Spago, with the following commands:
 
 ```text
-$ cd chapter3
-$ spago build
+cd chapter3
+spago build
 ```
 
 ## Simple Types
@@ -311,7 +311,7 @@ The PSCi interactive mode allows for rapid prototyping with immediate feedback, 
 First, build the code you've written:
 
 ```text
-$ spago build
+spago build
 ```
 
 Next, load PSCi, and use the `import` command to import your new module:
@@ -623,6 +623,7 @@ book6 = john ++ peggy ++ ned ++ emptyBook
 Another common technique for eliminating parens is to use `apply`'s infix operator `$`, along with your standard prefix functions.
 
 For example, the earlier `book3` example could be rewritten as:
+
 ```haskell
 book7 = insertEntry john $ insertEntry peggy $ insertEntry ned emptyBook
 ```
@@ -641,9 +642,11 @@ infixr 0 apply as $
 The `apply` function takes another function (of type `(a -> b)`) as its first argument and a value (of type `a`) as its second argument, then calls that function with that value. If it seems like this function doesn't contribute anything meaningful, you are absolutely correct! Your program is logically identical without it (see [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency)). The syntactic utility of this function comes from the special properties assigned to its infix operator. `$` is a right-associative (`infixr`), low precedence (`0`) operator, which lets us remove sets of parentheses for deeply-nested applications.
 
 Another parens-busting opportunity for the `$` operator is in our earlier `findEntry` function:
+
 ```haskell
 findEntry firstName lastName book = head $ filter filterEntry book
 ```
+
 We'll see an even more elegant way to rewrite this line with "function composition" in the next section.
 
 If you'd like to use a concise infix operator alias as a prefix function, you can surround it in parentheses:
@@ -687,7 +690,7 @@ In PureScript, the function composition operators are `<<<` and `>>>`. The first
 
 We can rewrite the right-hand side of `findEntry` using either operator. Using backwards-composition, the right-hand side would be
 
-```
+```haskell
 (head <<< filter filterEntry) book
 ```
 

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -67,7 +67,7 @@ The `tail` function returns a `Maybe` wrapping the given array without its first
 
 This example is obviously a very impractical way to find the length of an array in JavaScript, but should provide enough help to allow you to complete the following exercises:
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a recursive function `isEven` which returns `true` if and only if its input is an even integer.
  2. (Medium) Write a recursive function `countEven` which counts the number of even integers in an array. _Hint_: the function `head` (also available in `Data.Array`) can be used to find the first element in a non-empty array.
@@ -178,14 +178,14 @@ For example, suppose we wanted to compute an array of all numbers between 1 and 
 [2,4,6,8,10]
 ```
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a function `squared` which calculates the squares of an array of numbers. _Hint_: Use the `map` or `<$>` function.
  1. (Easy) Write a function `keepNonNegative` which removes the negative numbers from an array of numbers. _Hint_: Use the `filter` function.
  1. (Medium)
-    * Define an infix synonym `<$?>` for `filter`. _Note_: Infix synonyms may not be defined in the REPL, but you can define it in a file.
-    * Write a `keepNonNegativeRewrite` function, which is the same as `keepNonNegative`, but replaces `filter` with your new infix operator `<$?>`.
-    * Experiment with the precedence level and associativity of your operator in PSCi. _Note_: There are no unit tests for this step.
+    - Define an infix synonym `<$?>` for `filter`. _Note_: Infix synonyms may not be defined in the REPL, but you can define it in a file.
+    - Write a `keepNonNegativeRewrite` function, which is the same as `keepNonNegative`, but replaces `filter` with your new infix operator `<$?>`.
+    - Experiment with the precedence level and associativity of your operator in PSCi. _Note_: There are no unit tests for this step.
 
 ## Flattening Arrays
 
@@ -299,7 +299,7 @@ We can rewrite our `factors` function using do notation as follows:
 The keyword `do` introduces a block of code which uses do notation. The block consists of expressions of a few types:
 
 - Expressions which bind elements of an array to a name. These are indicated with the backwards-facing arrow `<-`, with a name on the left, and an expression on the right whose type is an array.
-- Expressions which do not bind elements of the array to names. The `do` *result* is an example of this kind of expression and is illustrated in the last line, `pure [i, j]`.
+- Expressions which do not bind elements of the array to names. The `do` _result_ is an example of this kind of expression and is illustrated in the last line, `pure [i, j]`.
 - Expressions which give names to expressions, using the `let` keyword.
 
 This new notation hopefully makes the structure of the algorithm clearer. If you mentally replace the arrow `<-` with the word "choose", you might read it as follows: "choose an element `i` between 1 and n, then choose an element `j` between `i` and `n`, and return `[i, j]`".
@@ -360,7 +360,7 @@ That is, if `guard` is passed an expression which evaluates to `true`, then it r
 
 This means that if the guard fails, then the current branch of the array comprehension will terminate early with no results. This means that a call to `guard` is equivalent to using `filter` on the intermediate array. Depending on the application, you might prefer to use `guard` instead of a `filter`. Try the two definitions of `factors` to verify that they give the same results.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a function `isPrime` which tests if its integer argument is prime or not. _Hint_: Use the `factors` function.
  1. (Medium) Write a function `cartesianProduct` which uses do notation to find the _cartesian product_ of two arrays, i.e. the set of all pairs of elements `a`, `b`, where `a` is an element of the first array, and `b` is an element of the second.
@@ -518,7 +518,7 @@ For example, we can reverse an array using `foldr`:
 
 Writing `reverse` in terms of `foldl` will be left as an exercise for the reader.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a function `allTrue` which uses `foldl` to test whether an array of boolean values are all true.
  2. (Medium - No Test) Characterize those arrays `xs` for which the function `foldl (==) false xs` returns `true`. In other words, complete the sentence: "The function returns `true` when `xs` contains ..."
@@ -612,7 +612,7 @@ Here is the new version:
 
 Try out the new version in PSCi - you should get the same result. I'll let you decide which version you find clearer.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a function `onlyFiles` which returns all _files_ (not directories) in all subdirectories of a directory.
  2. (Medium) Write a function `whereIs` to search for a file by name. The function should return a value of type `Maybe Path`, indicating the directory containing the file, if it exists. It should behave as follows:

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -85,6 +85,7 @@ A guard is a boolean-valued expression which must be satisfied in addition to th
 ```
 
 In this case, the third line uses a guard to impose the extra condition that the first argument is strictly larger than the second. The guard in the final line uses the expression `otherwise`, which might seem like a keyword, but is in fact just a regular binding in `Prelude`:
+
 ```text
 > :type otherwise
 Boolean
@@ -174,7 +175,7 @@ We are able to append additional fields to the record, and the `showPerson` func
 Type of expression lacks required label "last"
 ```
 
-We can read the new type signature of `showPerson` as "takes any record with `first` and `last` fields which are `Strings` _and any other fields_, and returns a `String`". This function is polymorphic in the _row_ `r` of record fields, hence the name _row polymorphism_.  Note that this behavior is different than that of the original `showPerson`. Without the row variable `r`, `showPerson` only accepts records with _exactly_ a `first` and `last` field and no others. 
+We can read the new type signature of `showPerson` as "takes any record with `first` and `last` fields which are `Strings` _and any other fields_, and returns a `String`". This function is polymorphic in the _row_ `r` of record fields, hence the name _row polymorphism_.  Note that this behavior is different than that of the original `showPerson`. Without the row variable `r`, `showPerson` only accepts records with _exactly_ a `first` and `last` field and no others.
 
 Note that we could have also written
 
@@ -452,6 +453,7 @@ newtype CouldError err a = CouldError (Either err a)
 ```
 
 Also note that the constructor of a newtype often has the same name as the newtype itself, but this is not a requirement. For example, unique names are also valid:
+
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:Coulomb}}
 ```
@@ -463,9 +465,11 @@ Another application of newtypes is to attach different _behavior_ to an existing
 ## Exercises
 
 1. (Easy) Define `Watt` as a `newtype` of `Number`. Then define a `calculateWattage` function using this new `Watt` type and the above definitions `Amp` and `Volt`:
+
 ```haskell
 calculateWattage :: Amp -> Volt -> Watt
 ```
+
 A wattage in `Watt`s can be calculated as the product of a given current in `Amp`s and a given voltage in `Volt`s.
 
 ## A Library for Vector Graphics

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -8,7 +8,7 @@ This motivating example for this chapter will be a library for hashing data stru
 
 We will also see a collection of standard type classes from PureScript's Prelude and standard libraries. PureScript code leans heavily on the power of type classes to express ideas concisely, so it will be beneficial to familiarize yourself with these classes.
 
-If you come from an Object Oriented background, please note that the word "class" means something _very_ different in this context than what you're used to. A type class serves a purpose more similar to an OO interface. 
+If you come from an Object Oriented background, please note that the word "class" means something _very_ different in this context than what you're used to. A type class serves a purpose more similar to an OO interface.
 
 ## Project Setup
 
@@ -127,7 +127,7 @@ No type class instance was found for
 
 Type class instances can be defined in one of two places: in the same module that the type class is defined, or in the same module that the type "belonging to" the type class is defined. An instance defined in any other spot is called an ["orphan instance"](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#orphan-instances) and is not allowed by the PureScript compiler. Some of the exercises in this chapter will require you to copy the definition of a type into your MySolutions module so that you can define type class instances for that type.
 
- ## Exercises
+## Exercises
 
 1. (Easy) Define a `Show` instance for `Point`. Match the same output as the `showPoint` function from the previous chapter. _Note:_ Point is now a `newtype` (instead of a `type` synonym), which allows us to customize how to `show` it. Otherwise, we'd be stuck with the default `Show` instance for records.
 
@@ -407,7 +407,6 @@ These two type class instances are provided in the `prelude` library.
 
 When the program is compiled, the correct type class instance for `Show` is chosen based on the inferred type of the argument to `show`. The selected instance might depend on many such instance relationships, but this complexity is not exposed to the developer.
 
-
 ## Exercises
 
 1. (Easy) The following declaration defines a type of non-empty arrays of elements of type `a`:
@@ -638,7 +637,7 @@ Another reason to define a superclass relationship is in the case where there is
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:Multiply_Action}}
       ...
     ```
-    
+
     Remember, your instance must satisfy the laws listed above.
 
 1. (Difficult) There are actually multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of a same instance, so you will have to replace your original implementation. _Note_: the tests cover 4 implementations.
@@ -649,7 +648,7 @@ Another reason to define a superclass relationship is in the case where there is
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:actionMultiplyString}}
       ...
     ```
-    
+
     _Hint_: Search Pursuit for a helper-function with the signature [`String -> Int -> String`](https://pursuit.purescript.org/search?q=String%20-%3E%20Int%20-%3E%20String). Note that `String` might appear as a more generic type (such as `Monoid`).
 
     Does this instance satisfy the laws listed above?
@@ -739,7 +738,7 @@ What about some more interesting types? To prove the type class law for the `Arr
 
 The source code for this chapter includes several other examples of `Hashable` instances, such as instances for the `Maybe` and `Tuple` type.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Use PSCi to test the hash functions for each of the defined instances. _Note_: There is no provided unit test for this exercise.
  1. (Medium) Write a function `arrayHasDuplicates` which tests if an array has any duplicate elements based on both hash and value equality. First check for hash equality with the `hashEqual` function, then check for value equality with `==` if a duplicate pair of hashes is found. _Hint_: the `nubByEq` function in `Data.Array` should make this task much simpler.

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -378,7 +378,7 @@ But the `combineList` function works for any `Applicative`! We can use it to com
 
 We will see the `combineList` function again later, when we consider `Traversable` functors.
 
- ## Exercises
+## Exercises
 
  1. (Medium) Write versions of the numeric operators `+`, `-`, `*` and `/` which work with optional arguments (i.e. arguments wrapped in `Maybe`) and return a value wrapped in `Maybe`. Name these functions `addMaybe`, `subMaybe`, `mulMaybe`, and `divMaybe`. _Hint_: Use `lift2`.
  1. (Medium) Extend the above exercise to work with all `Apply` types (not just `Maybe`). Name these new functions `addApply`, `subApply`, `mulApply`, and `divApply`.
@@ -537,7 +537,7 @@ pure ({ type: HomePhone, number: "555-555-5555" })
 invalid (["Field 'Number' did not match the required format"])
 ```
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a regular expression `stateRegex :: Regex` to check that a string only contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
  1. (Medium) Write a regular expression `nonEmptyRegex :: Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com) which has a great cheatsheet and interactive test environment.
@@ -639,7 +639,7 @@ These examples show that traversing the `Nothing` value returns `Nothing` with n
 
 Other traversable functors include `Array`, and `Tuple a` and `Either a` for any type `a`. Generally, most "container" data type constructors have `Traversable` instances. As an example, the exercises will include writing a `Traversable` instance for a type of binary trees.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write `Eq` and `Show` instances for the following binary tree data structure:
 
@@ -651,7 +651,7 @@ Other traversable functors include `Array`, and `Tuple a` and `Either a` for any
 
      There are many "correct" formatting options for `Show` output. The test for this exercise expects the following whitespace style. This happens to match the default formatting of generic show, so you only need to make note of this if you're planning on writing this instance manually.
 
-     ```
+     ```haskell
      (Branch (Branch Leaf 8 Leaf) 42 Leaf)
      ```
 

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -700,9 +700,9 @@ To keep things simple, the form will have a fixed shape: the different phone num
 You can launch the web app from the `exercises/chapter8` directory with the following commands:
 
 ```shell
-npm install
-npx spago build
-npx parcel src/index.html --open
+$ npm install
+$ npx spago build
+$ npx parcel src/index.html --open
 ```
 
 If development tools such as `spago` and `parcel` are installed globally, then the `npx` prefix may be omitted. You have likely already installed `spago` globally with `npm i -g spago`, and the same can be done for `parcel`.

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -305,7 +305,7 @@ Try writing `userCity` using only `pure` and `apply`: you will see that it is im
 
 In the last chapter, we saw that the `Applicative` type class can be used to express parallelism. This was precisely because the function arguments being lifted were independent of one another. Since the `Monad` type class allows computations to depend on the results of previous computations, the same does not apply - a monad has to combine its side-effects in sequence.
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type. _Hint:_ Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `arrays` package. Use do notation with the `Maybe` monad to combine these functions.
  1. (Medium) Write a function `possibleSums` which uses `foldM` to determine all possible totals that could be made using a set of coins. The coins will be specified as an array which contains the value of each coin. Your function should have the following result:
@@ -402,7 +402,7 @@ log :: String -> Effect Unit
 ```
 
 > _Aside:_ You may encounter IDE suggestions for the more general (and more elaborately typed) `log` function from `Effect.Class.Console`. This is interchangeable with the one from `Effect.Console` when dealing with the basic `Effect` monad. Reasons for the more general version will become clearer after reading about "Monad Transformers" in the "Monadic Adventures" chapter. For the curious (and impatient), this works because there's a `MonadEffect` instance for `Effect`.
-
+>
 > ```hs
 > log :: forall m. MonadEffect m => String -> m Unit
 > ```
@@ -428,7 +428,7 @@ main = random >>= logShow
 
 Try running this yourself with:
 
-```
+```shell
 spago run --main Test.Random
 ```
 
@@ -462,7 +462,7 @@ main = do
 
 We encounter the following exception:
 
-```
+```text
     throw err;
     ^
 Error: ENOENT: no such file or directory, open 'iDoNotExist.md'
@@ -699,10 +699,10 @@ To keep things simple, the form will have a fixed shape: the different phone num
 
 You can launch the web app from the `exercises/chapter8` directory with the following commands:
 
-```
-$ npm install
-$ npx spago build
-$ npx parcel src/index.html --open
+```shell
+npm install
+npx spago build
+npx parcel src/index.html --open
 ```
 
 If development tools such as `spago` and `parcel` are installed globally, then the `npx` prefix may be omitted. You have likely already installed `spago` globally with `npm i -g spago`, and the same can be done for `parcel`.
@@ -894,9 +894,9 @@ pure
 
 Here we produce `JSX` which represents the intended state of the DOM. This JSX is typically created by applying functions corresponding to HTML tags (e.g. `div`, `form`, `h3`, `li`, `ul`, `label`, `input`) which create single HTML elements. These HTML elements are actually React components themselves, converted to JSX. There are usually three variants of each of these functions:
 
-* `div_`: Accepts an array of child elements. Uses default attributes.
-* `div`: Accepts a `Record` of attributes. An array of child elements may be passed to the `children` field of this record.
-* `div'`: Same as `div`, but returns the `ReactComponent` before conversion to `JSX`.
+- `div_`: Accepts an array of child elements. Uses default attributes.
+- `div`: Accepts a `Record` of attributes. An array of child elements may be passed to the `children` field of this record.
+- `div'`: Same as `div`, but returns the `ReactComponent` before conversion to `JSX`.
 
 To display validation errors (if any) at the top of our form, we create a `renderValidationErrors` helper function that turns the `Errors` structure into an array of JSX. This array is prepended to the rest of our form.
 

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -16,7 +16,7 @@ New PureScript libraries introduced in this chapter are:
 When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module, which is listed as dependency in the `package.json` of this chapter. Install that by running:
 
 ```shell
-$ npm install
+npm install
 ```
 
 ## Asynchronous JavaScript
@@ -57,26 +57,32 @@ It is also possible to re-write the above snippet using callbacks or synchronous
 The syntax for working with `Aff` is very similar to working with `Effect`. They are both monads, and can therefore be written with do notation.
 
 For example, if we look at the signature of `readTextFile`, we see that it returns the file contents as a `String` wrapped in `Aff`:
+
 ```hs
 readTextFile :: Encoding -> FilePath -> Aff String
 ```
+
 We can "unwrap" the returned string with a bind arrow (`<-`) in do notation:
+
 ```hs
 my_data <- readTextFile UTF8 file1
 ```
+
 Then pass it as the string argument to `writeTextFile`:
+
 ```hs
 writeTextFile :: Encoding -> FilePath -> String -> Aff Unit
 ```
 
 The only other notable feature unique to `Aff` in the above example is `attempt`, which captures errors or exceptions encountered while running `Aff` code and stores them in an `Either`:
+
 ```hs
 attempt :: forall a. Aff a -> Aff (Either Error a)
 ```
 
 You should hopefully be able to draw on your knowledge of concepts from previous chapters and combine this with the new `Aff` patterns learned in the above `copyFile` example to tackle the following exercises:
 
- ## Exercises
+## Exercises
 
  1. (Easy) Write a `concatenateFiles` function which concatenates two text files.
 
@@ -89,8 +95,9 @@ You should hopefully be able to draw on your knowledge of concepts from previous
 If you haven't already taken a look at the [official Aff guide](https://pursuit.purescript.org/packages/purescript-aff/), skim through that now. It's not a direct prerequisite for completing the remaining exercises in this chapter, but you may find it helpful to lookup some functions on Pursuit.
 
 You're also welcome to consult these supplemental resources too, but again, the exercises in this chapter don't depend on them:
-* [Drew's Aff Post](https://blog.drewolson.org/asynchronous-purescript)
-* [Additional Aff Explanation and Examples](https://github.com/JordanMartinez/purescript-jordans-reference/tree/latestRelease/21-Hello-World/02-Effect-and-Aff/src/03-Aff)
+
+- [Drew's Aff Post](https://blog.drewolson.org/asynchronous-purescript)
+- [Additional Aff Explanation and Examples](https://github.com/JordanMartinez/purescript-jordans-reference/tree/latestRelease/21-Hello-World/02-Effect-and-Aff/src/03-Aff)
 
 ## A HTTP Client
 
@@ -188,7 +195,7 @@ unit
 
 A full listing of available parallel functions can be found in the [`parallel` docs on Pursuit](https://pursuit.purescript.org/packages/purescript-parallel/docs/Control.Parallel). The [aff docs section on parallel](https://github.com/purescript-contrib/purescript-aff#parallel-execution) also contains more examples.
 
- ## Exercises
+## Exercises
 
 1. (Easy) Write a `concatenateManyParallel` function which has the same signature as the earlier `concatenateMany` function, but reads all input files in parallel.
 
@@ -199,6 +206,7 @@ A full listing of available parallel functions can be found in the [`parallel` d
 1. (Difficult) Write a `recurseFiles` function which takes a "root" file and returns an array of all paths listed in that file (and listed in the listed files too). Read listed files in parallel. Paths are relative to the directory of the file they appear in. _Hint:_ The `node-path` module has some helpful functions for negotiating directories.
 
 For example, if starting from the following `root.txt` file:
+
 ```shell
 $ cat root.txt
 a.txt
@@ -217,7 +225,9 @@ $ cat b/a.txt
 
 $ cat c/a/a.txt
 ```
+
 The expected output is:
+
 ```hs
 ["root.txt","a.txt","b/a.txt","b/b.txt","b/c/a.txt","c/a/a.txt"]
 ```
@@ -225,6 +235,7 @@ The expected output is:
 ## Conclusion
 
 In this chapter we covered asynchronous effects and learned how to:
+
 - Run asynchronous code in the `Aff` monad with the `aff` library.
 - Make HTTP requests asynchronously with the `affjax` library.
 - Run asynchronous code in parallel with the `parallel` library.

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -16,7 +16,7 @@ New PureScript libraries introduced in this chapter are:
 When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module, which is listed as dependency in the `package.json` of this chapter. Install that by running:
 
 ```shell
-npm install
+$ npm install
 ```
 
 ## Asynchronous JavaScript


### PR DESCRIPTION
* Rules that may require major changes are not enabled in the settings (`.markdownlint.json`)
* Areas that can be automatically corrected and manually easily corrected were reflected in the documents (`**/*.md`)
* Add markdownlint task to the GitHub Actions (`.github/workflows/tests.yml`)