### PR TITLE
[chapter9] "npm install xhr2" statement corrected

### DIFF
--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -13,10 +13,10 @@ New PureScript libraries introduced in this chapter are:
 - `affjax` - HTTP requests with AJAX and `Aff`.
 - `parallel` - parallel execution of `Aff`.
 
-When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module. Install that by running:
+When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module, which is listed as dependency in the `package.json` of this chapter. Install that by running:
 
 ```shell
-$ npm install xhr2
+$ npm install
 ```
 
 ## Asynchronous JavaScript

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -16,7 +16,7 @@ New PureScript libraries introduced in this chapter are:
 When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module. Install that by running:
 
 ```shell
-$ npm install
+$ npm install xhr2
 ```
 
 ## Asynchronous JavaScript


### PR DESCRIPTION
The module name was missing. Probably obvious, but who knows.