### PR TITLE
Update Node.js to v14.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node toolchain
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
[Node.js v14.x or later is required  by markdownlint-cli v0.33.0](https://github.com/igorshubovych/markdownlint-cli/blob/b9158d3e9c36496bfaef9ce98f886d9117c6f502/package.json#L10), which is the current version which is installed with `npm install purescript spago markdownlint-cli`.

The cause of the CI failure is #423.

The CI result of this pull request can be seen in [fix/markdownlint-for-ci branch](https://github.com/gemmaro/purescript-book/tree/fix/markdownlint-for-ci).