### PR TITLE
[Scripts] Make removeAnchors script support Darwin's BSD find

### DIFF
--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -10,12 +10,12 @@ set -e
 # All .purs & .js files in the src/ and test/ directories of chapter exercises.
 FIND_FILES_PATTERN='\./exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)'
 
-EXTENDED_REGEX_FLAGS='-regextype posix-extended'
+EXTENDED_REGEX_FLAGS="-regextype posix-extended"
 # BSD find has different flags for extended regex
 if [[ $(uname) == 'FreeBSD' || $(uname) == 'Darwin' ]]; then
     EXTENDED_REGEX_FLAGS='-E'
 fi
-FILES=$(find . -type f "${EXTENDED_REGEX_FLAGS}" -regex "${FIND_FILES_PATTERN}")
+FILES=$(find . -type f $EXTENDED_REGEX_FLAGS -regex $FIND_FILES_PATTERN)
 
 for f in $FILES; do
   # Delete lines starting with an 'ANCHOR' comment

--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -2,13 +2,20 @@
 
 # This script removes all code anchors to improve readability
 
+FIND_FILES_PATTERN='\./exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)'
+OS=$(uname)
+
 # Echo commands to shell
 set -x
 # Exit on first failure
 set -e
 
 # All .purs & .js files in the src/ and test/ directories of chapter exercises.
-FILES=$(find . -regextype posix-extended -regex '\./exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)' -type f)
+if [[ "$OS" == 'Darwin' ]]; then
+    FILES=$(find -E . -regex "${FIND_FILES_PATTERN}" -type f)
+else
+    FILES=$(find . -regextype posix-extended -regex "${FIND_FILES_PATTERN}" -type f)
+fi
 
 for f in $FILES; do
   # Delete lines starting with an 'ANCHOR' comment

--- a/scripts/removeAnchors.sh
+++ b/scripts/removeAnchors.sh
@@ -2,20 +2,20 @@
 
 # This script removes all code anchors to improve readability
 
-FIND_FILES_PATTERN='\./exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)'
-OS=$(uname)
-
 # Echo commands to shell
 set -x
 # Exit on first failure
 set -e
 
 # All .purs & .js files in the src/ and test/ directories of chapter exercises.
-if [[ "$OS" == 'Darwin' ]]; then
-    FILES=$(find -E . -regex "${FIND_FILES_PATTERN}" -type f)
-else
-    FILES=$(find . -regextype posix-extended -regex "${FIND_FILES_PATTERN}" -type f)
+FIND_FILES_PATTERN='\./exercises/chapter[0-9]{1,2}/(src|test)/.*\.(purs|js)'
+
+EXTENDED_REGEX_FLAGS='-regextype posix-extended'
+# BSD find has different flags for extended regex
+if [[ $(uname) == 'FreeBSD' || $(uname) == 'Darwin' ]]; then
+    EXTENDED_REGEX_FLAGS='-E'
 fi
+FILES=$(find . -type f "${EXTENDED_REGEX_FLAGS}" -regex "${FIND_FILES_PATTERN}")
 
 for f in $FILES; do
   # Delete lines starting with an 'ANCHOR' comment


### PR DESCRIPTION
Within the `removeAnchors` bash script the GNU `find` command is assumed. On some operating systems (and I'm mainly thinking about macOS here) the BSD `find` is the one available out-of-the-box. The BSD `find` does not support the `-regextype` flag. As a consequence, anyone who runs the script using that command variant will encounter an error.

I updated the script to check for the OS and use the appropriate command version so that the script can be a tad more universal. 🙂

_edit_: I see that this PR can address the first bullet point of #396 