### PR TITLE
Do a grammarly pass

### DIFF
--- a/text/chapter1.md
+++ b/text/chapter1.md
@@ -4,7 +4,7 @@
 
 Functional programming techniques have been making appearances in JavaScript for some time now:
 
-- Libraries such as [UnderscoreJS](https://underscorejs.org) allow the developer to leverage tried-and-trusted functions such as `map`, `filter` and `reduce` to create larger programs from smaller programs by composition:
+- Libraries such as [UnderscoreJS](https://underscorejs.org) allow the developer to leverage tried-and-trusted functions such as `map`, `filter`, and `reduce` to create larger programs from smaller programs by composition:
 
     ```javascript
     var sumOfPrimes =
@@ -34,15 +34,15 @@ Functional programming techniques have been making appearances in JavaScript for
 
 - Libraries such as [React](https://reactjs.org) and [virtual-dom](https://github.com/Matt-Esch/virtual-dom) model views as pure functions of application state.
 
-Functions enable a simple form of abstraction which can yield great productivity gains. However, functional programming in JavaScript has its own disadvantages: JavaScript is verbose, untyped, and lacks powerful forms of abstraction. Unrestricted JavaScript code also makes equational reasoning very difficult.
+Functions enable a simple form of abstraction that can yield great productivity gains. However, functional programming in JavaScript has disadvantages: JavaScript is verbose, untyped, and lacks powerful forms of abstraction. Unrestricted JavaScript code also makes equational reasoning very difficult.
 
-PureScript is a programming language which aims to address these issues. It features lightweight syntax, which allows us to write very expressive code which is still clear and readable. It uses a rich type system to support powerful abstractions. It also generates fast, understandable code, which is important when interoperating with JavaScript, or other languages which compile to JavaScript. All in all, I hope to convince you that PureScript strikes a very practical balance between the theoretical power of purely functional programming, and the fast-and-loose programming style of JavaScript.
+PureScript is a programming language that aims to address these issues. It features lightweight syntax, which allows us to write very expressive code which is still clear and readable. It uses a rich type system to support powerful abstractions. It also generates fast, understandable code, which is important when interoperating with JavaScript or other languages that compile to JavaScript. All in all, I hope to convince you that PureScript strikes a very practical balance between the theoretical power of purely functional programming and the fast-and-loose programming style of JavaScript.
 
 ## Types and Type Inference
 
-The debate over statically typed languages versus dynamically typed languages is well-documented. PureScript is a _statically typed_ language, meaning that a correct program can be given a _type_ by the compiler which indicates its behavior. Conversely, programs which cannot be given a type are _incorrect programs_, and will be rejected by the compiler. In PureScript, unlike in dynamically typed languages, types exist only at _compile-time_, and have no representation at runtime.
+The debate over statically typed languages versus dynamically typed languages is well-documented. PureScript is a _statically typed_ language, meaning that a correct program can be given a _type_ by the compiler, which indicates its behavior. Conversely, programs that cannot be given a type are _incorrect programs_, and will be rejected by the compiler. In PureScript, unlike in dynamically typed languages, types exist only at _compile-time_ and have no representation at runtime.
 
-It is important to note that in many ways, the types in PureScript are unlike the types that you might have seen in other languages like Java or C#. While they serve the same purpose at a high level, the types in PureScript are inspired by languages like ML and Haskell. PureScript's types are expressive, allowing the developer to assert strong claims about their programs. Most importantly, PureScript's type system supports _type inference_ - it requires far fewer explicit type annotations than other languages, making the type system a _tool_ rather than a hindrance. As a simple example, the following code defines a _number_, but there is no mention of the `Number` type anywhere in the code:
+It is important to note that, in many ways, the types in PureScript are unlike the types that you might have seen in other languages like Java or C#. While they serve the same purpose at a high level, the types in PureScript are inspired by languages like ML and Haskell. PureScript's types are expressive, allowing the developer to assert strong claims about their programs. Most importantly, PureScript's type system supports _type inference_ – it requires far fewer explicit type annotations than other languages, making the type system a _tool_ rather than a hindrance. As a simple example, the following code defines a _number_, but there is no mention of the `Number` type anywhere in the code:
 
 ```haskell
 iAmANumber =
@@ -50,7 +50,7 @@ iAmANumber =
   in square 42.0
 ```
 
-A more involved example shows that type-correctness can be confirmed without type annotations, even when there exist types which are _unknown to the compiler_:
+A more involved example shows that type-correctness can be confirmed without type annotations, even when there exist types that are _unknown to the compiler_:
 
 ```haskell
 iterate f 0 x = x
@@ -61,15 +61,15 @@ Here, the type of `x` is unknown, but the compiler can still verify that `iterat
 
 In this book, I will try to convince you (or reaffirm your belief) that static types are not only a means of gaining confidence in the correctness of your programs, but also an aid to development in their own right. Refactoring a large body of code in JavaScript can be difficult when using any but the simplest of abstractions, but an expressive type system together with a type checker can even make refactoring into an enjoyable, interactive experience.
 
-In addition, the safety net provided by a type system enables more advanced forms of abstraction. In fact, PureScript provides a powerful form of abstraction which is fundamentally type-driven: type classes, made popular in the functional programming language Haskell.
+In addition, the safety net provided by a type system enables more advanced forms of abstraction. In fact, PureScript provides a powerful form of abstraction that is fundamentally type-driven: type classes, made popular in the functional programming language Haskell.
 
 ## Polyglot Web Programming
 
-Functional programming has its success stories - applications where it has been particularly successful: data analysis, parsing, compiler implementation, generic programming, parallelism, to name a few.
+Functional programming has its success stories – applications where it has been particularly successful: data analysis, parsing, compiler implementation, generic programming, parallelism, to name a few.
 
 It would be possible to practice end-to-end application development in a functional language like PureScript. PureScript provides the ability to import existing JavaScript code, by providing types for its values and functions, and then to use those functions in regular PureScript code. We'll see this approach later in the book.
 
-However, one of PureScript's strengths is its interoperability with other languages which target JavaScript. Another approach would be to use PureScript for a subset of your application's development, and to use one or more other languages to write the rest of the JavaScript.
+However, one of PureScript's strengths is its interoperability with other languages which target JavaScript. Another approach would be to use PureScript for a subset of your application's development and to use one or more other languages to write the rest of the JavaScript.
 
 Here are some examples:
 
@@ -83,7 +83,7 @@ In this book, we'll focus on solving small problems with PureScript. The solutio
 
 The software requirements for this book are minimal: the first chapter will guide you through setting up a development environment from scratch, and the tools we will use are available in the standard repositories of most modern operating systems.
 
-The PureScript compiler itself can be downloaded as a binary distribution, or built from source on any system running an up-to-date installation of the GHC Haskell compiler, and we will walk through this process in the next chapter.
+The PureScript compiler itself can be downloaded as a binary distribution or built from source on any system running an up-to-date installation of the GHC Haskell compiler, and we will walk through this process in the next chapter.
 
 The code in this version of the book is compatible with versions `0.15.*` of
 the PureScript compiler.
@@ -92,17 +92,17 @@ the PureScript compiler.
 
 I will assume that you are familiar with the basics of JavaScript. Any prior familiarity with common tools from the JavaScript ecosystem, such as NPM and Gulp, will be beneficial if you wish to customize the standard setup to your own needs, but such knowledge is not necessary.
 
-No prior knowledge of functional programming is required, but it certainly won't hurt. New ideas will be accompanied by practical examples, so you should be able to form an intuition for the concepts from functional programming that we will use.
+No prior knowledge of functional programming is required, but it certainly won't hurt. New ideas will be accompanied by practical examples, so you should be able to form an intuition for the concepts from the functional programming that we will use.
 
-Readers who are familiar with the Haskell programming language will recognize a lot of the ideas and syntax presented in this book, because PureScript is heavily influenced by Haskell. However, those readers should understand that there are a number of important differences between PureScript and Haskell. It is not necessarily always appropriate to try to apply ideas from one language in the other, although many of the concepts presented here will have some interpretation in Haskell.
+Readers who are familiar with the Haskell programming language will recognize a lot of the ideas and syntax presented in this book because PureScript is heavily influenced by Haskell. However, those readers should understand that there are a number of important differences between PureScript and Haskell. It is not necessarily always appropriate to try to apply ideas from one language in the other, although many of the concepts presented here will have some interpretation in Haskell.
 
 ## How to Read This Book
 
-The chapters in this book are largely self contained. A beginner with little functional programming experience would be well-advised, however, to work through the chapters in order. The first few chapters lay the groundwork required to understand the material later on in the book. A reader who is comfortable with the ideas of functional programming (especially one with experience in a strongly-typed language like ML or Haskell) will probably be able to gain a general understanding of the code in the later chapters of the book without reading the preceding chapters.
+The chapters in this book are largely self-contained. A beginner with little functional programming experience would be well-advised, however, to work through the chapters in order. The first few chapters lay the groundwork required to understand the material later on in the book. A reader who is comfortable with the ideas of functional programming (especially one with experience in a strongly-typed language like ML or Haskell) will probably be able to gain a general understanding of the code in the later chapters of the book without reading the preceding chapters.
 
-Each chapter will focus on a single practical example, providing the motivation for any new ideas introduced. Code for each chapter are available from the book's [GitHub repository](https://github.com/purescript-contrib/purescript-book). Some chapters will include code snippets taken from the chapter's source code, but for a full understanding, you should read the source code from the repository alongside the material from the book. Longer sections will contain shorter snippets which you can execute in the interactive mode PSCi to test your understanding.
+Each chapter will focus on a single practical example, providing the motivation for any new ideas introduced. Code for each chapter is available from the book's [GitHub repository](https://github.com/purescript-contrib/purescript-book). Some chapters will include code snippets taken from the chapter's source code, but for a full understanding, you should read the source code from the repository alongside the material from the book. Longer sections will contain shorter snippets which you can execute in the interactive mode PSCi to test your understanding.
 
-Code samples will appear in a monospaced font, as follows:
+Code samples will appear in a monospaced font as follows:
 
 ```haskell
 module Example where
@@ -118,7 +118,7 @@ Commands which should be typed at the command line will be preceded by a dollar 
 $ spago build
 ```
 
-Usually, these commands will be tailored to Linux/Mac OS users, so Windows users may need to make small changes such as modifying the file separator, or replacing shell built-ins with their Windows equivalents.
+Usually, these commands will be tailored to Linux/Mac OS users, so Windows users may need to make small changes, such as modifying the file separator or replacing shell built-ins with their Windows equivalents.
 
 Commands which should be typed at the PSCi interactive mode prompt will be preceded by an angle bracket:
 
@@ -127,39 +127,39 @@ Commands which should be typed at the PSCi interactive mode prompt will be prece
 3
 ```
 
-Each chapter will contain exercises, labelled with their difficulty level. It is strongly recommended that you attempt the exercises in each chapter to fully understand the material.
+Each chapter will contain exercises labelled with their difficulty level. It is strongly recommended that you attempt the exercises in each chapter to fully understand the material.
 
-This book aims to provide an introduction to the PureScript language for beginners, but it is not the sort of book that provides a list of template solutions to problems. For beginners, this book should be a fun challenge, and you will get the most benefit if you read the material, attempt the exercises, and most importantly of all, try to write some code of your own.
+This book aims to provide an introduction to the PureScript language for beginners, but it is not the sort of book that provides a list of template solutions to problems. For beginners, this book should be a fun challenge, and you will get the most benefit if you read the material, attempt the exercises, and, most importantly of all, try to write some code of your own.
 
 ## Getting Help
 
 If you get stuck at any point, there are a number of resources available online for learning PureScript:
 
-- The [PureScript Discord server](https://discord.gg/vKn9up84bp) is a great place to chat about issues you may be having. The server is dedicated to chat about PureScript
-- The [Purescript Discourse Forum](https://discourse.purescript.org/) is another good place to search for solutions to common problems. Questions you ask here will be available to help future readers, whereas on Slack, message history is only kept for approximately 2 weeks.
+- The [PureScript Discord server](https://discord.gg/vKn9up84bp) is a great place to chat about issues you may be having. The server is dedicated to chatting about PureScript
+- The [Purescript Discourse Forum](https://discourse.purescript.org/) is another good place to search for solutions to common problems.
 - [PureScript: Jordan's Reference](https://github.com/jordanmartinez/purescript-jordans-reference)  is an alternative learning resource that goes into great depth. If a concept in this book is difficult to understand, consider reading the corresponding section in that reference.
 - [Pursuit](https://pursuit.purescript.org) is a searchable database of PureScript types and functions. Read Pursuit's help page to [learn what kinds of searches you can do](https://pursuit.purescript.org/help/users).
 - The unofficial [PureScript Cookbook](https://github.com/JordanMartinez/purescript-cookbook) provides answers via code to "How do I do X?"-type questions.
-- The [PureScript documentation repository](https://github.com/purescript/documentation) collects articles and examples on a wide variety of topics, written by PureScript developers and users.
-- The [PureScript website](https://www.purescript.org) contains links to several learning resources, including code samples, videos and other resources for beginners.
-- [Try PureScript!](https://try.purescript.org) is a website which allows users to compile PureScript code in the web browser, and contains several simple examples of code.
+- The [PureScript documentation repository](https://github.com/purescript/documentation) collects articles and examples on a wide variety of topics written by PureScript developers and users.
+- The [PureScript website](https://www.purescript.org) contains links to several learning resources, including code samples, videos, and other resources for beginners.
+- [Try PureScript!](https://try.purescript.org) is a website that allows users to compile PureScript code in the web browser and contains several simple examples of code.
 
-If you prefer to learn by reading examples, the `purescript`, `purescript-node` and `purescript-contrib` GitHub organizations contain plenty of examples of PureScript code.
+If you prefer to learn by reading examples, the `purescript`, `purescript-node`, and `purescript-contrib` GitHub organizations contain plenty of examples of PureScript code.
 
 ## About the Author
 
-I am the original developer of the PureScript compiler. I'm based in Los Angeles, California, and started programming at an early age in BASIC on an 8-bit personal computer, the Amstrad CPC. Since then I have worked professionally in a variety of programming languages (including Java, Scala, C#, F#, Haskell and PureScript).
+I am the original developer of the PureScript compiler. I'm based in Los Angeles, California, and started programming at an early age in BASIC on an 8-bit personal computer, the Amstrad CPC. Since then, I have worked professionally in a variety of programming languages (including Java, Scala, C#, F#, Haskell and PureScript).
 
 Not long into my professional career, I began to appreciate functional programming and its connections with mathematics, and enjoyed learning functional concepts using the Haskell programming language.
 
-I started working on the PureScript compiler in response to my experience with JavaScript. I found myself using functional programming techniques that I had picked up in languages like Haskell, but wanted a more principled environment in which to apply them. Solutions at the time included various attempts to compile Haskell to JavaScript while preserving its semantics (Fay, Haste, GHCJS), but I was interested to see how successful I could be by approaching the problem from the other side - attempting to keep the semantics of JavaScript, while enjoying the syntax and type system of a language like Haskell.
+I started working on the PureScript compiler in response to my experience with JavaScript. I found myself using functional programming techniques that I had picked up in languages like Haskell, but wanted a more principled environment in which to apply them. Solutions at the time included various attempts to compile Haskell to JavaScript while preserving its semantics (Fay, Haste, GHCJS), but I was interested to see how successful I could be by approaching the problem from the other side – attempting to keep the semantics of JavaScript, while enjoying the syntax and type system of a language like Haskell.
 
 I maintain [a blog](https://blog.functorial.com), and can be [reached on Twitter](https://twitter.com/paf31).
 
 ## Acknowledgements
 
-I would like to thank the many contributors who helped PureScript to reach its current state. Without the huge collective effort which has been made on the compiler, tools, libraries, documentation and tests, the project would certainly have failed.
+I would like to thank the many contributors who helped PureScript to reach its current state. Without the huge collective effort which has been made on the compiler, tools, libraries, documentation, and tests, the project would certainly have failed.
 
-The PureScript logo which appears on the cover of this book was created by Gareth Hughes, and is gratefully reused here under the terms of the [Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/).
+The PureScript logo which appears on the cover of this book was created by Gareth Hughes and is gratefully reused here under the terms of the [Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/).
 
 Finally, I would like to thank everyone who has given me feedback and corrections on the contents of this book.

--- a/text/chapter10.md
+++ b/text/chapter10.md
@@ -2,7 +2,7 @@
 
 ## Chapter Goals
 
-This chapter will introduce PureScript's _foreign function interface_ (or _FFI_), which enables communication from PureScript code to JavaScript code, and vice versa. We will cover how to:
+This chapter will introduce PureScript's _foreign function interface_ (or _FFI_), which enables communication from PureScript code to JavaScript code and vice versa. We will cover how to:
 
 - Call pure, effectful, and asynchronous JavaScript functions from PureScript.
 - Work with untyped data.
@@ -13,14 +13,14 @@ Towards the end of this chapter, we will revisit our recurring address book exam
 - Alert the user with a popup notification.
 - Store the serialized form data in the browser's local storage, and reload it when the application restarts.
 
-There is also an addendum which covers some additional topics which are not as commonly sought-after. Feel free to read these sections, but don't let them stand in the way of progressing through the remainder of the book if they're less relevant to your learning objectives:
+There is also an addendum covering some additional topics that are not as commonly sought-after. Feel free to read these sections, but don't let them stand in the way of progressing through the remainder of the book if they're less relevant to your learning objectives:
 
 - Understand the representation of PureScript values at runtime.
 - Call PureScript functions from JavaScript.
 
 ## Project Setup
 
-The source code for this module is a continuation of the source code from chapters 3, 7 and 8. As such, the source tree includes the appropriate source files from those chapters.
+The source code for this module is a continuation of the source code from chapters 3, 7, and 8. As such, the source tree includes the appropriate source files from those chapters.
 
 This chapter introduces the `argonaut` library as a dependency. This library is used for encoding and decoding JSON.
 
@@ -30,9 +30,9 @@ The Address Book app can be launched with `parcel src/index.html --open`. It use
 
 ## A Disclaimer
 
-PureScript provides a straightforward foreign function interface to make working with JavaScript as simple as possible. However, it should be noted that the FFI is an _advanced_ feature of the language. To use it safely and effectively, you should have an understanding of the runtime representation of the data you plan to work with. This chapter aims to impart such an understanding as pertains to code in PureScript's standard libraries.
+PureScript provides a straightforward foreign function interface to make working with JavaScript as simple as possible. However, it should be noted that the FFI is an _advanced_ feature of the language. To use it safely and effectively, you should understand the runtime representation of the data you plan to work with. This chapter aims to impart such an understanding as pertains to code in PureScript's standard libraries.
 
-PureScript's FFI is designed to be very flexible. In practice, this means that developers have a choice, between giving their foreign functions very simple types, or using the type system to protect against accidental misuses of foreign code. Code in the standard libraries tends to favor the latter approach.
+PureScript's FFI is designed to be very flexible. In practice, this means that developers have a choice between giving their foreign functions very simple types or using the type system to protect against accidental misuses of foreign code. Code in the standard libraries tends to favor the latter approach.
 
 As a simple example, a JavaScript function makes no guarantees that its return value will not be `null`. Indeed, idiomatic JavaScript code returns `null` quite frequently! However, PureScript's types are usually not inhabited by a null value. Therefore, it is the responsibility of the developer to handle these corner cases appropriately when designing their interfaces to JavaScript code using the FFI.
 
@@ -49,7 +49,7 @@ node> encodeURIComponent('Hello World')
 'Hello%20World'
 ```
 
-This function has the correct runtime representation for the function type `String -> String`, since it takes non-null strings to non-null strings, and has no other side-effects.
+This function has the correct runtime representation for the function type `String -> String`, since it takes non-null strings to non-null strings and has no other side-effects.
 
 We can assign this type to the function with the following foreign import declaration:
 
@@ -57,7 +57,7 @@ We can assign this type to the function with the following foreign import declar
 {{#include ../exercises/chapter10/test/URI.purs}}
 ```
 
-We also need to write a foreign JavaScript module to import it from. A corresponding foreign JavaScript module is one of the same name but extension changed from `.purs` to `.js`. If the Purescript module above is saved as `URI.purs`, then the foreign JavaScript module is saved as `URI.js`.
+We also need to write a foreign JavaScript module to import it from. A corresponding foreign JavaScript module is one of the same name but the extension changed from `.purs` to `.js`. If the Purescript module above is saved as `URI.purs`, then the foreign JavaScript module is saved as `URI.js`.
 Since `encodeURIComponent` is already defined, we have to export it as `_encodeURIComponent`:
 
 ```javascript
@@ -110,7 +110,7 @@ Let's rewrite our `diagonal` function from Chapter 2 in a foreign module. This f
 {{#include ../exercises/chapter10/test/Examples.purs:diagonal}}
 ```
 
-Recall that functions in PureScript are _curried_. `diagonal` is a function that takes a `Number` and returns a _function_, that takes a `Number` and returns a `Number`.
+Recall that functions in PureScript are _curried_. `diagonal` is a function that takes a `Number` and returns a _function_ that takes a `Number` and returns a `Number`.
 
 ```js
 {{#include ../exercises/chapter10/test/Examples.js:diagonal}}
@@ -162,7 +162,7 @@ Type -> Type -> Type -> Type
 
 `Fn2` takes three type arguments. `Fn2 a b c` is a type representing an uncurried function of two arguments of types `a` and `b`, that returns a value of type `c`. We used it to import `diagonalUncurried` from the foreign module.
 
-We can then call it with `runFn2` which takes the uncurried function then the arguments.
+We can then call it with `runFn2`, which takes the uncurried function and then the arguments.
 
 ```text
 $ spago repl
@@ -177,7 +177,7 @@ The `functions` package defines similar type constructors for function arities f
 
 ## A Note About Uncurried Functions
 
-PureScript's curried functions has certain advantages. It allows us to partially apply functions, and to give type class instances for function types - but it comes with a performance penalty. For performance critical code, it is sometimes necessary to define uncurried JavaScript functions which accept multiple arguments.
+PureScript's curried functions have certain advantages. It allows us to partially apply functions, and to give type class instances for function types – but it comes with a performance penalty. For performance-critical code, it is sometimes necessary to define uncurried JavaScript functions which accept multiple arguments.
 
 We can also create uncurried functions from PureScript. For a function of two arguments, we can use the `mkFn2` function.
 
@@ -207,7 +207,7 @@ For contrast, here is a traditional curried function:
 {{#include ../exercises/chapter10/test/Examples.purs:curried_add}}
 ```
 
-and the resulting generated code, which is less compact due to the nested functions:
+And the resulting generated code, which is less compact due to the nested functions:
 
 ```javascript
 var curriedAdd = function (n) {
@@ -221,11 +221,11 @@ var curriedSum = curriedAdd(3)(10);
 
 ## A Note About Modern JavaScript Syntax
 
-The arrow function syntax we saw earlier is an ES6 feature, and so it is incompatible with some older browsers (namely IE11). As of writing, it is [estimated that arrow functions are unavailable for the 6% of users](https://caniuse.com/#feat=arrow-functions) who have not yet updated their web browser.
+The arrow function syntax we saw earlier is an ES6 feature, which is incompatible with some older browsers (namely IE11). As of writing, it is [estimated that arrow functions are unavailable for the 6% of users](https://caniuse.com/#feat=arrow-functions) who have not yet updated their web browser.
 
-In order to be compatible with the most users, the JavaScript code generated by the PureScript compiler does not use arrow functions. It is also recommended to **avoid arrow functions in public libraries** for the same reason.
+To be compatible with the most users, the JavaScript code generated by the PureScript compiler does not use arrow functions. It is also recommended to **avoid arrow functions in public libraries** for the same reason.
 
-You may still use arrow functions in your own FFI code, but then should include a tool such as [Babel](https://github.com/babel/babel#intro) in your deployment workflow to convert these back to ES5 compatible functions.
+You may still use arrow functions in your own FFI code, but then you should include a tool such as [Babel](https://github.com/babel/babel#intro) in your deployment workflow to convert these back to ES5 compatible functions.
 
 If you find arrow functions in ES6 more readable, you may transform JavaScript code in the compiler's `output` directory with a tool like [Lebab](https://github.com/lebab/lebab):
 
@@ -262,7 +262,7 @@ Record | Object
 
 We've already seen examples with the primitive types `String` and `Number`. We'll now take a look at the structural types `Array` and `Record` (`Object` in JavaScript).
 
-To demonstrate passing `Array`s, here's how to call a JavaScript function which takes an `Array` of `Int` and returns the cumulative sum as another array. Recall that, since JavaScript does not have a separate type for `Int`, both `Int` and `Number` in PureScript translate to `Number` in JavaScript.
+To demonstrate passing `Array`s, here's how to call a JavaScript function that takes an `Array` of `Int` and returns the cumulative sum as another array. Recall that since JavaScript does not have a separate type for `Int`, both `Int` and `Number` in PureScript translate to `Number` in JavaScript.
 
 ```hs
 foreign import cumulativeSums :: Array Int -> Array Int
@@ -288,7 +288,7 @@ $ spago repl
 [1,3,6]
 ```
 
-To demonstrate passing `Records`, here's how to call a JavaScript function which takes two `Complex` numbers as records, and returns their sum as another record. Note that a `Record` in PureScript is represented as an `Object` in JavaScript:
+To demonstrate passing `Records`, here's how to call a JavaScript function that takes two `Complex` numbers as records and returns their sum as another record. Note that a `Record` in PureScript is represented as an `Object` in JavaScript:
 
 ```hs
 type Complex = {
@@ -316,7 +316,7 @@ $ spago repl
 { imag: 6.0, real: 4.0 }
 ```
 
-Note that the above techniques require trusting that JavaScript will return the expected types, as PureScript is not able to apply type checking to JavaScript code. We will describe this type safety concern in more detail later on in the JSON section, as well as cover techniques to protect against type mismatches.
+Note that the above techniques require trusting that JavaScript will return the expected types, as PureScript cannot apply type checking to JavaScript code. We will describe this type safety concern in more detail later on in the JSON section, as well as cover techniques to protect against type mismatches.
 
 ## Exercises
 
@@ -383,28 +383,30 @@ Note that we wrote:
 forall a. (forall x. x -> Maybe x) -> (forall x. Maybe x) -> Array a -> Maybe a
 ```
 
-and not:
+And not:
 
 ```hs
-forall a. ( a -> Maybe a) -> Maybe a -> Array a -> Maybe a
+forall a. (a -> Maybe a) -> Maybe a -> Array a -> Maybe a
 ```
 
 While both forms work, the latter is more vulnerable to unwanted inputs in place of `Just` and `Nothing`.
-For example, in the more vulnerable case we could call it as follows:
+
+For example, in the more vulnerable case, we could call it as follows:
 
 ```hs
 maybeHeadImpl (\_ -> Just 1000) (Just 1000) [1,2,3]
 ```
 
-which returns `Just 1000` for any array input.
-This vulnerability is allowed because `(\_ -> Just 1000)` and `Just 1000` match the signatures of `(a -> Maybe a)` and `Maybe a` respectively when `a` is `Int` (based on input array).
+Which returns `Just 1000` for any array input.
+
+This vulnerability is allowed because `(\_ -> Just 1000)` and `Just 1000` match the signatures of `(a -> Maybe a)` and `Maybe a`, respectively, when `a` is `Int` (based on input array).
 
 In the more secure type signature, even when `a` is determined to be `Int` based on the input array, we still need to provide valid functions matching the signatures involving `forall x`.
 The _only_ option for `(forall x. Maybe x)` is `Nothing`, since a `Just` value would assume a type for `x` and will no longer be valid for all `x`. The only options for `(forall x. x -> Maybe x)` are `Just` (our desired argument) and `(\_ -> Nothing)`, which is the only remaining vulnerability.
 
 ## Defining Foreign Types
 
-Suppose instead of returning a `Maybe a`, we want to actually return `arr[0]`. We want a type that represents a value either of type `a` or the `undefined` value (but not `null`). We'll call this type `Undefined a`.
+Suppose instead of returning a `Maybe a`, we want to return `arr[0]`. We want a type that represents a value either of type `a` or the `undefined` value (but not `null`). We'll call this type `Undefined a`.
 
 We can define a _foreign type_ using a _foreign type declaration_. The syntax is similar to defining a foreign function:
 
@@ -414,7 +416,7 @@ foreign import data Undefined :: Type -> Type
 
 The `data` keyword here indicates that we are defining a _type_, not a value. Instead of a type signature, we give the _kind_ of the new type. In this case, we declare the kind of `Undefined` to be `Type -> Type`. In other words, `Undefined` is a type constructor.
 
-We can now simply reuse our original definition for `head`:
+We can now reuse our original definition for `head`:
 
 ```javascript
 export const undefinedHead = arr =>
@@ -427,9 +429,9 @@ And in the PureScript module:
 foreign import undefinedHead :: forall a. Array a -> Undefined a
 ```
 
-The body of the `undefinedHead` function returns `arr[0]` which may be `undefined`, and the type signature correctly reflects that fact.
+The body of the `undefinedHead` function returns `arr[0]`, which may be `undefined`, and the type signature correctly reflects that fact.
 
-This function has the correct runtime representation for its type, but is quite useless since we have no way to use a value of type `Undefined a`. Well, not exactly. We can use this type in another FFI!
+This function has the correct runtime representation for its type, but it's quite useless since we have no way to use a value of type `Undefined a`. Well, not exactly. We can use this type in another FFI!
 
 We can write a function that will tell us whether a value is undefined or not:
 
@@ -451,7 +453,7 @@ isEmpty :: forall a. Array a -> Boolean
 isEmpty = isUndefined <<< undefinedHead
 ```
 
-Here, the foreign function we defined is very simple, which means we can benefit from the use of PureScript's typechecker as much as possible. This is good practice in general: foreign functions should be kept as small as possible, and application logic moved into PureScript code wherever possible.
+Here, the foreign function we defined is very simple, which means we can benefit from using PureScript's typechecker as much as possible. This is good practice in general: foreign functions should be kept as small as possible, and application logic moved into PureScript code wherever possible.
 
 ## Exceptions
 
@@ -500,9 +502,9 @@ export const unsafeHead = arr => {
 
 ## Using Type Class Member Functions
 
-Just like our earlier guide on passing the `Maybe` constructor over FFI, this is another case of writing PureScript that calls JavaScript, which in turn calls PureScript functions again. Here we will explore how to pass type class member functions over the FFI.
+Like our earlier guide on passing the `Maybe` constructor over FFI, this is another case of writing PureScript that calls JavaScript, which calls PureScript functions again. Here we will explore how to pass type class member functions over the FFI.
 
-We start with writing a foreign JavaScript function which expects the appropriate instance of `show` to match the type of `x`.
+We start with writing a foreign JavaScript function that expects the appropriate instance of `show` to match the type of `x`.
 
 ```js
 export const boldImpl = show => x =>
@@ -515,14 +517,14 @@ Then we write the matching signature:
 foreign import boldImpl :: forall a. (a -> String) -> a -> String
 ```
 
-and a wrapper function that passes the correct instance of `show`:
+And a wrapper function that passes the correct instance of `show`:
 
 ```hs
 bold :: forall a. Show a => a -> String
 bold x = boldImpl show x
 ```
 
-Alternatively in point-free form:
+Alternatively, in point-free form:
 
 ```hs
 bold :: forall a. Show a => a -> String
@@ -586,7 +588,7 @@ yell :: forall a. Show a => a -> Effect Unit
 yell = yellImpl show
 ```
 
-When testing this in the repl, notice that the string is printed directly to the console (instead of being quoted) and a `unit` value is returned.
+When testing this in the repl, notice that the string is printed directly to the console (instead of being quoted), and a `unit` value is returned.
 
 ```text
 $ spago repl
@@ -600,7 +602,7 @@ unit
 
 There are also `EffectFn` wrappers from `Effect.Uncurried`. These are similar to the `Fn` wrappers from `Data.Function.Uncurried` that we've already seen. These wrappers let you call uncurried effectful functions in PureScript.
 
-You'd generally only use these if you want to call existing JavaScript library APIs directly, rather than wrapping those APIs in curried functions. So it doesn't make much sense to present an example of uncurried `yell`, where the JavaScript relies on PureScript type class members, since you wouldn't find that in the existing JavaScript ecosystem.
+You'd generally only use these if you want to call existing JavaScript library APIs directly rather than wrapping those APIs in curried functions. So it doesn't make much sense to present an example of uncurried `yell`, where the JavaScript relies on PureScript type class members since you wouldn't find that in the existing JavaScript ecosystem.
 
 Instead, we'll modify our previous `diagonal` example to include logging in addition to returning the result:
 
@@ -672,7 +674,7 @@ unit
 done waiting
 ```
 
-Note that asynchronous logging in the repl just waits to print until the entire block has finished executing. This code behaves more predictably when run with `spago test` where there is a slight delay _between_ prints.
+Note that asynchronous logging in the repl waits to print until the entire block has finished executing. This code behaves more predictably when run with `spago test` where there is a slight delay _between_ prints.
 
 Let's look at another example where we return a value from a promise. This function is written with `async` and `await`, which is just syntactic sugar for promises.
 
@@ -717,7 +719,7 @@ Exercises for the above sections are still on the ToDo list. If you have any ide
 
 ## JSON
 
-There are many reasons to use JSON in an application, for example, it's a common means of communicating with web APIs. This section will discuss other use-cases too, beginning with a technique to improve type safety when passing structural data over the FFI.
+There are many reasons to use JSON in an application; for example, it's a common means of communicating with web APIs. This section will discuss other use-cases, too, beginning with a technique to improve type safety when passing structural data over the FFI.
 
 Let's revisit our earlier FFI functions `cumulativeSums` and `addComplex` and introduce a bug to each:
 
@@ -741,7 +743,7 @@ export const addComplexBroken = a => b => {
 };
 ```
 
-We can use the original type signatures, and the code will still compile, despite the fact that the return types are incorrect.
+We can use the original type signatures, and the code will still compile, despite the incorrect return types.
 
 ```hs
 foreign import cumulativeSumsBroken :: Array Int -> Array Int
@@ -892,8 +894,8 @@ Map String Int
 
 1. (Medium) Write a JavaScript function and PureScript wrapper `valuesOfMap :: Map String Int -> Either JsonDecodeError (Set Int)` that returns a `Set` of all the values in a `Map`. _Hint_: The `.values()` instance method for Map may be useful in your JavaScript code.
 1. (Easy) Write a new wrapper for the previous JavaScript function with the signature `valuesOfMapGeneric :: forall k v. Map k v -> Either JsonDecodeError (Set v)` so it works with a wider variety of maps. Note that you'll need to add some type class constraints for `k` and `v`. The compiler will guide you.
-1. (Medium) Rewrite the earlier `quadraticRoots` function as `quadraticRootsSet` which returns the `Complex` roots as a `Set` via JSON (instead of as a `Pair`).
-1. (Difficult) Rewrite the earlier `quadraticRoots` function as `quadraticRootsSafe` which uses JSON to pass the `Pair` of `Complex` roots over FFI. Don't use the `Pair` constructor in JavaScript, but instead, just return the pair in a decoder-compatible format.
+1. (Medium) Rewrite the earlier `quadraticRoots` function as `quadraticRootsSet` that returns the `Complex` roots as a `Set` via JSON (instead of as a `Pair`).
+1. (Difficult) Rewrite the earlier `quadraticRoots` function as `quadraticRootsSafe` that uses JSON to pass the `Pair` of `Complex` roots over FFI. Don't use the `Pair` constructor in JavaScript, but instead, just return the pair in a decoder-compatible format.
 _Hint_: You'll need to write a `DecodeJson` instance for `Pair`. Consult the [argonaut docs](https://github.com/purescript-contrib/purescript-argonaut-codecs/tree/main/docs#writing-new-instances) for instruction on writing your own decode instance. Their [decodeJsonTuple](https://github.com/purescript-contrib/purescript-argonaut-codecs/blob/master/src/Data/Argonaut/Decode/Class.purs) instance may also be a helpful reference.  Note that you'll need a `newtype` wrapper for `Pair` to avoid creating an "orphan instance".
 1. (Medium) Write a `parseAndDecodeArray2D :: String -> Either String (Array (Array Int))` function to parse and decode a JSON string containing a 2D array, such as `"[[1, 2, 3], [4, 5], [6]]"`. _Hint_: You'll need to use `jsonParser` to convert the `String` into `Json` before decoding.
 1. (Medium) The following data type represents a binary tree with values at the leaves:
@@ -919,7 +921,7 @@ _Hint_: You'll need to write a `DecodeJson` instance for `Pair`. Consult the [ar
 
 ## Address book
 
-In this section we will apply our newly-acquired FFI and JSON knowledge to build on our address book example from chapter 8. We will add the following features:
+In this section, we will apply our newly-acquired FFI and JSON knowledge to build on our address book example from Chapter 8. We will add the following features:
 
 - A Save button at the bottom of the form that, when clicked, serializes the state of the form to JSON and saves it in local storage.
 - Automatic retrieval of the JSON document from local storage upon page reload. The form fields are populated with the contents of this document.
@@ -983,7 +985,7 @@ Note that if we attempt to compile at this stage, we'll encounter the following 
     Data.Argonaut.Encode.Class.EncodeJson PhoneType
 ```
 
-This is because `PhoneType` in the `Person` record needs an `EncodeJson` instance. We'll just derive a generic encode instance, and a decode instance too while we're at it. More information how this works is available in the argonaut docs:
+This is because `PhoneType` in the `Person` record needs an `EncodeJson` instance. We'll also derive a generic encode instance and a decode instance while we're at it. More information on how this works is available in the argonaut docs:
 
 ```hs
 {{#include ../exercises/chapter10/src/Data/AddressBook.purs:import}}
@@ -999,7 +1001,7 @@ We'll start with retrieving the "person" string from local storage:
 item <- getItem "person"
 ```
 
-Then we'll create a helper function to handle converting the string from local storage to our `Person` record. Note that this string in storage may be `null`, so we represent it as a foreign `Json` until it is successfully decoded as a `String`. There are a number of other conversion steps along the way - each of which return an `Either` value, so it makes sense to organize these together in a `do` block.
+Then we'll create a helper function to convert the string from local storage to our `Person` record. Note that this string in storage may be `null`, so we represent it as a foreign `Json` until it is successfully decoded as a `String`. There are a number of other conversion steps along the way – each of which returns an `Either` value, so it makes sense to organize these together in a `do` block.
 
 ```hs
 processItem :: Json -> Either String Person
@@ -1009,7 +1011,7 @@ processItem item = do
   decodeJson j
 ```
 
-Then we inspect this result to see if it succeeded. If it failed, we'll log the errors and use our default `examplePerson`, otherwise we'll use the person retrieved from local storage.
+Then we inspect this result to see if it succeeded. If it fails, we'll log the errors and use our default `examplePerson`, otherwise, we'll use the person retrieved from local storage.
 
 ```hs
 initialPerson <- case processItem item of
@@ -1045,9 +1047,9 @@ processItem item = do
   lmap               ("Cannot decode Person: "       <> _) $ decodeJson j
 ```
 
-Only the first error should ever occur during normal operation of this app. You can trigger the other errors by opening your web browser's dev tools, editing the saved "person" string in local storage, and refreshing the page. How you modify the JSON string determines which error is triggered. See if you can trigger each of them.
+Only the first error should ever occur during the normal operation of this app. You can trigger the other errors by opening your web browser's dev tools, editing the saved "person" string in local storage, and refreshing the page. How you modify the JSON string determines which error is triggered. See if you can trigger each of them.
 
-That covers local storage. Next we'll implement the `alert` action, which is very similar to the `log` action from the `Effect.Console` module. The only difference is that the `alert` action uses the `window.alert` method, whereas the `log` action uses the `console.log` method. As such, `alert` can only be used in environments where `window.alert` is defined, such as a web browser.
+That covers local storage. Next, we'll implement the `alert` action, similar to the `log` action from the `Effect.Console` module. The only difference is that the `alert` action uses the `window.alert` method, whereas the `log` action uses the `console.log` method. As such, `alert` can only be used in environments where `window.alert` is defined, such as a web browser.
 
 ```hs
 foreign import alert :: String -> Effect Unit
@@ -1080,13 +1082,13 @@ alert $ "Error: " <> err <> ". Loading examplePerson"
 
 ## Conclusion
 
-In this chapter, we've learned how to work with foreign JavaScript code from PureScript and we've seen the issues involved with writing trustworthy code using the FFI:
+In this chapter, we've learned how to work with foreign JavaScript code from PureScript, and we've seen the issues involved with writing trustworthy code using the FFI:
 
 - We've seen the importance of ensuring that foreign functions have correct representations.
-- We learned how to deal with corner cases like null values and other types of JavaScript data, by using foreign types, or the `Json` data type.
+- We learned how to deal with corner cases like null values and other types of JavaScript data by using foreign types or the `Json` data type.
 - We saw how to safely serialize and deserialize JSON data.
 
-For more examples, the `purescript`, `purescript-contrib` and `purescript-node` GitHub organizations provide plenty of examples of libraries which use the FFI. In the remaining chapters, we will see some of these libraries put to use to solve real-world problems in a type-safe way.
+For more examples, the `purescript`, `purescript-contrib`, and `purescript-node` GitHub organizations provide plenty of examples of libraries that use the FFI. In the remaining chapters, we will see some of these libraries put to use to solve real-world problems in a type-safe way.
 
 ## Addendum
 
@@ -1104,7 +1106,7 @@ gcd 0 m = m
 gcd n 0 = n
 gcd n m
   | n > m     = gcd (n - m) m
-  | otherwise = gcd (m - n) n
+  | otherwise = gcd (m – n) n
 ```
 
 This function finds the greatest common divisor of two numbers by repeated subtraction. It is a nice example of a case where you might like to use PureScript to define the function, but have a requirement to call it from JavaScript: it is simple to define this function in PureScript using pattern matching and recursion, and the implementor can benefit from the use of the type checker.
@@ -1116,13 +1118,13 @@ import Test from 'Test.js';
 Test.gcd(15)(20);
 ```
 
-Here, I am assuming that the code was compiled with `spago build`, which compiles PureScript modules to ES modules. For that reason, I was able to reference the `gcd` function on the `Test` object, after importing the `Test` module using `import`.
+Here, I assume the code was compiled with `spago build`, which compiles PureScript modules to ES modules. For that reason, I could reference the `gcd` function on the `Test` object, after importing the `Test` module using `import`.
 
 You can also use the `spago bundle-app` and `spago bundle-module` commands to bundle your generated JavaScript into a single file. Consult [the documentation](https://github.com/purescript/spago#bundle-a-project-into-a-single-js-file) for more information.
 
 ### Understanding Name Generation
 
-PureScript aims to preserve names during code generation as much as possible. In particular, most identifiers which are neither PureScript nor JavaScript keywords can be expected to be preserved, at least for names of top-level declarations.
+PureScript aims to preserve names during code generation as much as possible. In particular, most identifiers that are neither PureScript nor JavaScript keywords can be expected to be preserved, at least for names of top-level declarations.
 
 If you decide to use a JavaScript keyword as an identifier, the name will be escaped with a double dollar symbol. For example,
 
@@ -1130,7 +1132,7 @@ If you decide to use a JavaScript keyword as an identifier, the name will be esc
 null = []
 ```
 
-generates the following JavaScript:
+Generates the following JavaScript:
 
 ```javascript
 var $$null = [];
@@ -1142,17 +1144,17 @@ In addition, if you would like to use special characters in your identifier name
 example' = 100
 ```
 
-generates the following JavaScript:
+Generates the following JavaScript:
 
 ```javascript
 var example$prime = 100;
 ```
 
-Where compiled PureScript code is intended to be called from JavaScript, it is recommended that identifiers only use alphanumeric characters, and avoid JavaScript keywords. If user-defined operators are provided for use in PureScript code, it is good practice to provide an alternative function with an alphanumeric name for use in JavaScript.
+Where compiled PureScript code is intended to be called from JavaScript, it is recommended that identifiers only use alphanumeric characters and avoid JavaScript keywords. If user-defined operators are provided for use in PureScript code, it is good practice to provide an alternative function with an alphanumeric name for use in JavaScript.
 
 ### Runtime Data Representation
 
-Types allow us to reason at compile-time that our programs are "correct" in some sense - that is, they will not break at runtime. But what does that mean? In PureScript, it means that the type of an expression should be compatible with its representation at runtime.
+Types allow us to reason at compile-time that our programs are "correct" in some sense – that is, they will not break at runtime. But what does that mean? In PureScript, it means that the type of an expression should be compatible with its representation at runtime.
 
 For that reason, it is important to understand the representation of data at runtime to be able to use PureScript and JavaScript code together effectively. This means that for any given PureScript expression, we should be able to understand the behavior of the value it will evaluate to at runtime.
 
@@ -1160,21 +1162,21 @@ The good news is that PureScript expressions have particularly simple representa
 
 For simple types, the correspondence is almost trivial. For example, if an expression has the type `Boolean`, then its value `v` at runtime should satisfy `typeof v === 'boolean'`. That is, expressions of type `Boolean` evaluate to one of the (JavaScript) values `true` or `false`. In particular, there is no PureScript expression of type `Boolean` which evaluates to `null` or `undefined`.
 
-A similar law holds for expressions of type `Int`, `Number`, and `String` - expressions of type `Int` or `Number` evaluate to non-null JavaScript numbers, and expressions of type `String` evaluate to non-null JavaScript strings. Expressions of type `Int` will evaluate to integers at runtime, even though they cannot be distinguished from values of type `Number` by using `typeof`.
+A similar law holds for expressions of type `Int`, `Number`, and `String` – expressions of type `Int` or `Number` evaluate to non-null JavaScript numbers, and expressions of type `String` evaluate to non-null JavaScript strings. Expressions of type `Int` will evaluate to integers at runtime, even though they cannot be distinguished from values of type `Number` by using `typeof`.
 
-What about `Unit`? Well, since `Unit` has only one inhabitant (`unit`) and its value is not observable, it doesn't actually matter what it's represented with at runtime. Old code tends to represent it using `{}`. Newer code, however, tends to use `undefined`. So, although it doesn't really matter what you use to represent `Unit`, it is recommended to use `undefined` (not returning anything from a function also returns `undefined`).
+What about `Unit`? Well, since `Unit` has only one inhabitant (`unit`) and its value is not observable, it doesn't matter what it's represented with at runtime. Old code tends to represent it using `{}`. Newer code, however, tends to use `undefined`. So, although it doesn't matter what you use to represent `Unit`, it is recommended to use `undefined` (not returning anything from a function also returns `undefined`).
 
 What about some more complex types?
 
-As we have already seen, PureScript functions correspond to JavaScript functions of a single argument. More precisely, if an expression `f` has type `a -> b` for some types `a` and `b`, and an expression `x` evaluates to a value with the correct runtime representation for type `a`, then `f` evaluates to a JavaScript function, which when applied to the result of evaluating `x`, has the correct runtime representation for type `b`. As a simple example, an expression of type `String -> String` evaluates to a function which takes non-null JavaScript strings to non-null JavaScript strings.
+As we have already seen, PureScript functions correspond to JavaScript functions of a single argument. More precisely, if an expression `f` has type `a -> b` for some types `a` and `b`, and an expression `x` evaluates to a value with the correct runtime representation for type `a`, then `f` evaluates to a JavaScript function, which, when applied to the result of evaluating `x`, has the correct runtime representation for type `b`. As a simple example, an expression of type `String -> String` evaluates to a function that takes non-null JavaScript strings to non-null JavaScript strings.
 
-As you might expect, PureScript's arrays correspond to JavaScript arrays. But remember - PureScript arrays are homogeneous, so every element has the same type. Concretely, if a PureScript expression `e` has type `Array a` for some type `a`, then `e` evaluates to a (non-null) JavaScript array, all of whose elements have the correct runtime representation for type `a`.
+As you might expect, PureScript's arrays correspond to JavaScript arrays. But remember – PureScript arrays are homogeneous, so every element has the same type. Concretely, if a PureScript expression `e` has type `Array a` for some type `a`, then `e` evaluates to a (non-null) JavaScript array, all of whose elements have the correct runtime representation for type `a`.
 
-We've already seen that PureScript's records evaluate to JavaScript objects. Just as for functions and arrays, we can reason about the runtime representation of data in a record's fields by considering the types associated with its labels. Of course, the fields of a record are not required to be of the same type.
+We've already seen that PureScript's records evaluate to JavaScript objects. As for functions and arrays, we can reason about the runtime representation of data in a record's fields by considering the types associated with its labels. Of course, the fields of a record are not required to be of the same type.
 
 ### Representing ADTs
 
-For every constructor of an algebraic data type, the PureScript compiler creates a new JavaScript object type by defining a function. Its constructors correspond to functions which create new JavaScript objects based on those prototypes.
+For every constructor of an algebraic data type, the PureScript compiler creates a new JavaScript object type by defining a function. Its constructors correspond to functions that create new JavaScript objects based on those prototypes.
 
 For example, consider the following simple ADT:
 
@@ -1203,13 +1205,13 @@ Here, we see two JavaScript object types: `Zero` and `One`. It is possible to cr
 
 The PureScript compiler also generates helper functions. For constructors with no arguments, the compiler generates a `value` property, which can be reused instead of using the `new` operator repeatedly. For constructors with one or more arguments, the compiler generates a `create` function, which takes arguments with the appropriate representation and applies the appropriate constructor.
 
-What about constructors with more than one argument? In that case, the PureScript compiler also creates a new object type, and a helper function. This time, however, the helper function is curried function of two arguments. For example, this algebraic data type:
+What about constructors with more than one argument? In that case, the PureScript compiler also creates a new object type, and a helper function. This time, however, the helper function is a curried function of two arguments. For example, this algebraic data type:
 
 ```haskell
 data Two a b = Two a b
 ```
 
-generates this JavaScript code:
+Generates this JavaScript code:
 
 ```javascript
 function Two(value0, value1) {
@@ -1224,17 +1226,17 @@ Two.create = function (value0) {
 };
 ```
 
-Here, values of the object type `Two` can be created using the `new` keyword, or by using the `Two.create` function.
+Here, values of the object type `Two` can be created using the `new` keyword or by using the `Two.create` function.
 
-The case of newtypes is slightly different. Recall that a newtype is like an algebraic data type, restricted to having a single constructor taking a single argument. In this case, the runtime representation of the newtype is actually the same as the type of its argument.
+The case of newtypes is slightly different. Recall that a newtype is like an algebraic data type, restricted to having a single constructor taking a single argument. In this case, the runtime representation of the newtype is the same as its argument type.
 
-For example, this newtype representing telephone numbers:
+For example, this newtype represents telephone numbers is represented as a JavaScript string at runtime:
 
 ```haskell
 newtype PhoneNumber = PhoneNumber String
 ```
 
-is actually represented as a JavaScript string at runtime. This is useful for designing libraries, since newtypes provide an additional layer of type safety, but without the runtime overhead of another function call.
+This is useful for designing libraries since newtypes provide an additional layer of type safety without the runtime overhead of another function call.
 
 ### Representing Quantified Types
 
@@ -1259,7 +1261,7 @@ In fact, the `identity` function is the _only_ (total) function with this type! 
 
 What is the runtime representation of a quantified type `forall a. t`? Well, any expression with the runtime representation for this type must have the correct runtime representation for the type `t` for any choice of type `a`. In our example above, a function of type `forall a. a -> a` must have the correct runtime representation for the types `String -> String`, `Number -> Number`, `Array Boolean -> Array Boolean`, and so on. It must take strings to strings, numbers to numbers, etc.
 
-But that is not enough - the runtime representation of a quantified type is more strict than this. We require any expression to be _parametrically polymorphic_ - that is, it cannot use any information about the type of its argument in its implementation. This additional condition prevents problematic implementations such as the following JavaScript function from inhabiting a polymorphic type:
+But that is not enough – the runtime representation of a quantified type is more strict than this. We require any expression to be _parametrically polymorphic_ – that is, it cannot use any information about the type of its argument in its implementation. This additional condition prevents problematic implementations such as the following JavaScript function from inhabiting a polymorphic type:
 
 ```javascript
 function invalid(a) {
@@ -1271,17 +1273,17 @@ function invalid(a) {
 }
 ```
 
-Certainly, this function takes strings to strings, numbers to numbers, etc. but it does not meet the additional condition, since it inspects the (runtime) type of its argument, so this function would not be a valid inhabitant of the type `forall a. a -> a`.
+Certainly, this function takes strings to strings, numbers to numbers, etc. But it does not meet the additional condition, since it inspects the (runtime) type of its argument, so this function would not be a valid inhabitant of the type `forall a. a -> a`.
 
-Without being able to inspect the runtime type of our function argument, our only option is to return the argument unchanged, and so `identity` is indeed the only inhabitant of the type `forall a. a -> a`.
+Without being able to inspect the runtime type of our function argument, our only option is to return the argument unchanged. So `identity` is indeed the only inhabitant of the type `forall a. a -> a`.
 
-A full discussion of _parametric polymorphism_ and _parametricity_ is beyond the scope of this book. Note however, that since PureScript's types are _erased_ at runtime, a polymorphic function in PureScript _cannot_ inspect the runtime representation of its arguments (without using the FFI), and so this representation of polymorphic data is appropriate.
+A full discussion of _parametric polymorphism_ and _parametricity_ is beyond the scope of this book. Note, however, that since PureScript's types are _erased_ at runtime, a polymorphic function in PureScript _cannot_ inspect the runtime representation of its arguments (without using the FFI), so this representation of polymorphic data is appropriate.
 
 ### Representing Constrained Types
 
-Functions with a type class constraint have an interesting representation at runtime. Because the behavior of the function might depend on the type class instance chosen by the compiler, the function is given an additional argument, called a _type class dictionary_, which contains the implementation of the type class functions provided by the chosen instance.
+Functions with a type class constraint have an interesting representation at runtime. Because the function's behavior might depend on the type class instance chosen by the compiler, the function is given an additional argument, called a _type class dictionary_, which contains the implementation of the type class functions provided by the chosen instance.
 
-For example, here is a simple PureScript function with a constrained type which uses the `Show` type class:
+For example, here is a simple PureScript function with a constrained type that uses the `Show` type class:
 
 ```haskell
 shout :: forall a. Show a => a -> String
@@ -1323,7 +1325,7 @@ shout(showNumber)(42);
 
 ### Representing Side Effects
 
-The `Effect` monad is also defined as a foreign type. Its runtime representation is quite simple - an expression of type `Effect a` should evaluate to a JavaScript function of **no arguments**, which performs any side-effects and returns a value with the correct runtime representation for type `a`.
+The `Effect` monad is also defined as a foreign type. Its runtime representation is quite simple – an expression of type `Effect a` should evaluate to a JavaScript function of **no arguments**, which performs any side-effects and returns a value with the correct runtime representation for type `a`.
 
 The definition of the `Effect` type constructor is given in the `Effect` module as follows:
 
@@ -1343,7 +1345,7 @@ The definition of the `random` function is given here:
 export const random = Math.random;
 ```
 
-Notice that the `random` function is represented at runtime as a function of no arguments. It performs the side effect of generating a random number, and returns it, and the return value matches the runtime representation of the `Number` type: it is a non-null JavaScript number.
+Notice that the `random` function is represented at runtime as a function of no arguments. It performs the side effect of generating a random number, returns it, and the return value matches the runtime representation of the `Number` type: it is a non-null JavaScript number.
 
 As a slightly more interesting example, consider the `log` function defined by the `Effect.Console` module in the `console` package. The `log` function has the following type:
 
@@ -1371,4 +1373,4 @@ import { main } from 'Main'
 main();
 ```
 
-When using `spago bundle-app --to` or `spago run`, this call to `main` is generated automatically, whenever the `Main` module is defined.
+When using `spago bundle-app --to` or `spago run`, this call to `main` is generated automatically whenever the `Main` module is defined.

--- a/text/chapter11.md
+++ b/text/chapter11.md
@@ -2,7 +2,7 @@
 
 ## Chapter Goals
 
-The goal of this chapter will be to learn about _monad transformers_, which provide a way to combine side-effects provided by different monads. The motivating example will be a text adventure game which can be played on the console in NodeJS. The various side-effects of the game (logging, state, and configuration) will all be provided by a monad transformer stack.
+The goal of this chapter will be to learn about _monad transformers_, which provide a way to combine side-effects provided by different monads. The motivating example will be a text adventure game that can be played on the console in NodeJS. The various side-effects of the game (logging, state, and configuration) will all be provided by a monad transformer stack.
 
 ## Project Setup
 
@@ -11,13 +11,13 @@ This module's project introduces the following new dependencies:
 - `ordered-collections`, which provides data types for immutable maps and sets
 - `transformers`, which provides implementations of standard monad transformers
 - `node-readline`, which provides FFI bindings to the [`readline`](https://nodejs.org/api/readline.html) interface provided by NodeJS
-- `optparse`, which provides applicative parsers for processing command line arguments
+- `optparse`, which provides applicative parsers for processing command-line arguments
 
 ## How To Play The Game
 
 To run the project, use `spago run`
 
-By default you will see a usage message:
+By default, you will see a usage message:
 
 ```text
 Monadic Adventures! A game to learn monad transformers
@@ -32,7 +32,8 @@ Available options:
   -h,--help                Show this help text
 ```
 
-To provide command line arguments, you can either call `spago run` with the `-a` option to pass additional arguments directly to your application, or you can call `spago bundle-app`, which will create an index.js file that can be run directly with `node`.  
+To provide command line arguments, you can either call `spago run` with the `-a` option to pass additional arguments directly to your application or call `spago bundle-app`, which will create an index.js file that can be run directly with `node`.
+
 For example, to provide the player name using the `-p` option:
 
 ```text
@@ -46,9 +47,9 @@ $ node index.js -p Phil
 >
 ```
 
-From the prompt, you can enter commands like `look`, `inventory`, `take`, `use`, `north`, `south`, `east`, and `west`. There is also a `debug` command, which can be used to print the game state when the `--debug` command line option is provided.
+From the prompt, you can enter commands like `look`, `inventory`, `take`, `use`, `north`, `south`, `east`, and `west`. There is also a `debug` command, which can print the game state when the `--debug` command line option is provided.
 
-The game is played on a two-dimensional grid, and the player moves by issuing commands `north`, `south`, `east`, and `west`. The game contains a collection of items which can either be in the player's possession (in the user's _inventory_), or on the game grid at some location. Items can be picked up by the player, using the `take` command.
+The game is played on a two-dimensional grid, and the player moves by issuing commands `north`, `south`, `east`, and `west`. The game contains a collection of items that can either be in the player's possession (in the user's _inventory_) or on the game grid at some location. Items can be picked up by the player using the `take` command.
 
 For reference, here is a complete walkthrough of the game:
 
@@ -82,15 +83,15 @@ Congratulations, Phil!
 You win!
 ```
 
-The game is very simple, but the aim of the chapter is to use the `transformers` package to build a library which will enable rapid development of this type of game.
+The game is very simple, but the aim of the chapter is to use the `transformers` package to build a library that will enable rapid development of this type of game.
 
 ## The State Monad
 
 We will start by looking at some of the monads provided by the `transformers` package.
 
-The first example is the `State` monad, which provides a way to model _mutable state_ in pure code. We have already seen an approach to mutable state provided by the `Effect` monad. `State` provides an alternative.
+The first example is the `State` monad, which provides a way to model _mutable state_ in pure code. We have already seen an approach to a mutable state provided by the `Effect` monad. `State` provides an alternative.
 
-The `State` type constructor takes two type parameters: the type `s` of the state, and the return type `a`. Even though we speak of the "`State` monad", the instance of the `Monad` type class is actually provided for the `State s` type constructor, for any type `s`.
+The `State` type constructor takes two type parameters: the type `s` of the state and the return type `a`. Even though we speak of the "`State` monad", the instance of the `Monad` type class is actually provided for the `State s` type constructor for any type `s`.
 
 The `Control.Monad.State` module provides the following API:
 
@@ -102,9 +103,9 @@ modify  :: forall s. (s -> s) -> State s s
 modify_ :: forall s. (s -> s) -> State s Unit
 ```
 
-Note that these API signatures are presented in a simplified form using the `State` type constructor for now. The actual API involves `MonadState` which we'll cover in the later "Type Classes" section of this chapter, so don't worry if you see different signatures in your IDE tooltips or on Pursuit.
+Note that these API signatures are presented in a simplified form using the `State` type constructor for now. The actual API involves `MonadState`, which we'll cover in the later "Type Classes" section of this chapter, so don't worry if you see different signatures in your IDE tooltips or on Pursuit.
 
-Let's see an example. One use of the `State` monad might be to add the values in an array of integers to the current state. We could do that by choosing `Int` as the state type `s`, and using `traverse_` to traverse the array, with a call to `modify` for each array element:
+Let's see an example. One use of the `State` monad might be to add the values in an array of integers to the current state. We could do that by choosing `Int` as the state type `s` and using `traverse_` to traverse the array, with a call to `modify` for each array element:
 
 ```haskell
 import Data.Foldable (traverse_)
@@ -123,7 +124,7 @@ execState :: forall s a. State s a -> s -> s
 runState  :: forall s a. State s a -> s -> Tuple a s
 ```
 
-Each of these functions takes an initial state of type `s` and a computation of type `State s a`. `evalState` only returns the return value, `execState` only returns the final state, and `runState` returns both, expressed as a value of type `Tuple a s`.
+Each function takes an initial state of type `s` and a computation of type `State s a`. `evalState` only returns the return value, `execState` only returns the final state, and `runState` returns both, expressed as a value of type `Tuple a s`.
 
 Given the `sumArray` function above, we could use `execState` in PSCi to sum the numbers in several arrays as follows:
 
@@ -140,8 +141,7 @@ Given the `sumArray` function above, we could use `execState` in PSCi to sum the
 ## Exercises
 
  1. (Easy) What is the result of replacing `execState` with `runState` or `evalState` in our example above?
- 1. (Medium) A string of parentheses is _balanced_ if it is obtained by either concatenating zero-or-more shorter balanced
-     strings, or by wrapping a shorter balanced string in a pair of parentheses.
+ 1. (Medium) A string of parentheses is _balanced_ if it is obtained by either concatenating zero-or-more shorter balanced strings or wrapping a shorter balanced string in a pair of parentheses.
 
      Use the `State` monad and the `traverse_` function to write a function
 
@@ -149,8 +149,7 @@ Given the `sumArray` function above, we could use `execState` in PSCi to sum the
      testParens :: String -> Boolean
      ```
 
-     which tests whether or not a `String` of parentheses is balanced, by keeping track of the number of opening parentheses
-     which have not been closed. Your function should work as follows:
+     which tests whether or not a `String` of parentheses is balanced by keeping track of the number of opening parentheses that have not been closed. Your function should work as follows:
 
      ```text
      > testParens ""
@@ -231,7 +230,7 @@ type Level = Int
 type Doc = Reader Level String
 ```
 
- 1. (Easy) Write a function `line` which renders a function at the current indentation level. Your function should have the following type:
+ 1. (Easy) Write a function `line` that renders a function at the current indentation level. Your function should have the following type:
 
      ```haskell
      line :: String -> Doc
@@ -260,7 +259,7 @@ type Doc = Reader Level String
 
      which renders a document as a String.
 
- You should now be able to use your library to write simple documents, as follows:
+ You should now be able to use your library to write simple documents as follows:
 
  ```haskell
  render $ cat
@@ -275,11 +274,11 @@ type Doc = Reader Level String
 
 ## The Writer Monad
 
-The `Writer` monad provides the ability to accumulate a secondary value in addition to the return value of a computation.
+The `Writer` monad allows accumulating a secondary value in addition to the return value of a computation.
 
-A common use case is to accumulate a log of type `String` or `Array String`, but the `Writer` monad is more general than this. It can actually be used to accumulate a value in any monoid, so it might be used to keep track of an integer total using the `Additive Int` monoid, or to track whether any of several intermediate `Boolean` values were true, using the `Disj Boolean` monoid.
+A common use case is to accumulate a log of type `String` or `Array String`, but the `Writer` monad is more general than this. It can accumulate a value in any monoid, so it might be used to keep track of an integer total using the `Additive Int` monoid or to track whether any of several intermediate `Boolean` values were true using the `Disj Boolean` monoid.
 
-The `Writer` type constructor takes two type arguments: a type `w` which should be an instance of the `Monoid` type class, and the return type `a`.
+The `Writer` type constructor takes two type arguments: a type `w` that should be an instance of the `Monoid` type class, and the return type `a`.
 
 The key element of the `Writer` API is the `tell` function:
 
@@ -289,7 +288,7 @@ tell :: forall w a. Monoid w => w -> Writer w Unit
 
 The `tell` action appends the provided value to the current accumulated result.
 
-As an example, let's add a log to an existing function by using the `Array String` monoid. Consider our previous implementation of the _greatest common divisor_ function:
+As an example, let's add a log to an existing function using the `Array String` monoid. Consider our previous implementation of the _greatest common divisor_ function:
 
 ```haskell
 gcd :: Int -> Int -> Int
@@ -343,7 +342,7 @@ Tuple 3 ["gcdLog 21 15","gcdLog 6 15","gcdLog 6 9","gcdLog 6 3","gcdLog 3 3"]
 ## Exercises
 
  1. (Medium) Rewrite the `sumArray` function above using the `Writer` monad and the `Additive Int` monoid from the `monoid` package.
- 1. (Medium) The _Collatz_ function is defined on natural numbers `n` as `n / 2` when `n` is even, and `3 * n + 1` when `n` is odd. For example, the iterated Collatz sequence starting at `10` is as follows:
+ 1. (Medium) The _Collatz_ function is defined on natural numbers `n` as `n / 2` when `n` is even and `3 * n + 1` when `n` is odd. For example, the iterated Collatz sequence starting at `10` is as follows:
 
      ```text
      10, 5, 16, 8, 4, 2, 1, ...
@@ -351,19 +350,19 @@ Tuple 3 ["gcdLog 21 15","gcdLog 6 15","gcdLog 6 9","gcdLog 6 3","gcdLog 3 3"]
 
      It is conjectured that the iterated Collatz sequence always reaches `1` after some finite number of applications of the Collatz function.
 
-     Write a function which uses recursion to calculate how many iterations of the Collatz function are required before the sequence reaches `1`.
+     Write a function that uses recursion to calculate how many iterations of the Collatz function are required before the sequence reaches `1`.
 
      Modify your function to use the `Writer` monad to log each application of the Collatz function.
 
 ## Monad Transformers
 
-Each of the three monads above: `State`, `Reader` and `Writer`, are also examples of so-called _monad transformers_. The equivalent monad transformers are called `StateT`, `ReaderT`, and `WriterT` respectively.
+Each of the three monads above: `State`, `Reader`, and `Writer`, are also examples of so-called _monad transformers_. The equivalent monad transformers are called `StateT`, `ReaderT`, and `WriterT`, respectively.
 
 What is a monad transformer? Well, as we have seen, a monad augments PureScript code with some type of side effect, which can be interpreted in PureScript by using the appropriate handler (`runState`, `runReader`, `runWriter`, etc.) This is fine if we only need to use _one_ side-effect. However, it is often useful to use more than one side-effect at once. For example, we might want to use `Reader` together with `Maybe` to express _optional results_ in the context of some global configuration. Or we might want the mutable state provided by the `State` monad together with the pure error tracking capability of the `Either` monad. This is the problem solved by _monad transformers_.
 
-Note that we have already seen that the `Effect` monad provides a partial solution to this problem. Monad transformers provide another solution, and each approach has its own benefits and limitations.
+Note that we have already seen that the `Effect` monad partially solves this problem. Monad transformers provide another solution, and each approach has its own benefits and limitations.
 
-A monad transformer is a type constructor which is parameterized not only by a type, but by another type constructor. It takes one monad and turns it into another monad, adding its own variety of side-effects.
+A monad transformer is a type constructor parameterized by a type and another type constructor. It takes one monad and turns it into another monad, adding its own variety of side-effects.
 
 Let's see an example. The monad transformer version of the `State` monad is `StateT`, defined in the `Control.Monad.State.Trans` module. We can find the kind of `StateT` using PSCi:
 
@@ -396,20 +395,20 @@ We are left with a type constructor. The final argument represents the return ty
 Type
 ```
 
-Finally we are left with something of kind `Type`, which means we can try to find values of this type.
+Finally, we are left with something of kind `Type`, which means we can try to find values of this type.
 
-The monad we have constructed - `StateT String (Either String)` - represents computations which can fail with an error, and which can use mutable state.
+The monad we have constructed – `StateT String (Either String)` – represents computations that can fail with an error and use mutable state.
 
-We can use the actions of the outer `StateT String` monad (`get`, `put`, and `modify`) directly, but in order to use the effects of the wrapped monad (`Either String`), we need to "lift" them over the monad transformer. The `Control.Monad.Trans` module defines the `MonadTrans` type class, which captures those type constructors which are monad transformers, as follows:
+We can use the actions of the outer `StateT String` monad (`get`, `put`, and `modify`) directly, but to use the effects of the wrapped monad (`Either String`), we need to "lift" them over the monad transformer. The `Control.Monad.Trans` module defines the `MonadTrans` type class, which captures those type constructors which are monad transformers, as follows:
 
 ```haskell
 class MonadTrans t where
   lift :: forall m a. Monad m => m a -> t m a
 ```
 
-This class contains a single member, `lift`, which takes computations in any underlying monad `m` and lifts them into the wrapped monad `t m`. In our case, the type constructor `t` is `StateT String`, and `m` is the `Either String` monad, so `lift` provides a way to lift computations of type `Either String a` to computations of type `StateT String (Either String) a`. This means that we can use the effects of `StateT String` and `Either String` side-by-side, as long as we use `lift` every time we use a computation of type `Either String a`.
+This class contains a single member, `lift`, which takes computations in any underlying monad `m` and lifts them into the wrapped monad `t m`. In our case, the type constructor `t` is `StateT String`,  `m` is the `Either String` monad, so `lift` provides a way to lift computations of type `Either String a` to computations of type `StateT String (Either String) a`. This means that we can use the effects of `StateT String` and `Either String` side-by-side, as long as we use `lift` every time we use a computation of type `Either String a`.
 
-For example, the following computation reads the underlying state, and then throws an error if the state is the empty string:
+For example, the following computation reads the underlying state and then throws an error if the state is the empty string:
 
 ```haskell
 import Data.String (drop, take)
@@ -424,7 +423,7 @@ split = do
       pure (take 1 s)
 ```
 
-If the state is not empty, the computation uses `put` to update the state to `drop 1 s` (that is, `s` with the first character removed), and returns `take 1 s` (that is, the first character of `s`).
+If the state is not empty, the computation uses `put` to update the state to `drop 1 s` (that is, `s` with the first character removed) and returns `take 1 s` (that is, the first character of `s`).
 
 Let's try this in PSCi:
 
@@ -436,18 +435,18 @@ Right (Tuple "t" "est")
 Left "Empty string"
 ```
 
-This is not very remarkable, since we could have implemented this without `StateT`. However, since we are working in a monad, we can use do notation or applicative combinators to build larger computations from smaller ones. For example, we can apply `split` twice to read the first two characters from a string:
+This is not very remarkable since we could have implemented this without `StateT`. However, since we are working in a monad, we can use do notation or applicative combinators to build larger computations from smaller ones. For example, we can apply `split` twice to read the first two characters from a string:
 
 ```text
 > runStateT ((<>) <$> split <*> split) "test"
 (Right (Tuple "te" "st"))
 ```
 
-We can use the `split` function with a handful of other actions to build a basic parsing library. In fact, this is the approach taken by the `parsing` library. This is the power of monad transformers - we can create custom-built monads for a variety of problems, choosing the side-effects that we need, and keeping the expressiveness of do notation and applicative combinators.
+We can use the `split` function with a handful of other actions to build a basic parsing library. In fact, this is the approach taken by the `parsing` library. This is the power of monad transformers – we can create custom-built monads for various problems, choose the side-effects we need, and keep the expressiveness of do notation and applicative combinators.
 
 ## The ExceptT Monad Transformer
 
-The `transformers` package also defines the `ExceptT e` monad transformer, which is the transformer corresponding to the `Either e` monad. It provides the following API:
+The `transformers` package also defines the `ExceptT e` monad transformer, corresponding to the `Either e` monad. It provides the following API:
 
 ```haskell
 class MonadError e m where
@@ -459,7 +458,7 @@ instance Monad m => MonadError e (ExceptT e m)
 runExceptT :: forall e m a. ExceptT e m a -> m (Either e a)
 ```
 
-The `MonadError` class captures those monads which support throwing and catching of errors of some type `e`, and an instance is provided for the `ExceptT e` monad transformer. The `throwError` action can be used to indicate failure, just like `Left` in the `Either e` monad. The `catchError` action allows us to continue after an error is thrown using `throwError`.
+The `MonadError` class captures those monads that support throwing and catching errors of some type `e`, and an instance is provided for the `ExceptT e` monad transformer. The `throwError` action can indicate failure, like `Left` in the `Either e` monad. The `catchError` action allows us to continue after an error is thrown using `throwError`.
 
 The `runExceptT` handler is used to run a computation of type `ExceptT e m a`.
 
@@ -489,15 +488,15 @@ If we test this function in PSCi, we can see how the two effects of accumulating
 Tuple (Left "Error!") ["Before the error"]
 ```
 
-Note that only those log messages which were written before the error was thrown actually get appended to the log.
+Note that only those log messages that were written before the error was thrown get appended to the log.
 
 ## Monad Transformer Stacks
 
-As we have seen, monad transformers can be used to build new monads on top of existing monads. For some monad transformer `t1` and some monad `m`, the application `t1 m` is also a monad. That means that we can apply a _second_ monad transformer `t2` to the result `t1 m` to construct a third monad `t2 (t1 m)`. In this way, we can construct a _stack_ of monad transformers, which combine the side-effects provided by their constituent monads.
+As we have seen, monad transformers can be used to build new monads on top of existing monads. For some monad transformer `t1` and some monad `m`, the application `t1 m` is also a monad. That means we can apply a _second_ monad transformer `t2` to the result `t1 m` to construct a third monad `t2 (t1 m)`. In this way, we can construct a _stack_ of monad transformers, which combine the side-effects provided by their constituent monads.
 
-In practice, the underlying monad `m` is either the `Effect` monad, if native side-effects are required, or the `Identity` monad, defined in the `Data.Identity` module. The `Identity` monad adds no new side-effects, so transforming the `Identity` monad only provides the effects of the monad transformer. In fact, the `State`, `Reader` and `Writer` monads are implemented by transforming the `Identity` monad with `StateT`, `ReaderT` and `WriterT` respectively.
+In practice, the underlying monad `m` is either the `Effect` monad, if native side-effects are required, or the `Identity` monad, defined in the `Data.Identity` module. The `Identity` monad adds no new side-effects, so transforming the `Identity` monad only provides the effects of the monad transformer. The `State`, `Reader`, and `Writer` monads are implemented by transforming the `Identity` monad with `StateT`, `ReaderT`, and `WriterT`, respectively.
 
-Let's see an example in which three side effects are combined. We will use the `StateT`, `WriterT` and `ExceptT` effects, with the `Identity` monad on the bottom of the stack. This monad transformer stack will provide the side effects of mutable state, accumulating a log, and pure errors.
+Let's see an example in which three side effects are combined. We will use the `StateT`, `WriterT`, and `ExceptT` effects, with the `Identity` monad on the bottom of the stack. This monad transformer stack will provide the side effects of mutable state, accumulating a log, and pure errors.
 
 We can use this monad transformer stack to reproduce our `split` action with the added feature of logging.
 
@@ -521,7 +520,7 @@ split = do
 
 If we test this computation in PSCi, we see that the state is appended to the log for every invocation of `split`.
 
-Note that we have to remove the side-effects in the order in which they appear in the monad transformer stack: first we use `runStateT` to remove the `StateT` type constructor, then `runWriterT`, then `runExceptT`. Finally, we run the computation in the `Identity` monad by using `unwrap`.
+Note that we have to remove the side-effects in the order in which they appear in the monad transformer stack: first, we use `runStateT` to remove the `StateT` type constructor, then `runWriterT`, then `runExceptT`. Finally, we run the computation in the `Identity` monad by using `unwrap`.
 
 ```text
 > runParser p s = unwrap $ runExceptT $ runWriterT $ runStateT p s
@@ -540,9 +539,9 @@ However, if the parse is unsuccessful because the state is empty, then no log is
 (Left ["Empty string"])
 ```
 
-This is because of the way in which the side-effects provided by the `ExceptT` monad transformer interact with the side-effects provided by the `WriterT` monad transformer. We can address this by changing the order in which the monad transformer stack is composed. If we move the `ExceptT` transformer to the top of the stack, then the log will contain all messages written up until the first error, as we saw earlier when we transformed `Writer` with `ExceptT`.
+This is because of how the side-effects provided by the `ExceptT` monad transformer interact with the side-effects provided by the `WriterT` monad transformer. We can address this by changing the order in which the monad transformer stack is composed. If we move the `ExceptT` transformer to the top of the stack, then the log will contain all messages written up until the first error, as we saw earlier when we transformed `Writer` with `ExceptT`.
 
-One problem with this code is that we have to use the `lift` function multiple times to lift computations over multiple monad transformers: for example, the call to `throwError` has to be lifted twice, once over `WriterT` and a second time over `StateT`. This is fine for small monad transformer stacks, but quickly becomes inconvenient.
+One problem with this code is that we have to use the `lift` function multiple times to lift computations over multiple monad transformers; for example, the call to `throwError` has to be lifted twice, once over `WriterT` and a second time over `StateT`. This is fine for small monad transformer stacks but quickly becomes inconvenient.
 
 Fortunately, as we will see, we can use the automatic code generation provided by type class inference to do most of this "heavy lifting" for us.
 
@@ -555,7 +554,7 @@ Fortunately, as we will see, we can use the automatic code generation provided b
      string :: String -> Parser String
      ```
 
-     which matches a string as a prefix of the current state, or fails with an error message.
+     which matches a string as a prefix of the current state or fails with an error message.
 
      Your parser should work as follows:
 
@@ -565,7 +564,7 @@ Fortunately, as we will see, we can use the automatic code generation provided b
      ```
 
      _Hint_: you can use the implementation of `split` as a starting point. You might find the `stripPrefix` function useful.
- 1. (Difficult) Use the `ReaderT` and `WriterT` monad transformers to reimplement the document printing library which we wrote earlier using the `Reader` monad.
+ 1. (Difficult) Use the `ReaderT` and `WriterT` monad transformers to reimplement the document printing library, which we wrote earlier using the `Reader` monad.
 
      Instead of using `line` to emit strings and `cat` to concatenate strings, use the `Array String` monoid with the `WriterT` monad transformer, and `tell` to append a line to the result. Use the same names as in the original implementation but ending with an apostrophe (`'`).
 
@@ -589,21 +588,21 @@ modify :: forall m s. MonadState s m => (s -> s) -> m Unit
 
 The `Control.Monad.State.Class` module defines the `MonadState` (multi-parameter) type class, which allows us to abstract over "monads which support pure mutable state". As one would expect, the `State s` type constructor is an instance of the `MonadState s` type class, but there are many more interesting instances of this class.
 
-In particular, there are instances of `MonadState` for the `WriterT`, `ReaderT` and `ExceptT` monad transformers, provided in the `transformers` package. Each of these monad transformers has an instance for `MonadState` whenever the underlying `Monad` does. In practice, this means that as long as `StateT` appears _somewhere_ in the monad transformer stack, and everything above `StateT` is an instance of `MonadState`, then we are free to use `get`, `put` and `modify` directly, without the need to use `lift`.
+In particular, there are instances of `MonadState` for the `WriterT`, `ReaderT`, and `ExceptT` monad transformers provided in the `transformers` package. Each has an instance for `MonadState` whenever the underlying `Monad` does. In practice, this means that as long as `StateT` appears _somewhere_ in the monad transformer stack, and everything above `StateT` is an instance of `MonadState`, then we are free to use `get`, `put`, and `modify` directly without the need to use `lift`.
 
-Indeed, the same is true of the actions we covered for the `ReaderT`, `WriterT`, and `ExceptT` transformers. `transformers` defines a type class for each of the major transformers, allowing us to abstract over monads which support their operations.
+Indeed, the same is true of the actions we covered for the `ReaderT`, `WriterT`, and `ExceptT` transformers. `transformers` defines a type class for each of the major transformers, allowing us to abstract over monads that support their operations.
 
-In the case of the `split` function above, the monad stack we constructed is an instance of each of the `MonadState`, `MonadWriter` and `MonadError` type classes. This means that we don't need to call `lift` at all! We can just use the actions `get`, `put`, `tell` and `throwError` as if they were defined on the monad stack itself:
+In the case of the `split` function above, the monad stack we constructed is an instance of each of the `MonadState`, `MonadWriter`, and `MonadError` type classes. This means that we don't need to call `lift` at all! We can just use the actions `get`, `put`, `tell`, and `throwError` as if they were defined on the monad stack itself:
 
 ```haskell
 {{#include ../exercises/chapter11/src/Split.purs:split}}
 ```
 
-This computation really looks like we have extended our programming language to support the three new side-effects of mutable state, logging and error handling. However, everything is still implemented using pure functions and immutable data under the hood.
+This computation looks like we have extended our programming language to support the three new side-effects of mutable state, logging, and error handling. However, everything is still implemented using pure functions and immutable data under the hood.
 
 ## Alternatives
 
-The `control` package defines a number of abstractions for working with computations which can fail. One of these is the `Alternative` type class:
+The `control` package defines a number of abstractions for working with computations that can fail. One of these is the `Alternative` type class:
 
 ```haskell
 class Functor f <= Alt f where
@@ -615,7 +614,7 @@ class Alt f <= Plus f where
 class (Applicative f, Plus f) <= Alternative f
 ```
 
-`Alternative` provides two new combinators: the `empty` value, which provides a prototype for a failing computation, and the `alt` function (and its alias, `<|>`) which provides the ability to fall back to an _alternative_ computation in the case of an error.
+`Alternative` provides two new combinators: the `empty` value, which provides a prototype for a failing computation, and the `alt` function (and its alias, `<|>`), which provides the ability to fall back to an _alternative_ computation in the case of an error.
 
 The `Data.Array` module provides two useful functions for working with type constructors in the `Alternative` type class:
 
@@ -626,7 +625,7 @@ some :: forall f a. Alternative f => Lazy (f (Array a)) => f a -> f (Array a)
 
 There is also an equivalent `many` and `some` for `Data.List`
 
-The `many` combinator uses the `Alternative` type class to repeatedly run a computation _zero-or-more_ times. The `some` combinator is similar, but requires at least the first computation to succeed.
+The `many` combinator uses the `Alternative` type class to repeatedly run a computation _zero-or-more_ times. The `some` combinator is similar but requires at least the first computation to succeed.
 
 In the case of our `Parser` monad transformer stack, there is an instance of `Alternative` induced by the `ExceptT` component, which supports failure by composing errors in different branches using a `Monoid` instance (this is why we chose `Array String` for our `Errors` type). This means that we can use the `many` and `some` functions to run a parser multiple times:
 
@@ -654,7 +653,7 @@ class (Monad m, Alternative m) <= MonadPlus m
 
 In particular, our `Parser` monad is an instance of `MonadPlus`.
 
-When we covered array comprehensions earlier in the book, we introduced the `guard` function, which could be used to filter out unwanted results. In fact, the `guard` function is more general, and can be used for any monad which is an instance of `MonadPlus`:
+When we covered array comprehensions earlier in the book, we introduced the `guard` function, which could be used to filter out unwanted results. In fact, the `guard` function is more general and can be used for any monad, which is an instance of `MonadPlus`:
 
 ```haskell
 guard :: forall m. Alternative m => Boolean -> m Unit
@@ -666,7 +665,7 @@ The `<|>` operator allows us to backtrack in case of failure. To see how this is
 {{#include ../exercises/chapter11/src/Split.purs:upper}}
 ```
 
-Here, we use a `guard` to fail if the string is not upper case. Note that this code looks very similar to the array comprehensions we saw earlier - using `MonadPlus` in this way, we sometimes refer to constructing _monad comprehensions_.
+Here, we use a `guard` to fail if the string is not upper case. Note that this code looks very similar to the array comprehensions we saw earlier – using `MonadPlus` in this way, we sometimes refer to constructing _monad comprehensions_.
 
 ## Backtracking
 
@@ -711,13 +710,13 @@ We can even use `many` to fully split a string into its lower and upper case com
               ]))
 ```
 
-Again, this illustrates the power of reusability that monad transformers bring - we were able to write a backtracking parser in a declarative style with only a few lines of code, by reusing standard abstractions!
+Again, this illustrates the power of reusability that monad transformers bring – we were able to write a backtracking parser in a declarative style with only a few lines of code, by reusing standard abstractions!
 
 ## Exercises
 
- 1. (Easy) Remove the calls to the `lift` function from your implementation of the `string` parser. Verify that the new implementation type checks, and convince yourself that it should.
- 1. (Medium) Use your `string` parser with the `some` combinator to write a parser `asFollowedByBs` which recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
- 1. (Medium) Use the `<|>` operator to write a parser `asOrBs` which recognizes strings of the letters `a` or `b` in any order.
+ 1. (Easy) Remove the calls to the `lift` function from your implementation of the `string` parser. Verify that the new implementation type checks, and convince yourself it should.
+ 1. (Medium) Use your `string` parser with the `some` combinator to write a parser `asFollowedByBs` that recognizes strings consisting of several copies of the string `"a"` followed by several copies of the string `"b"`.
+ 1. (Medium) Use the `<|>` operator to write a parser `asOrBs` that recognizes strings of the letters `a` or `b` in any order.
  1. (Difficult) The `Parser` monad might also be defined as follows:
 
      ```haskell
@@ -728,7 +727,7 @@ Again, this illustrates the power of reusability that monad transformers bring -
 
 ## The RWS Monad
 
-One particular combination of monad transformers is so common that it is provided as a single monad transformer in the `transformers` package. The `Reader`, `Writer` and `State` monads are combined into the _reader-writer-state_ monad, or more simply the `RWS` monad. This monad has a corresponding monad transformer called the `RWST` monad transformer.
+One particular combination of monad transformers is so common that it is provided as a single monad transformer in the `transformers` package. The `Reader`, `Writer`, and `State` monads are combined into the _reader-writer-state_ or simply `RWS` monad. This monad has a corresponding monad transformer called the `RWST` monad transformer.
 
 We will use the `RWS` monad to model the game logic for our text adventure game.
 
@@ -738,9 +737,9 @@ The `RWS` monad is defined in terms of three type parameters (in addition to its
 type RWS r w s = RWST r w s Identity
 ```
 
-Notice that the `RWS` monad is defined in terms of its own monad transformer, by setting the base monad to `Identity` which provides no side-effects.
+Notice that the `RWS` monad is defined as its own monad transformer by setting the base monad to `Identity`, which provides no side-effects.
 
-The first type parameter, `r`, represents the global configuration type. The second, `w`, represents the monoid which we will use to accumulate a log, and the third, `s` is the type of our mutable state.
+The first type parameter, `r`, represents the global configuration type. The second, `w`, represents the monoid, which we will use to accumulate a log, and the third, `s`, is the type of our mutable state.
 
 In the case of our game, our global configuration is defined in a type called `GameEnvironment` in the `Data.GameEnvironment` module:
 
@@ -748,7 +747,7 @@ In the case of our game, our global configuration is defined in a type called `G
 {{#include ../exercises/chapter11/src/Data/GameEnvironment.purs:env}}
 ```
 
-It defines the player name, and a flag which indicates whether or not the game is running in debug mode. These options will be set from the command line when we come to run our monad transformer.
+It defines the player name and a flag that indicates whether or not the game is running in debug mode. These options will be set from the command line when we come to run our monad transformer.
 
 The mutable state is defined in a type called `GameState` in the `Data.GameState` module:
 
@@ -764,9 +763,9 @@ The `Coords` data type represents points on a two-dimensional grid, and the `Gam
 {{#include ../exercises/chapter11/src/Data/GameItem.purs:GameItem}}
 ```
 
-The `GameState` type uses two new data structures: `Map` and `Set`, which represent sorted maps and sorted sets respectively. The `items` property is a mapping from coordinates of the game grid to sets of game items at that location. The `player` property stores the current coordinates of the player, and the `inventory` property stores a set of game items currently held by the player.
+The `GameState` type uses two new data structures: `Map` and `Set`, which represent sorted maps and sorted sets, respectively. The `items` property is a mapping from coordinates of the game grid to sets of game items at that location. The `player` property stores the current coordinates of the player, and the `inventory` property stores a set of game items currently held by the player.
 
-The `Map` and `Set` data structures are sorted by their keys, can be used with any key type in the `Ord` type class. This means that the keys in our data structures should be totally ordered.
+The `Map` and `Set` data structures are sorted by their keys, and can be used with any key type in the `Ord` type class. This means that the keys in our data structures should be totally ordered.
 
 We will see how the `Map` and `Set` structures are used as we write the actions for our game.
 
@@ -778,7 +777,7 @@ For our log, we will use the `List String` monoid. We can define a type synonym 
 
 ## Implementing Game Logic
 
-Our game is going to be built from simple actions defined in the `Game` monad, by reusing the actions from the `Reader`, `Writer` and `State` monads. At the top level of our application, we will run the pure computations in the `Game` monad, and use the `Effect` monad to turn the results into observable side-effects, such as printing text to the console.
+Our game will be built from simple actions defined in the `Game` monad by reusing the actions from the `Reader`, `Writer`, and `State` monads. At the top level of our application, we will run the pure computations in the `Game` monad and use the `Effect` monad to turn the results into observable side-effects, such as printing text to the console.
 
 One of the simplest actions in our game is the `has` action. This action tests whether the player's inventory contains a particular game item. It is defined as follows:
 
@@ -786,7 +785,7 @@ One of the simplest actions in our game is the `has` action. This action tests w
 {{#include ../exercises/chapter11/src/Game.purs:has}}
 ```
 
-This function uses the `get` action defined in the `MonadState` type class to read the current game state, and then uses the `member` function defined in `Data.Set` to test whether the specified `GameItem` appears in the `Set` of inventory items.
+This function uses the `get` action defined in the `MonadState` type class to read the current game state and then uses the `member` function defined in `Data.Set` to test whether the specified `GameItem` appears in the `Set` of inventory items.
 
 Another action is the `pickUp` action. It adds a game item to the player's inventory if it appears in the current room. It uses actions from the `MonadWriter` and `MonadState` type classes. First of all, it reads the current game state:
 
@@ -800,7 +799,7 @@ Next, `pickUp` looks up the set of items in the current room. It does this by us
 {{#include ../exercises/chapter11/src/Game.purs:pickup_case}}
 ```
 
-The `lookup` function returns an optional result indicated by the `Maybe` type constructor. If the key does not appear in the map, the `lookup` function returns `Nothing`, otherwise it returns the corresponding value in the `Just` constructor.
+The `lookup` function returns an optional result indicated by the `Maybe` type constructor. If the key does not appear in the map, the `lookup` function returns `Nothing`; otherwise, it returns the corresponding value in the `Just` constructor.
 
 We are interested in the case where the corresponding item set contains the specified game item. Again we can test this using the `member` function:
 
@@ -808,17 +807,17 @@ We are interested in the case where the corresponding item set contains the spec
 {{#include ../exercises/chapter11/src/Game.purs:pickup_Just}}
 ```
 
-In this case, we can use `put` to update the game state, and `tell` to add a message to the log:
+In this case, we can use `put` to update the game state and `tell` to add a message to the log:
 
 ```haskell
 {{#include ../exercises/chapter11/src/Game.purs:pickup_body}}
 ```
 
-Note that there is no need to `lift` either of the two computations here, because there are appropriate instances for both `MonadState` and `MonadWriter` for our `Game` monad transformer stack.
+Note that there is no need to `lift` either of the two computations here because there are appropriate instances for both `MonadState` and `MonadWriter` for our `Game` monad transformer stack.
 
-The argument to `put` uses a record update to modify the game state's `items` and `inventory` fields. We use the `update` function from `Data.Map` which modifies a value at a particular key. In this case, we modify the set of items at the player's current location, using the `delete` function to remove the specified item from the set. `inventory` is also updated, using `insert` to add the new item to the player's inventory set.
+The argument to `put` uses a record update to modify the game state's `items` and `inventory` fields. We use the `update` function from `Data.Map`, which modifies a value at a particular key. In this case, we modify the set of items at the player's current location, using the `delete` function to remove the specified item from the set. `inventory` is also updated, using `insert` to add the new item to the player's inventory set.
 
-Finally, the `pickUp` function handles the remaining cases, by notifying the user using `tell`:
+Finally, the `pickUp` function handles the remaining cases by notifying the user using `tell`:
 
 ```haskell
 {{#include ../exercises/chapter11/src/Game.purs:pickup_err}}
@@ -830,15 +829,15 @@ As an example of using the `Reader` monad, we can look at the code for the `debu
 {{#include ../exercises/chapter11/src/Game.purs:debug}}
 ```
 
-Here, we use the `ask` action to read the game configuration. Again, note that we don't need to `lift` any computation, and we can use actions defined in the `MonadState`, `MonadReader` and `MonadWriter` type classes in the same do notation block.
+Here, we use the `ask` action to read the game configuration. Again, note that we don't need to `lift` any computation, and we can use actions defined in the `MonadState`, `MonadReader`, and `MonadWriter` type classes in the same do notation block.
 
-If the `debugMode` flag is set, then the `tell` action is used to write the state to the log. Otherwise, an error message is added.
+If the `debugMode` flag is set, the `tell` action is used to write the state to the log. Otherwise, an error message is added.
 
-The remainder of the `Game` module defines a set of similar actions, each using only the actions defined by the `MonadState`, `MonadReader` and `MonadWriter` type classes.
+The remainder of the `Game` module defines a set of similar actions, each using only the actions defined by the `MonadState`, `MonadReader`, and `MonadWriter` type classes.
 
 ## Running the Computation
 
-Since our game logic runs in the `RWS` monad, it is necessary to run the computation in order to respond to the user's commands.
+Since our game logic runs in the `RWS` monad, it is necessary to run the computation to respond to the user's commands.
 
 The front-end of our game is built using two packages: `optparse`, which provides applicative command line parsing, and `node-readline`, which wraps NodeJS' `readline` module, allowing us to write interactive console-based applications.
 
@@ -848,7 +847,7 @@ The interface to our game logic is provided by the function `game` in the `Game`
 {{#include ../exercises/chapter11/src/Game.purs:game_sig}}
 ```
 
-To run this computation, we pass a list of words entered by the user as an array of strings, and run the resulting `RWS` computation using `runRWS`:
+To run this computation, we pass a list of words entered by the user as an array of strings and run the resulting `RWS` computation using `runRWS`:
 
 ```haskell
 data RWSResult state result writer = RWSResult state result writer
@@ -856,7 +855,7 @@ data RWSResult state result writer = RWSResult state result writer
 runRWS :: forall r w s a. RWS r w s a -> r -> s -> RWSResult s a w
 ```
 
-`runRWS` looks like a combination of `runReader`, `runWriter` and `runState`. It takes a global configuration and an initial state as an argument, and returns a data structure containing the log, the result and the final state.
+`runRWS` looks like a combination of `runReader`, `runWriter`, and `runState`. It takes a global configuration and an initial state as an argument and returns a data structure containing the log, the result, and the final state.
 
 The front-end of our application is defined by a function `runGame`, with the following type signature:
 
@@ -866,7 +865,7 @@ The front-end of our application is defined by a function `runGame`, with the fo
 
 This function interacts with the user via the console (using the `node-readline` and `console` packages). `runGame` takes the game configuration as a function argument.
 
-The `node-readline` package provides the `LineHandler` type, which represents actions in the `Effect` monad which handle user input from the terminal. Here is the corresponding API:
+The `node-readline` package provides the `LineHandler` type, which represents actions in the `Effect` monad, which handle user input from the terminal. Here is the corresponding API:
 
 ```haskell
 type LineHandler a = String -> Effect a
@@ -878,7 +877,7 @@ foreign import setLineHandler
   -> Effect Unit
 ```
 
-The `Interface` type represents a handle for the console, and is passed as an argument to the functions which interact with it. An `Interface` can be created using the `createConsoleInterface` function:
+The `Interface` type represents a handle for the console and is passed as an argument to the functions which interact with it. An `Interface` can be created using the `createConsoleInterface` function:
 
 ```haskell
 {{#include ../exercises/chapter11/src/Main.purs:import_RL}}
@@ -906,7 +905,7 @@ The first thing this action does is to break the user input into words using the
 
 Having run the game logic, which is a pure computation, we need to print any log messages to the screen and show the user a prompt for the next command. The `for_` action is used to traverse the log (of type `List String`) and print its entries to the console. Finally, `setLineHandler` is used to update the line handler function to use the updated game state, and the prompt is displayed again using the `prompt` action.
 
-The `runGame` function finally attaches the initial line handler to the console interface, and displays the initial prompt:
+The `runGame` function finally attaches the initial line handler to the console interface and displays the initial prompt:
 
 ```haskell
 {{#include ../exercises/chapter11/src/Main.purs:runGame_attach_handler}}
@@ -917,7 +916,7 @@ The `runGame` function finally attaches the initial line handler to the console 
  1. (Medium) Implement a new command `cheat`, which moves all game items from the game grid into the user's inventory. Create a function `cheat :: Game Unit` in the `Game` module, and use this function from `game`.
  1. (Difficult) The `Writer` component of the `RWS` monad is currently used for two types of messages: error messages and informational messages. Because of this, several parts of the code use case statements to handle error cases.
 
-     Refactor the code to use the `ExceptT` monad transformer to handle the error messages, and `RWS` to handle informational messages. _Note:_ There are no tests for this exercise.
+     Refactor the code to use the `ExceptT` monad transformer to handle the error messages and `RWS` to handle informational messages. _Note:_ There are no tests for this exercise.
 
 ## Handling Command Line Options
 
@@ -945,7 +944,7 @@ The second argument is the complete description of our parser program:
 {{#include ../exercises/chapter11/src/Main.purs:parserOptions}}
 ```
 
-Here `OP.info` combines a `Parser` with a set of options for how the help message is formatted. `env <**> OP.helper` takes any command line argument `Parser` named `env` and adds a `--help` option to it automatically. Options for the help message are of type `InfoMod`, which is a monoid, so we can use the `fold` function to add several options together.
+Here `OP.info` combines a `Parser` with a set of options for how the help message is formatted. `env <**> OP.helper` takes any command line argument `Parser` named `env` and automatically adds a `--help` option. Options for the help message are of type `InfoMod`, which is a monoid, so we can use the `fold` function to add several options together.
 
 The interesting part of our parser is constructing the `GameEnvironment`:
 
@@ -953,20 +952,20 @@ The interesting part of our parser is constructing the `GameEnvironment`:
 {{#include ../exercises/chapter11/src/Main.purs:env}}
 ```
 
-`player` and `debug` are both `Parser`s, so we can use our applicative operators `<$>` and `<*>` to lift our `gameEnvironment` function, which has the type `PlayerName -> Boolean -> GameEnvironment` over `Parser`. `OP.strOption` constructs a command line option that expects a string value, and is configured via a collection of `Mod`s folded together. `OP.flag` works similarly, but doesn't expect an associated value. `optparse` offers extensive [documentation](https://pursuit.purescript.org/packages/purescript-optparse) on different modifiers available to build various command line parsers.
+`player` and `debug` are both `Parser`s, so we can use our applicative operators `<$>` and `<*>` to lift our `gameEnvironment` function, which has the type `PlayerName -> Boolean -> GameEnvironment` over `Parser`. `OP.strOption` constructs a command line option that expects a string value and is configured via a collection of `Mod`s folded together. `OP.flag` works similarly but doesn't expect an associated value. `optparse` offers extensive [documentation](https://pursuit.purescript.org/packages/purescript-optparse) on different modifiers available to build various command line parsers.
 
-Notice how we were able to use the notation afforded by the applicative operators to give a compact, declarative specification of our command line interface. In addition, it is simple to add new command line arguments, simply by adding a new function argument to `runGame`, and then using `<*>` to lift `runGame` over an additional argument in the definition of `env`.
+Notice how we used the notation afforded by the applicative operators to give a compact, declarative specification of our command line interface. In addition, it is simple to add new command line arguments by adding a new function argument to `runGame` and then using `<*>` to lift `runGame` over an additional argument in the definition of `env`.
 
 ## Exercises
 
- 1. (Medium) Add a new Boolean-valued property `cheatMode` to the `GameEnvironment` record. Add a new command line flag `-c` to the `optparse` configuration which enables cheat mode. The `cheat` command from the previous exercise should be disallowed if cheat mode is not enabled.
+ 1. (Medium) Add a new Boolean-valued property `cheatMode` to the `GameEnvironment` record. Add a new command line flag `-c` to the `optparse` configuration, enabling cheat mode. The `cheat` command from the previous exercise should be disallowed if cheat mode is not enabled.
 
 ## Conclusion
 
-This chapter was a practical demonstration of the techniques we've learned so far, using monad transformers to build a pure specification of our game, and the `Effect` monad to build a front-end using the console.
+This chapter was a practical demonstration of the techniques we've learned so far, using monad transformers to build a pure specification of our game and the `Effect` monad to build a front-end using the console.
 
 Because we separated our implementation from the user interface, it would be possible to create other front-ends for our game. For example, we could use the `Effect` monad to render the game in the browser using the Canvas API or the DOM.
 
-We have seen how monad transformers allow us to write safe code in an imperative style, where effects are tracked by the type system. In addition, type classes provide a powerful way to abstract over the actions provided by a monad, enabling code reuse. We were able to use standard abstractions like `Alternative` and `MonadPlus` to build useful monads by combining standard monad transformers.
+We have seen how monad transformers allow us to write safe code in an imperative style, where the type system tracks effects. In addition, type classes provide a powerful way to abstract over the actions provided by a monad, enabling code reuse. We used standard abstractions like `Alternative` and `MonadPlus` to build useful monads by combining standard monad transformers.
 
-Monad transformers are an excellent demonstration of the sort of expressive code that can be written by relying on advanced type system features such as higher-kinded polymorphism and multi-parameter type classes.
+Monad transformers are an excellent demonstration of expressive code that can be written by relying on advanced type system features such as higher-kinded polymorphism and multi-parameter type classes.

--- a/text/chapter12.md
+++ b/text/chapter12.md
@@ -13,15 +13,15 @@ This module's project introduces the following new dependencies:
 
 The source code for the chapter is broken up into a set of modules, each of which defines a `main` method. Different sections of this chapter are implemented in different files, and the `Main` module can be changed by modifying the Spago build command to run the appropriate file's `main` method at each point.
 
-The HTML file `html/index.html` contains a single `canvas` element which will be used in each example, and a `script` element to load the compiled PureScript code. To test the code for each section, open the HTML file in your browser. Because most exercises target the browser, there are no unit tests for this chapter.
+The HTML file `html/index.html` contains a single `canvas` element which will be used in each example, and a `script` element to load the compiled PureScript code. To test the code for each section, open the HTML file in your browser. Because most exercises target the browser, this chapter has no unit tests.
 
 ## Simple Shapes
 
 The `Example/Rectangle.purs` file contains a simple introductory example, which draws a single blue rectangle at the center of the canvas. The module imports the `Effect` type from the `Effect` module, and also the `Graphics.Canvas` module, which contains actions in the `Effect` monad for working with the Canvas API.
 
-The `main` action starts, like in the other modules, by using the `getCanvasElementById` action to get a reference to the canvas object, and the `getContext2D` action to access the 2D rendering context for the canvas:
+The `main` action starts, like in the other modules, by using the `getCanvasElementById` action to get a reference to the canvas object and the `getContext2D` action to access the 2D rendering context for the canvas:
 
-The `void` function takes a functor and replaces its value with `Unit`. In the example it is used to make `main` conform with its signature.
+The `void` function takes a functor and replaces its value with `Unit`. In the example, it is used to make `main` conform with its signature.
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/Rectangle.purs:main}}
@@ -39,7 +39,7 @@ getContext2D :: CanvasElement -> Effect Context2D
 
 `CanvasElement` and `Context2D` are types defined in the `Graphics.Canvas` module. The same module also defines the `Canvas` effect, which is used by all of the actions in the module.
 
-The graphics context `ctx` manages the state of the canvas, and provides methods to render primitive shapes, set styles and colors, and apply transformations.
+The graphics context `ctx` manages the state of the canvas and provides methods to render primitive shapes, set styles and colors, and apply transformations.
 
 We continue by setting the fill style to solid blue using the `setFillStyle` action. The longer hex notation of `#0000FF` may also be used for blue, but shorthand notation is easier for simple colors:
 
@@ -55,7 +55,7 @@ Finally, we use the `fillPath` action to fill the rectangle. `fillPath` has the 
 fillPath :: forall a. Context2D -> Effect a -> Effect a
 ```
 
-`fillPath` takes a graphics context and another action which builds the path to render. To build a path, we can use the `rect` action. `rect` takes a graphics context, and a record which provides the position and size of the rectangle:
+`fillPath` takes a graphics context and another action that builds the path to render. To build a path, we can use the `rect` action. `rect` takes a graphics context and a record that provides the position and size of the rectangle:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/Rectangle.purs:fillPath}}
@@ -71,9 +71,9 @@ Now, open the `html/index.html` file and verify that this code renders a blue re
 
 ## Putting Row Polymorphism to Work
 
-There are other ways to render paths. The `arc` function renders an arc segment, and the `moveTo`, `lineTo` and `closePath` functions can be used to render piecewise-linear paths.
+There are other ways to render paths. The `arc` function renders an arc segment, and the `moveTo`, `lineTo`, and `closePath` functions can render piecewise-linear paths.
 
-The `Shapes.purs` file renders three shapes: a rectangle, an arc segment and a triangle.
+The `Shapes.purs` file renders three shapes: a rectangle, an arc segment, and a triangle.
 
 We have seen that the `rect` function takes a record as its argument. In fact, the properties of the rectangle are defined in a type synonym:
 
@@ -86,7 +86,7 @@ type Rectangle =
   }
 ```
 
-The `x` and `y` properties represent the location of the top-left corner, while the `w` and `h` properties represent the width and height respectively.
+The `x` and `y` properties represent the location of the top-left corner, while the `w` and `h` properties represent the width and height, respectively.
 
 To render an arc segment, we can use the `arc` function, passing a record with the following type:
 
@@ -100,9 +100,9 @@ type Arc =
   }
 ```
 
-Here, the `x` and `y` properties represent the center point, `r` is the radius, and `start` and `end` represent the endpoints of the arc in radians.
+Here, the `x` and `y` properties represent the center point, `r` is the radius, `start` and `end` represent the endpoints of the arc in radians.
 
-For example, this code fills an arc segment centered at `(300, 300)` with radius `50`. The arc completes 2/3rds of a rotation. Note that the unit circle is flipped vertically, since the y-axis increases towards the bottom of the canvas:
+For example, this code fills an arc segment centered at `(300, 300)` with radius `50`. The arc completes 2/3rds of a rotation. Note that the unit circle is flipped vertically since the y-axis increases towards the bottom of the canvas:
 
 ```haskell
   fillPath ctx $ arc ctx
@@ -114,9 +114,9 @@ For example, this code fills an arc segment centered at `(300, 300)` with radius
     }
 ```
 
-Notice that both the `Rectangle` and `Arc` record types contain `x` and `y` properties of type `Number`. In both cases, this pair represents a point. This means that we can write row-polymorphic functions which can act on either type of record.
+Notice that both the `Rectangle` and `Arc` record types contain `x` and `y` properties of type `Number`. In both cases, this pair represents a point. This means we can write row-polymorphic functions acting on either type of record.
 
-For example, the `Shapes` module defines a `translate` function which translates a shape by modifying its `x` and `y` properties:
+For example, the `Shapes` module defines a `translate` function that translates a shape by modifying its `x` and `y` properties:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/Shapes.purs:translate}}
@@ -126,7 +126,7 @@ Notice the row-polymorphic type. It says that `translate` accepts any record wit
 
 This is an example of _record update syntax_. The expression `shape { ... }` creates a new record based on the `shape` record, with the fields inside the braces updated to the specified values. Note that the expressions inside the braces are separated from their labels by equals symbols, not colons like in record literals.
 
-The `translate` function can be used with both the `Rectangle` and `Arc` records, as can be seen in the `Shapes` example.
+The `translate` function can be used with both the `Rectangle` and `Arc` records, as seen in the `Shapes` example.
 
 The third type of path rendered in the `Shapes` example is a piecewise-linear path. Here is the corresponding code:
 
@@ -152,8 +152,8 @@ and open `html/index.html` again to see the result. You should see the three dif
 
 ## Exercises
 
- 1. (Easy) Experiment with the `strokePath` and `setStrokeStyle` functions in each of the examples so far.
- 1. (Easy) The `fillPath` and `strokePath` functions can be used to render complex paths with a common style by using a do notation block inside the function argument. Try changing the `Rectangle` example to render two rectangles side-by-side using the same call to `fillPath`. Try rendering a sector of a circle by using a combination of a piecewise-linear path and an arc segment.
+ 1. (Easy) Experiment with the `strokePath` and `setStrokeStyle` functions in each example so far.
+ 1. (Easy) The `fillPath` and `strokePath` functions can render complex paths with a common style using a do notation block inside the function argument. Try changing the `Rectangle` example to render two rectangles side-by-side using the same call to `fillPath`. Try rendering a sector of a circle by using a combination of a piecewise-linear path and an arc segment.
  1. (Medium) Given the following record type:
 
      ```haskell
@@ -175,15 +175,15 @@ and open `html/index.html` again to see the result. You should see the three dif
      f :: Number -> Point
      ```
 
-     which takes a `Number` between `0` and `1` as its argument and returns a `Point`, write an action which plots `f` by using your `renderPath` function. Your action should approximate the path by sampling `f` at a finite set of points.
+     which takes a `Number` between `0` and `1` as its argument and returns a `Point`, write an action that plots `f` by using your `renderPath` function. Your action should approximate the path by sampling `f` at a finite set of points.
 
      Experiment by rendering different paths by varying the function `f`.
 
 ## Drawing Random Circles
 
-The `Example/Random.purs` file contains an example which uses the `Effect` monad to interleave two different types of side-effect: random number generation, and canvas manipulation. The example renders one hundred randomly generated circles onto the canvas.
+The `Example/Random.purs` file contains an example that uses the `Effect` monad to interleave two types of side-effect: random number generation and canvas manipulation. The example renders one hundred randomly generated circles onto the canvas.
 
-The `main` action obtains a reference to the graphics context as before, and then sets the stroke and fill styles:
+The `main` action obtains a reference to the graphics context as before and then sets the stroke and fill styles:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/Random.purs:style}}
@@ -195,7 +195,7 @@ Next, the code uses the `for_` function to loop over the integers between `0` an
 {{#include ../exercises/chapter12/src/Example/Random.purs:for}}
 ```
 
-On each iteration, the do notation block starts by generating three random numbers distributed between `0` and `1`. These numbers represent the `x` and `y` coordinates, and the radius of a circle:
+On each iteration, the do notation block starts by generating three random numbers distributed between `0` and `1`. These numbers represent the `x` and `y` coordinates and the radius of a circle:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/Random.purs:random}}
@@ -217,7 +217,7 @@ and view the result by opening `html/index.html`.
 
 ## Transformations
 
-There is more to the canvas than just rendering simple shapes. Every canvas maintains a transformation which is used to transform shapes before rendering. Shapes can be translated, rotated, scaled, and skewed.
+There is more to the canvas than just rendering simple shapes. Every canvas maintains a transformation that is used to transform shapes before rendering. Shapes can be translated, rotated, scaled, and skewed.
 
 The `canvas` library supports these transformations using the following functions:
 
@@ -241,7 +241,7 @@ transform :: Context2D
 
 The `translate` action performs a translation whose components are specified by the properties of the `TranslateTransform` record.
 
-The `rotate` action performs a rotation around the origin, through some number of radians specified by the first argument.
+The `rotate` action rotates around the origin through some number of radians specified by the first argument.
 
 The `scale` action performs a scaling, with the origin as the center. The `ScaleTransform` record specifies the scale factors along the `x` and `y` axes.
 
@@ -264,7 +264,7 @@ The effect of this sequence of actions is that the scene is rotated, then scaled
 
 ## Preserving the Context
 
-A common use case is to render some subset of the scene using a transformation, and then to reset the transformation afterwards.
+A common use case is to render some subset of the scene using a transformation and then reset the transformation.
 
 The Canvas API provides the `save` and `restore` methods, which manipulate a _stack_ of states associated with the canvas. `canvas` wraps this functionality into the following functions:
 
@@ -280,7 +280,7 @@ restore
 
 The `save` action pushes the current state of the context (including the current transformation and any styles) onto the stack, and the `restore` action pops the top state from the stack and restores it.
 
-This allows us to save the current state, apply some styles and transformations, render some primitives, and finally restore the original transformation and state. For example, the following function performs some canvas action, but applies a rotation before doing so, and restores the transformation afterwards:
+This allows us to save the current state, apply some styles and transformations, render some primitives, and finally restore the original transformation and state. For example, the following function performs some canvas action but applies a rotation before doing so and restores the transformation afterwards:
 
 ```haskell
 rotated ctx render = do
@@ -312,7 +312,7 @@ rotated ctx render =
 
 In this section, we'll use the `refs` package to demonstrate another effect in the `Effect` monad.
 
-The `Effect.Ref` module provides a type constructor for global mutable references, and an associated effect:
+The `Effect.Ref` module provides a type constructor for global mutable references and an associated effect:
 
 ```text
 > import Effect.Ref
@@ -323,9 +323,9 @@ Type -> Type
 
 A value of type `Ref a` is a mutable reference cell containing a value of type `a`, used to track global mutation. As such, it should be used sparingly.
 
-The `Example/Refs.purs` file contains an example which uses a `Ref` to track mouse clicks on the `canvas` element.
+The `Example/Refs.purs` file contains an example that uses a `Ref` to track mouse clicks on the `canvas` element.
 
-The code starts by creating a new reference containing the value `0`, by using the `new` action:
+The code starts by creating a new reference containing the value `0` by using the `new` action:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/Refs.purs:clickCount}}
@@ -343,12 +343,12 @@ In the `render` function, the click count is used to determine the transformatio
 {{#include ../exercises/chapter12/src/Example/Refs.purs:withContext}}
 ```
 
-This action uses `withContext` to preserve the original transformation, and then applies the following sequence of transformations (remember that transformations are applied bottom-to-top):
+This action uses `withContext` to preserve the original transformation and then applies the following sequence of transformations (remember that transformations are applied bottom-to-top):
 
-- The rectangle is translated through `(-100, -100)` so that its center lies at the origin.
+- The rectangle is translated through `(-100, -100)`, so its center lies at the origin.
 - The rectangle is scaled around the origin.
 - The rectangle is rotated through some multiple of `10` degrees around the origin.
-- The rectangle is translated through `(300, 300)` so that it center lies at the center of the canvas.
+- The rectangle is translated through `(300, 300)`, so its center lies at the center of the canvas.
 
 Build the example:
 
@@ -360,19 +360,19 @@ and open the `html/index.html` file. If you click the canvas repeatedly, you sho
 
 ## Exercises
 
- 1. (Easy) Write a higher-order function which strokes and fills a path simultaneously. Rewrite the `Random.purs` example using your function.
- 1. (Medium) Use `Random` and `Dom` to create an application which renders a circle with random position, color and radius to the canvas when the mouse is clicked.
- 1. (Medium) Write a function which transforms the scene by rotating it around a point with specified coordinates. _Hint_: use a translation to first translate the scene to the origin.
+ 1. (Easy) Write a higher-order function that simultaneously strokes and fills a path. Rewrite the `Random.purs` example using your function.
+ 1. (Medium) Use `Random` and `Dom` to create an application that renders a circle with random position, color, and radius to the canvas when the mouse is clicked.
+ 1. (Medium) Write a function that transforms the scene by rotating it around a point with specified coordinates. _Hint_: use a translation to first translate the scene to the origin.
 
 ## L-Systems
 
 In this final example, we will use the `canvas` package to write a function for rendering _L-systems_ (or _Lindenmayer systems_).
 
-An L-system is defined by an _alphabet_, an initial sequence of letters from the alphabet, and a set of _production rules_. Each production rule takes a letter of the alphabet and returns a sequence of replacement letters. This process is iterated some number of times starting with the initial sequence of letters.
+An L-system is defined by an _alphabet_, an initial sequence of letters from the alphabet, and a set of _production rules_. Each production rule takes a letter of the alphabet and returns a sequence of replacement letters. This process is iterated some number of times, starting with the initial sequence of letters.
 
 If each letter of the alphabet is associated with some instruction to perform on the canvas, the L-system can be rendered by following the instructions in order.
 
-For example, suppose the alphabet consists of the letters `L` (turn left), `R` (turn right) and `F` (move forward). We might define the following production rules:
+For example, suppose the alphabet consists of the letters `L` (turn left), `R` (turn right), and `F` (move forward). We might define the following production rules:
 
 ```text
 L -> L
@@ -388,7 +388,7 @@ FLFRRFLFRRFLFRRFLFRRFLFRRFLFRR
 FLFRRFLFLFLFRRFLFRRFLFRRFLFLFLFRRFLFRRFLFRRFLF...
 ```
 
-and so on. Plotting a piecewise-linear path corresponding to this set of instruction approximates a curve called the _Koch curve_. Increasing the number of iterations increases the resolution of the curve.
+and so on. Plotting a piecewise-linear path corresponding to this set of instructions approximates the _Koch curve_. Increasing the number of iterations increases the resolution of the curve.
 
 Let's translate this into the language of types and functions.
 
@@ -416,7 +416,7 @@ Our production rules can be represented as a function from `Letter` to `Sentence
 
 This is just copied straight from the specification above.
 
-Now we can implement a function `lsystem` which will take a specification in this form, and render it to the canvas. What type should `lsystem` have? Well, it needs to take values like `initial` and `productions` as arguments, as well as a function which can render a letter of the alphabet to the canvas.
+Now we can implement a function `lsystem` that will take a specification in this form and render it to the canvas. What type should `lsystem` have? Well, it needs to take values like `initial` and `productions` as arguments, as well as a function that can render a letter of the alphabet to the canvas.
 
 Here is a first approximation to the type of `lsystem`:
 
@@ -430,7 +430,7 @@ Sentence
 
 The first two argument types correspond to the values `initial` and `productions`.
 
-The third argument represents a function which takes a letter of the alphabet and _interprets_ it by performing some actions on the canvas. In our example, this would mean turning left in the case of the letter `L`, turning right in the case of the letter `R`, and moving forward in the case of a letter `F`.
+The third argument represents a function that takes a letter of the alphabet and _interprets_ it by performing some actions on the canvas. In our example, this would mean turning left in the case of the letter `L`, turning right in the case of the letter `R`, and moving forward in the case of a letter `F`.
 
 The final argument is a number representing the number of iterations of the production rules we would like to perform.
 
@@ -444,7 +444,7 @@ forall a. Array a
           -> Effect Unit
 ```
 
-The second observation is that, in order to implement instructions like "turn left" and "turn right", we will need to maintain some state, namely the direction in which the path is moving at any time. We need to modify our function to pass the state through the computation. Again, the `lsystem` function should work for any type of state, so we will represent it using the type variable `s`.
+The second observation is that, to implement instructions like "turn left" and "turn right", we will need to maintain some state, namely the direction in which the path is moving at any time. We need to modify our function to pass the state through the computation. Again, the `lsystem` function should work for any type of state, so we will represent it using the type variable `s`.
 
 We need to add the type `s` in three places:
 
@@ -490,9 +490,9 @@ lsystem :: forall a s
 {{#include ../exercises/chapter12/src/Example/LSystem.purs:lsystem_impl}}
 ```
 
-The `go` function works by recursion on its second argument. There are two cases: when `n` is zero, and when `n` is non-zero.
+The `go` function works by recursion on its second argument. There are two cases: when `n` is zero and `n` is non-zero.
 
-In the first case, the recursion is complete, and we simply need to interpret the current sentence according to the interpretation function. We have a sentence of type `Array a`, a state of type `s`, and a function of type `s -> a -> Effect s`. This sounds like a job for the `foldM` function which we defined earlier, and which is available from the `control` package:
+In the first case, the recursion is complete, and we need to interpret the current sentence according to the interpretation function. We have a sentence of type `Array a`, a state of type `s`, and a function of type `s -> a -> Effect s`. This sounds like a job for the `foldM` function which we defined earlier, and which is available from the `control` package:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/LSystem.purs:lsystem_go_s_0}}
@@ -504,7 +504,7 @@ What about in the non-zero case? In that case, we can simply apply the productio
 {{#include ../exercises/chapter12/src/Example/LSystem.purs:lsystem_go_s_i}}
 ```
 
-That's it! Note how the use of higher order functions like `foldM` and `concatMap` allowed us to communicate our ideas concisely.
+That's it! Note how using higher-order functions like `foldM` and `concatMap` allowed us to communicate our ideas concisely.
 
 However, we're not quite done. The type we have given is actually still too specific. Note that we don't use any canvas operations anywhere in our implementation. Nor do we make use of the structure of the `Effect` monad at all. In fact, our function works for _any_ monad `m`!
 
@@ -514,9 +514,9 @@ Here is the more general type of `lsystem`, as specified in the accompanying sou
 {{#include ../exercises/chapter12/src/Example/LSystem.purs:lsystem_anno}}
 ```
 
-We can understand this type as saying that our interpretation function is free to have any side-effects at all, captured by the monad `m`. It might render to the canvas, or print information to the console, or support failure or multiple return values. The reader is encouraged to try writing L-systems which use these various types of side-effect.
+We can understand this type as saying that our interpretation function is free to have any side-effects at all, captured by the monad `m`. It might render to the canvas, print information to the console, or support failure or multiple return values. The reader is encouraged to try writing L-systems that use these various types of side-effect.
 
-This function is a good example of the power of separating data from implementation. The advantage of this approach is that we gain the freedom to interpret our data in multiple different ways. We might even factor `lsystem` into two smaller functions: the first would build the sentence using repeated application of `concatMap`, and the second would interpret the sentence using `foldM`. This is also left as an exercise for the reader.
+This function is a good example of the power of separating data from implementation. The advantage of this approach is that we can interpret our data in multiple ways. We might even factor `lsystem` into two smaller functions: the first would build the sentence using repeated application of `concatMap`, and the second would interpret the sentence using `foldM`. This is also left as an exercise for the reader.
 
 Let's complete our example by implementing its interpretation function. The type of `lsystem` tells us that its type signature must be `s -> a -> m s` for some types `a` and `s` and a type constructor `m`. We know that we want `a` to be `Letter` and `s` to be `State`, and for the monad `m` we can choose `Effect`. This gives us the following type:
 
@@ -530,7 +530,7 @@ To implement this function, we need to handle the three data constructors of the
 {{#include ../exercises/chapter12/src/Example/LSystem.purs:interpretLR}}
 ```
 
-To interpret the letter `F` (move forward), we can calculate the new position of the path, render a line segment, and update the state, as follows:
+To interpret the letter `F` (move forward), we can calculate the new position of the path, render a line segment, and update the state as follows:
 
 ```haskell
 {{#include ../exercises/chapter12/src/Example/LSystem.purs:interpretF}}
@@ -555,9 +555,9 @@ and open `html/index.html`. You should see the Koch curve rendered to the canvas
 ## Exercises
 
  1. (Easy) Modify the L-system example above to use `fillPath` instead of `strokePath`. _Hint_: you will need to include a call to `closePath`, and move the call to `moveTo` outside of the `interpret` function.
- 1. (Easy) Try changing the various numerical constants in the code, to understand their effect on the rendered system.
+ 1. (Easy) Try changing the various numerical constants in the code to understand their effect on the rendered system.
  1. (Medium) Break the `lsystem` function into two smaller functions. The first should build the final sentence using repeated application of `concatMap`, and the second should use `foldM` to interpret the result.
- 1. (Medium) Add a drop shadow to the filled shape, by using the `setShadowOffsetX`, `setShadowOffsetY`, `setShadowBlur` and `setShadowColor` actions. _Hint_: use PSCi to find the types of these functions.
+ 1. (Medium) Add a drop shadow to the filled shape using the `setShadowOffsetX`, `setShadowOffsetY`, `setShadowBlur`, and `setShadowColor` actions. _Hint_: use PSCi to find the types of these functions.
  1. (Medium) The angle of the corners is currently a constant (`tau/6`). Instead, it can be moved into the `Letter` data type, which allows it to be changed by the production rules:
 
      ```haskell
@@ -567,7 +567,7 @@ and open `html/index.html`. You should see the Koch curve rendered to the canvas
      ```
 
      How can this new information be used in the production rules to create interesting shapes?
- 1. (Difficult) An L-system is given by an alphabet with four letters: `L` (turn left through 60 degrees), `R` (turn right through 60 degrees), `F` (move forward) and `M` (also move forward).
+ 1. (Difficult) An L-system is given by an alphabet with four letters: `L` (turn left through 60 degrees), `R` (turn right through 60 degrees), `F` (move forward), and `M` (also move forward).
 
      The initial sentence of the system is the single letter `M`.
 
@@ -580,7 +580,7 @@ and open `html/index.html`. You should see the Koch curve rendered to the canvas
      M -> MRFRMLFLMLFLMRFRM
      ```
 
-     Render this L-system. _Note_: you will need to decrease the number of iterations of the production rules, since the size of the final sentence grows exponentially with the number of iterations.
+     Render this L-system. _Note_: you will need to decrease the number of iterations of the production rules since the size of the final sentence grows exponentially with the number of iterations.
 
      Now, notice the symmetry between `L` and `M` in the production rules. The two "move forward" instructions can be differentiated using a `Boolean` value using the following alphabet type:
 
@@ -593,7 +593,7 @@ and open `html/index.html`. You should see the Koch curve rendered to the canvas
 
 ## Conclusion
 
-In this chapter, we learned how to use the HTML5 Canvas API from PureScript by using the `canvas` library. We also saw a practical demonstration of many of the techniques we have learned already: maps and folds, records and row polymorphism, and the `Effect` monad for handling side-effects.
+In this chapter, we learned how to use the HTML5 Canvas API from PureScript by using the `canvas` library. We also saw a practical demonstration of many techniques we have learned already: maps and folds, records and row polymorphism, and the `Effect` monad for handling side-effects.
 
 The examples also demonstrated the power of higher-order functions and _separating data from implementation_. It would be possible to extend these ideas to completely separate the representation of a scene from its rendering function, using an algebraic data type, for example:
 
@@ -607,6 +607,6 @@ data Scene
   | ...
 ```
 
-This approach is taken in the `drawing` package, and it brings the flexibility of being able to manipulate the scene as data in various ways before rendering.
+This approach is taken in the `drawing` package, and it brings the flexibility of manipulating the scene as data in various ways before rendering.
 
 For examples of games rendered to the canvas, see the "Behavior" and "Signal" recipes in the [cookbook](https://github.com/JordanMartinez/purescript-cookbook/blob/master/README.md#recipes).

--- a/text/chapter13.md
+++ b/text/chapter13.md
@@ -20,7 +20,7 @@ The `Merge` module implements a simple function `merge`, which we will use to de
 merge :: Array Int -> Array Int -> Array Int
 ```
 
-`merge` takes two sorted arrays of integers, and merges their elements so that the result is also sorted. For example:
+`merge` takes two sorted arrays of integers and merges their elements so that the result is also sorted. For example:
 
 ```text
 > import Merge
@@ -29,11 +29,11 @@ merge :: Array Int -> Array Int -> Array Int
 [1, 2, 3, 4, 5, 5]
 ```
 
-In a typical test suite, we might test `merge` by generating a few small test cases like this by hand, and asserting that the results were equal to the appropriate values. However, everything we need to know about the `merge` function can be summarized by this property:
+In a typical test suite, we might test `merge` by generating a few small test cases like this by hand and asserting that the results were equal to the appropriate values. However, everything we need to know about the `merge` function can be summarized by this property:
 
 - If `xs` and `ys` are sorted, then `merge xs ys` is the sorted result of both arrays appended together.
 
-`quickcheck` allows us to test this property directly, by generating random test cases. We simply state the properties that we want our code to have, as functions. In this case, we have a single property:
+`quickcheck` allows us to test this property directly by generating random test cases. We state the properties we want our code to have as functions. In this case, we have a single property:
 
 ```haskell
 main = do
@@ -41,7 +41,7 @@ main = do
     eq (merge (sort xs) (sort ys)) (sort $ xs <> ys)
 ```
 
-When we run this code, `quickcheck` will attempt to disprove the properties we claimed, by generating random inputs `xs` and `ys`, and passing them to our functions. If our function returns `false` for any inputs, the property will be incorrect, and the library will raise an error. Fortunately, the library is unable to disprove our properties after generating 100 random test cases:
+When we run this code, `quickcheck` will attempt to disprove the properties we claimed by generating random inputs `xs` and `ys` and passing them to our functions. If our function returns `false` for any inputs, the property will be incorrect, and the library will raise an error. Fortunately, the library is unable to disprove our properties after generating 100 random test cases:
 
 ```text
 $ spago test
@@ -89,7 +89,7 @@ Notice how the input `xs` and `ys` were generated as arrays of randomly-selected
 
 ## Exercises
 
- 1. (Easy) Write a property which asserts that merging an array with the empty array does not modify the original array. _Note_: This new property is redundant, since this situation is already covered by our existing property. We're just trying to give you readers a simple way to practice using quickCheck.
+ 1. (Easy) Write a property that asserts that merging an array with an empty one does not modify the original array. _Note_: This new property is redundant since this situation is already covered by our existing property. We're just trying to give readers a simple way to practice using quickCheck.
  1. (Easy) Add an appropriate error message to the remaining property for `merge`.
 
 ## Testing Polymorphic Code
@@ -111,14 +111,14 @@ The instance head contains unknown type variables.
 Consider adding a type annotation.
 ```
 
-This error message indicates that the compiler could not generate random test cases, because it did not know what type of elements we wanted our arrays to have. In these sorts of cases, we can use type annotations to force the compiler to infer a particular type, such as `Array Int`:
+This error message indicates that the compiler could not generate random test cases because it did not know what type of elements we wanted our arrays to have. In these sorts of cases, we can use type annotations to force the compiler to infer a particular type, such as `Array Int`:
 
 ```haskell
 quickCheck \xs ys ->
   eq (mergePoly (sort xs) (sort ys) :: Array Int) (sort $ xs <> ys)
 ```
 
-We can alternatively use a helper function to specify type, which may result in cleaner code. For example, if we define a function `ints` as a synonym for the identity function:
+We can alternatively use a helper function to specify the type, which may result in cleaner code. For example, if we define a function `ints` as a synonym for the identity function:
 
 ```haskell
 ints :: Array Int -> Array Int
@@ -132,16 +132,16 @@ quickCheck \xs ys ->
   eq (ints $ mergePoly (sort xs) (sort ys)) (sort $ xs <> ys)
 ```
 
-Here, `xs` and `ys` both have type `Array Int`, since the `ints` function has been used to disambiguate the unknown type.
+Here, `xs` and `ys` have type `Array Int` since the `ints` function has been used to disambiguate the unknown type.
 
 ## Exercises
 
- 1. (Easy) Write a function `bools` which forces the types of `xs` and `ys` to be `Array Boolean`, and add additional properties which test `mergePoly` at that type.
+ 1. (Easy) Write a function `bools` that forces the types of `xs` and `ys` to be `Array Boolean`, and add additional properties that test `mergePoly` at that type.
  1. (Medium) Choose a pure function from the core libraries (for example, from the `arrays` package), and write a QuickCheck property for it, including an appropriate error message. Your property should use a helper function to fix any polymorphic type arguments to either `Int` or `Boolean`.
 
 ## Generating Arbitrary Data
 
-Now we will see how the `quickcheck` library is able to randomly generate test cases for our properties.
+Now we will see how the `quickcheck` library can randomly generate test cases for our properties.
 
 Those types whose values can be randomly generated are captured by the `Arbitrary` type class:
 
@@ -154,7 +154,7 @@ The `Gen` type constructor represents the side-effects of _deterministic random 
 
 `Gen` is also a monad and an applicative functor, so we have the usual collection of combinators at our disposal for creating new instances of the `Arbitrary` type class.
 
-For example, we can use the `Arbitrary` instance for the `Int` type, provided in the `quickcheck` library, to create a distribution on the 256 byte values, using the `Functor` instance for `Gen` to map a function from integers to bytes over arbitrary integer values:
+For example, we can use the `Arbitrary` instance for the `Int` type, provided in the `quickcheck` library, to create a distribution on the 256-byte values, using the `Functor` instance for `Gen` to map a function from integers to bytes over arbitrary integer values:
 
 ```haskell
 newtype Byte = Byte Int
@@ -175,7 +175,7 @@ quickCheck \xs ys ->
   eq (numbers $ mergePoly (sort xs) (sort ys)) (sort $ xs <> ys)
 ```
 
-In this test, we generated arbitrary arrays `xs` and `ys`, but had to sort them, since `merge` expects sorted input. On the other hand, we could create a newtype representing sorted arrays, and write an `Arbitrary` instance which generates sorted data:
+In this test, we generated arbitrary arrays `xs` and `ys`, but had to sort them, since `merge` expects sorted input. On the other hand, we could create a newtype representing sorted arrays and write an `Arbitrary` instance that generates sorted data:
 
 ```haskell
 newtype Sorted a = Sorted (Array a)
@@ -194,7 +194,7 @@ quickCheck \xs ys ->
   eq (ints $ mergePoly (sorted xs) (sorted ys)) (sort $ sorted xs <> sorted ys)
 ```
 
-This may look like a small change, but the types of `xs` and `ys` have changed to `Sorted Int`, instead of just `Array Int`. This communicates our _intent_ in a clearer way - the `mergePoly` function takes sorted input. Ideally, the type of the `mergePoly` function itself would be updated to use the `Sorted` type constructor.
+This may look like a small change, but the types of `xs` and `ys` have changed to `Sorted Int` instead of just `Array Int`. This communicates our _intent_ in a clearer way – the `mergePoly` function takes sorted input. Ideally, the type of the `mergePoly` function itself would be updated to use the `Sorted` type constructor.
 
 As a more interesting example, the `Tree` module defines a type of sorted binary trees with values at the branches:
 
@@ -213,7 +213,7 @@ fromArray :: forall a. Ord a => Array a -> Tree a
 toArray   :: forall a. Tree a -> Array a
 ```
 
-The `insert` function is used to insert a new element into a sorted tree, and the `member` function can be used to query a tree for a particular value. For example:
+The `insert` function inserts a new element into a sorted tree, and the `member` function can query a tree for a particular value. For example:
 
 ```text
 > import Tree
@@ -225,14 +225,14 @@ true
 false
 ```
 
-The `toArray` and `fromArray` functions can be used to convert sorted trees to and from arrays. We can use `fromArray` to write an `Arbitrary` instance for trees:
+The `toArray` and `fromArray` functions can convert sorted trees to and from arrays. We can use `fromArray` to write an `Arbitrary` instance for trees:
 
 ```haskell
 instance (Arbitrary a, Ord a) => Arbitrary (Tree a) where
   arbitrary = map fromArray arbitrary
 ```
 
-We can now use `Tree a` as the type of an argument to our test properties, whenever there is an `Arbitrary` instance available for the type `a`. For example, we can test that the `member` test always returns `true` after inserting a value:
+We can now use `Tree a` as the type of an argument to our test properties whenever there is an `Arbitrary` instance available for the type `a`. For example, we can test that the `member` test always returns `true` after inserting a value:
 
 ```haskell
 quickCheck \t a ->
@@ -244,13 +244,13 @@ Here, the argument `t` is a randomly-generated tree of type `Tree Int`, where th
 ## Exercises
 
  1. (Medium) Create a newtype for `String` with an associated `Arbitrary` instance which generates collections of randomly-selected characters in the range `a-z`. _Hint_: use the `elements` and `arrayOf` functions from the `Test.QuickCheck.Gen` module.
- 1. (Difficult) Write a property which asserts that a value inserted into a tree is still a member of that tree after arbitrarily many more insertions.
+ 1. (Difficult) Write a property that asserts that a value inserted into a tree is still a member of that tree after arbitrarily many more insertions.
 
 ## Testing Higher-Order Functions
 
-The `Merge` module defines another generalization of the `merge` function - the `mergeWith` function takes an additional function as an argument which is used to determine the order in which elements should be merged. That is, `mergeWith` is a higher-order function.
+The `Merge` module defines another generalization of the `merge` function – the `mergeWith` function takes an additional function as an argument to determine the order in which elements should be merged. That is, `mergeWith` is a higher-order function.
 
-For example, we can pass the `length` function as the first argument, to merge two arrays which are already in length-increasing order. The result should also be in length-increasing order:
+For example, we can pass the `length` function as the first argument to merge two arrays already in length-increasing order. The result should also be in length-increasing order:
 
 ```haskell
 > import Data.String
@@ -262,26 +262,26 @@ For example, we can pass the `length` function as the first argument, to merge t
 ["","x","ab","xyz","abcd"]
 ```
 
-How might we test such a function? Ideally, we would like to generate values for all three arguments, including the first argument which is a function.
+How might we test such a function? Ideally, we would like to generate values for all three arguments, including the first argument, which is a function.
 
-There is a second type class which allows us to create randomly-generated functions. It is called `Coarbitrary`, and it is defined as follows:
+There is a second type class that allows us to create randomly-generated functions. It is called `Coarbitrary`, and it is defined as follows:
 
 ```haskell
 class Coarbitrary t where
   coarbitrary :: forall r. t -> Gen r -> Gen r
 ```
 
-The `coarbitrary` function takes a function argument of type `t`, and a random generator for a function result of type `r`, and uses the function argument to _perturb_ the random generator. That is, it uses the function argument to modify the random output of the random generator for the result.
+The `coarbitrary` function takes a function argument of type `t` and a random generator for a function result of type `r`. It uses the function argument to _perturb_ the random generator. That is, it uses the function argument to modify the random output of the random generator for the result.
 
-In addition, there is a type class instance which gives us `Arbitrary` functions if the function domain is `Coarbitrary` and the function codomain is `Arbitrary`:
+In addition, there is a type class instance that gives us `Arbitrary` functions if the function domain is `Coarbitrary` and the function codomain is `Arbitrary`:
 
 ```haskell
 instance (Coarbitrary a, Arbitrary b) => Arbitrary (a -> b)
 ```
 
-In practice, this means that we can write properties which take functions as arguments. In the case of the `mergeWith` function, we can generate the first argument randomly, modifying our tests to take account of the new argument.
+In practice, we can write properties that take functions as arguments. In the case of the `mergeWith` function, we can generate the first argument randomly, modifying our tests to take account of the new argument.
 
-We cannot guarantee that the result will be sorted - we do not even necessarily have an `Ord` instance - but we can expect that the result be sorted with respect to the function `f` that we pass in as an argument. In addition, we need the two input arrays to be sorted with respect to `f`, so we use the `sortBy` function to sort `xs` and `ys` based on comparison after the function `f` has been applied:
+We cannot guarantee that the result will be sorted – we do not even necessarily have an `Ord` instance – but we can expect that the result be sorted with respect to the function `f` that we pass in as an argument. In addition, we need the two input arrays to be sorted concerning `f`, so we use the `sortBy` function to sort `xs` and `ys` based on comparison after the function `f` has been applied:
 
 ```haskell
 quickCheck \xs ys f ->
@@ -311,7 +311,7 @@ In addition to being `Arbitrary`, functions are also `Coarbitrary`:
 instance (Arbitrary a, Coarbitrary b) => Coarbitrary (a -> b)
 ```
 
-This means that we are not limited to just values and functions - we can also randomly generate _higher-order functions_, or functions whose arguments are higher-order functions, and so on.
+This means that we are not limited to just values and functions – we can also randomly generate _higher-order functions_, or functions whose arguments are higher-order functions, and so on.
 
 ## Writing Coarbitrary Instances
 
@@ -323,7 +323,7 @@ Let's write a `Coarbitrary` instance for our `Tree` type. We will need a `Coarbi
 instance Coarbitrary a => Coarbitrary (Tree a) where
 ```
 
-We have to write a function which perturbs a random generator given a value of type `Tree a`. If the input value is a `Leaf`, then we will just return the generator unchanged:
+We have to write a function that perturbs a random generator given a value of type `Tree a`. If the input value is a `Leaf`, then we will return the generator unchanged:
 
 ```haskell
   coarbitrary Leaf = id
@@ -338,13 +338,13 @@ If the tree is a `Branch`, then we will perturb the generator using the left sub
     coarbitrary r
 ```
 
-Now we are free to write properties whose arguments include functions taking trees as arguments. For example, the `Tree` module defines a function `anywhere`, which tests if a predicate holds on any subtree of its argument:
+Now we can write properties whose arguments include functions taking trees as arguments. For example, the `Tree` module defines a function `anywhere`, which tests if a predicate holds on any subtree of its argument:
 
 ```haskell
 anywhere :: forall a. (Tree a -> Boolean) -> Tree a -> Boolean
 ```
 
-Now we are able to generate the predicate function randomly. For example, we expect the `anywhere` function to _respect disjunction_:
+Now we can generate the predicate function randomly. For example, we expect the `anywhere` function to _respect disjunction_:
 
 ```haskell
 quickCheck \f g t ->
@@ -361,7 +361,7 @@ treeOfInt = id
 
 ## Testing Without Side-Effects
 
-For the purposes of testing, we usually include calls to the `quickCheck` function in the `main` action of our test suite. However, there is a variant of the `quickCheck` function, called `quickCheckPure` which does not use side-effects. Instead, it is a pure function which takes a random seed as an input, and returns an array of test results.
+For the purposes of testing, we usually include calls to the `quickCheck` function in the `main` action of our test suite. However, there is a variant of the `quickCheck` function, called `quickCheckPure` which does not use side-effects. Instead, it is a pure function that takes a random seed as an input and returns an array of test results.
 
 We can test `quickCheckPure` using PSCi. Here, we test that the `merge` operation is associative:
 
@@ -382,7 +382,7 @@ Success : Success : ...
 
 `quickCheckPure` takes three arguments: the random seed, the number of test cases to generate, and the property to test. If all tests pass, you should see an array of `Success` data constructors printed to the console.
 
-`quickCheckPure` might be useful in other situations, such as generating random input data for performance benchmarks, or generating sample form data for web applications.
+`quickCheckPure` might be useful in other situations, such as generating random input data for performance benchmarks or sample form data for web applications.
 
 ## Exercises
 
@@ -395,7 +395,7 @@ Success : Success : ...
      ```
 
      _Hint_: Use the `oneOf` function defined in `Test.QuickCheck.Gen` to define your `Arbitrary` instance.
- 1. (Medium) Use `all` to simplify the result of the `quickCheckPure` function - your new function should have type `List Result -> Boolean` and should return `true` if every test passes and `false` otherwise.
+ 1. (Medium) Use `all` to simplify the result of the `quickCheckPure` function – your new function should have the type `List Result -> Boolean` and should return `true` if every test passes and `false` otherwise.
  1. (Medium) As another approach to simplifying the result of `quickCheckPure`, try writing a function `squashResults :: List Result -> Result`. Consider using the `First` monoid from `Data.Maybe.First` with the `foldMap` function to preserve the first error in case of failure.
 
 ## Conclusion
@@ -403,6 +403,6 @@ Success : Success : ...
 In this chapter, we met the `quickcheck` package, which can be used to write tests in a declarative way using the paradigm of _generative testing_. In particular:
 
 - We saw how to automate QuickCheck tests using `spago test`.
-- We saw how to write properties as functions, and how to use the `<?>` operator to improve error messages.
-- We saw how the `Arbitrary` and `Coarbitrary` type classes enable generation of boilerplate testing code, and how they allow us to test higher-order properties.
+- We saw how to write properties as functions and how to use the `<?>` operator to improve error messages.
+- We saw how the `Arbitrary` and `Coarbitrary` type classes enable generation of boilerplate testing code and how they allow us to test higher-order properties.
 - We saw how to implement custom `Arbitrary` and `Coarbitrary` instances for our own data types.

--- a/text/chapter14.md
+++ b/text/chapter14.md
@@ -4,22 +4,22 @@
 
 In this chapter, we will explore the implementation of _domain-specific languages_ (or _DSLs_) in PureScript, using a number of standard techniques.
 
-A domain-specific language is a language which is well-suited to development in a particular problem domain. Its syntax and functions are chosen to maximize readability of code used to express ideas in that domain. We have already seen a number of examples of domain-specific languages in this book:
+A domain-specific language is a language that is well-suited to development in a particular problem domain. Its syntax and functions are chosen to maximize the readability of code used to express ideas in that domain. We have already seen several examples of domain-specific languages in this book:
 
 - The `Game` monad and its associated actions, developed in chapter 11, constitute a domain-specific language for the domain of _text adventure game development_.
-- The `quickcheck` package, covered in chapter 13, is a domain-specific language for the domain of _generative testing_. Its combinators enable a particularly expressive notation for test properties.
+- The `quickcheck` package, covered in Chapter 13, is a domain-specific language for the domain of _generative testing_. Its combinators enable a particularly expressive notation for test properties.
 
-This chapter will take a more structured approach to some of standard techniques in the implementation of domain-specific languages. It is by no means a complete exposition of the subject, but should provide you with enough knowledge to build some practical DSLs for your own tasks.
+This chapter will take a more structured approach to some standard techniques in implementing domain-specific languages. It is by no means a complete exposition of the subject, but should provide you with enough knowledge to build some practical DSLs for your own tasks.
 
-Our running example will be a domain-specific language for creating HTML documents. Our aim will be to develop a type-safe language for describing correct HTML documents, and we will work by improving a naive implementation in small steps.
+Our running example will be a domain-specific language for creating HTML documents. We will aim to develop a type-safe language for describing correct HTML documents, and we will work by improving a naive implementation in small steps.
 
 ## Project Setup
 
-The project accompanying this chapter adds one new dependency - the `free` library, which defines the _free monad_, one of the tools which we will be using.
+The project accompanying this chapter adds one new dependency – the `free` library, which defines the _free monad_, one of the tools we will use.
 
 We will test this chapter's project in PSCi.
 
-## A HTML Data Type
+## An HTML Data Type
 
 The most basic version of our HTML library is defined in the `Data.DOM.Simple` module. The module contains the following type definitions:
 
@@ -40,7 +40,7 @@ newtype Attribute = Attribute
   }
 ```
 
-The `Element` type represents HTML elements. Each element consists of an element name, an array of attribute pairs and some content. The content property uses the `Maybe` type to indicate that an element might be open (containing other elements and text) or closed.
+The `Element` type represents HTML elements. Each element consists of an element name, an array of attribute pairs, and some content. The content property uses the `Maybe` type to indicate that an element might be open (containing other elements and text) or closed.
 
 The key function of our library is a function
 
@@ -79,7 +79,7 @@ unit
 
 As it stands, there are several problems with this library:
 
-- Creating HTML documents is difficult - every new element requires at least one record and one data constructor.
+- Creating HTML documents is difficult – every new element requires at least one record and one data constructor.
 - It is possible to represent invalid documents:
   - The developer might mistype the element name
   - The developer can associate an attribute with the wrong type of element
@@ -89,7 +89,7 @@ In the remainder of the chapter, we will apply certain techniques to solve these
 
 ## Smart Constructors
 
-The first technique we will apply is simple but can be very effective. Instead of exposing the representation of the data to the module's users, we can use the module exports list to hide the `Element`, `Content` and `Attribute` data constructors, and only export so-called _smart constructors_, which construct data which is known to be correct.
+The first technique we will apply is simple but can be very effective. Instead of exposing the representation of the data to the module's users, we can use the module exports list to hide the `Element`, `Content`, and `Attribute` data constructors, and only export so-called _smart constructors_, which construct data known to be correct.
 
 Here is an example. First, we provide a convenience function for creating HTML elements:
 
@@ -102,7 +102,7 @@ element name attribs content = Element
   }
 ```
 
-Next, we create smart constructors for those HTML elements we want our users to be able to create, by applying the `element` function:
+Next, we create smart constructors for those HTML elements we want our users to be able to create by applying the `element` function:
 
 ```haskell
 a :: Array Attribute -> Array Content -> Element
@@ -135,9 +135,9 @@ The module exports list is provided immediately after the module name inside par
 
 - A value (or function), indicated by the name of the value,
 - A type class, indicated by the name of the class,
-- A type constructor and any associated data constructors, indicated by the name of the type followed by a parenthesized list of exported data constructors.
+- A type constructor and any associated data constructors indicated by the name of the type followed by a parenthesized list of exported data constructors.
 
-Here, we export the `Element` _type_, but we do not export its data constructors. If we did, the user would be able to construct invalid HTML elements.
+Here, we export the `Element` _type_, but we do not export its data constructors. If we did, the user could construct invalid HTML elements.
 
 In the case of the `Attribute` and `Content` types, we still export all of the data constructors (indicated by the symbol `..` in the exports list). We will apply the technique of smart constructors to these types shortly.
 
@@ -146,7 +146,7 @@ Notice that we have already made some big improvements to our library:
 - It is impossible to represent HTML elements with invalid names (of course, we are restricted to the set of element names provided by the library).
 - Closed elements cannot contain content by construction.
 
-We can apply this technique to the `Content` type very easily. We simply remove the data constructors for the `Content` type from the exports list, and provide the following smart constructors:
+We can apply this technique to the `Content` type very easily. We simply remove the data constructors for the `Content` type from the exports list and provide the following smart constructors:
 
 ```haskell
 text :: String -> Content
@@ -168,7 +168,7 @@ attribute key value = Attribute
 infix 4 attribute as :=
 ```
 
-This representation suffers from the same problem as the original `Element` type - it is possible to represent attributes which do not exist or whose names were entered incorrectly. To solve this problem, we can create a newtype which represents attribute names:
+This representation suffers from the same problem as the original `Element` type – it is possible to represent attributes that do not exist or whose names were entered incorrectly. To solve this problem, we can create a newtype that represents attribute names:
 
 ```haskell
 newtype AttributeKey = AttributeKey String
@@ -244,12 +244,12 @@ $ spago repl
 unit
 ```
 
-Note, however, that no changes had to be made to the `render` function, because the underlying data representation never changed. This is one of the benefits of the smart constructors approach - it allows us to separate the internal data representation for a module from the representation which is perceived by users of its external API.
+Note, however, that no changes had to be made to the `render` function, because the underlying data representation never changed. This is one of the benefits of the smart constructors approach – it allows us to separate the internal data representation for a module from the representation perceived by users of its external API.
 
 ## Exercises
 
  1. (Easy) Use the `Data.DOM.Smart` module to experiment by creating new HTML documents using `render`.
- 1. (Medium) Some HTML attributes such as `checked` and `disabled` do not require values, and may be rendered as _empty attributes_:
+ 1. (Medium) Some HTML attributes, such as `checked` and `disabled`, do not require values and may be rendered as _empty attributes_:
 
      ```html
      <input disabled>
@@ -351,8 +351,8 @@ unit
 
 ## Exercises
 
- 1. (Easy) Create a data type which represents either pixel or percentage lengths. Write an instance of `IsValue` for your type. Modify the `width` and `height` attributes to use your new type.
- 1. (Difficult) By defining type-level representatives for the Boolean values `true` and `false`, we can use a phantom type to encode whether an `AttributeKey` represents an _empty attribute_ such as `disabled` or `checked`.
+ 1. (Easy) Create a data type representing either pixel or percentage lengths. Write an instance of `IsValue` for your type. Modify the `width` and `height` attributes to use your new type.
+ 1. (Difficult) By defining type-level representatives for the Boolean values `true` and `false`, we can use a phantom type to encode whether an `AttributeKey` represents an _empty attribute_, such as `disabled` or `checked`.
 
      ```haskell
      data True
@@ -363,7 +363,7 @@ unit
 
 ## The Free Monad
 
-In our final set of modifications to our API, we will use a construction called the _free monad_ to turn our `Content` type into a monad, enabling do notation. This will allow us to structure our HTML documents in a form in which the nesting of elements becomes clearer - instead of this:
+In our final set of modifications to our API, we will use a construction called the _free monad_ to turn our `Content` type into a monad, enabling do notation. This will allow us to structure our HTML documents in a form in which the nesting of elements becomes clearer – instead of this:
 
 ```haskell
 p [ _class := "main" ]
@@ -388,9 +388,9 @@ p [ _class := "main" ] $ do
   text "A cat"
 ```
 
-However, do notation is not the only benefit of a free monad. The free monad allows us to separate the _representation_ of our monadic actions from their _interpretation_, and even support _multiple interpretations_ of the same actions.
+However, do notation is not the only benefit of a free monad. The free monad allows us to separate the _representation_ of our monadic actions from their _interpretation_ and even support _multiple interpretations_ of the same actions.
 
-The `Free` monad is defined in the `free` library, in the `Control.Monad.Free` module. We can find out some basic information about it using PSCi, as follows:
+The `Free` monad is defined in the `free` library in the `Control.Monad.Free` module. We can find out some basic information about it using PSCi, as follows:
 
 ```text
 > import Control.Monad.Free
@@ -399,9 +399,9 @@ The `Free` monad is defined in the `free` library, in the `Control.Monad.Free` m
 (Type -> Type) -> Type -> Type
 ```
 
-The kind of `Free` indicates that it takes a type constructor as an argument, and returns another type constructor. In fact, the `Free` monad can be used to turn any `Functor` into a `Monad`!
+The kind of `Free` indicates that it takes a type constructor as an argument and returns another type constructor. In fact, the `Free` monad can be used to turn any `Functor` into a `Monad`!
 
-We begin by defining the _representation_ of our monadic actions. To do this, we need to create a `Functor` with one data constructor for each monadic action we wish to support. In our case, our two monadic actions will be `elem` and `text`. In fact, we can simply modify our `Content` type as follows:
+We begin by defining the _representation_ of our monadic actions. To do this, we need to create a `Functor` with one data constructor for each monadic action we wish to support. In our case, our two monadic actions will be `elem` and `text`. We can simply modify our `Content` type as follows:
 
 ```haskell
 data ContentF a
@@ -413,7 +413,7 @@ instance Functor ContentF where
   map f (ElementContent e x) = ElementContent e (f x)
 ```
 
-Here, the `ContentF` type constructor looks just like our old `Content` data type - however, it now takes a type argument `a`, and each data constructor has been modified to take a value of type `a` as an additional argument. The `Functor` instance simply applies the function `f` to the value of type `a` in each data constructor.
+Here, the `ContentF` type constructor looks just like our old `Content` data type – however, it now takes a type argument `a`, and each data constructor has been modified to take a value of type `a` as an additional argument. The `Functor` instance simply applies the function `f` to the value of type `a` in each data constructor.
 
 With that, we can define our new `Content` monad as a type synonym for the `Free` monad, which we construct by using our `ContentF` type constructor as the first type argument:
 
@@ -421,7 +421,7 @@ With that, we can define our new `Content` monad as a type synonym for the `Free
 type Content = Free ContentF
 ```
 
-Instead of a type synonym, we might use a `newtype` to avoid exposing the internal representation of our library to our users - by hiding the `Content` data constructor, we restrict our users to only using the monadic actions we provide.
+Instead of a type synonym, we might use a `newtype` to avoid exposing the internal representation of our library to our users – by hiding the `Content` data constructor, we restrict our users to only using the monadic actions we provide.
 
 Because `ContentF` is a `Functor`, we automatically get a `Monad` instance for `Free ContentF`.
 
@@ -435,13 +435,13 @@ newtype Element = Element
   }
 ```
 
-In addition, we have to modify our `elem` and `text` functions, which become our new monadic actions for the `Content` monad. To do this, we can use the `liftF` function, provided by the `Control.Monad.Free` module. Here is its type:
+In addition, we have to modify our `elem` and `text` functions, which become our new monadic actions for the `Content` monad. To do this, we can use the `liftF` function provided by the `Control.Monad.Free` module. Here is its type:
 
 ```haskell
 liftF :: forall f a. f a -> Free f a
 ```
 
-`liftF` allows us to construct an action in our free monad from a value of type `f a` for some type `a`. In our case, we can simply use the data constructors of our `ContentF` type constructor directly:
+`liftF` allows us to construct an action in our free monad from a value of type `f a` for some type `a`. In our case, we can use the data constructors of our `ContentF` type constructor directly:
 
 ```haskell
 text :: String -> Content Unit
@@ -475,9 +475,9 @@ runFreeM
 
 The `runFree` function is used to compute a _pure_ result. The `runFreeM` function allows us to use a monad to interpret the actions of our free monad.
 
-_Note_: Technically, we are restricted to using monads `m` which satisfy the stronger `MonadRec` constraint. In practice, this means that we don't need to worry about stack overflow, since `m` supports safe _monadic tail recursion_.
+_Note_: Technically, we are restricted to monads `m` that satisfy the stronger `MonadRec` constraint. In practice, we don't need to worry about stack overflow since `m` supports safe _monadic tail recursion_.
 
-First, we have to choose a monad in which we can interpret our actions. We will use the `Writer String` monad to accumulate a HTML string as our result.
+First, we have to choose a monad in which we can interpret our actions. We will use the `Writer String` monad to accumulate an HTML string as our result.
 
 Our new `render` method starts by delegating to a helper function, `renderElement`, and using `execWriter` to run our computation in the `Writer` monad:
 
@@ -536,7 +536,7 @@ The type of `renderContentItem` can be deduced from the type signature of `runFr
       renderContentItem :: ContentF (Content Unit) -> Writer String (Content Unit)
 ```
 
-We can implement this function by simply pattern matching on the two data constructors of `ContentF`:
+We can implement this function by pattern matching on the two data constructors of `ContentF`:
 
 ```haskell
       renderContentItem (TextContent s rest) = do
@@ -547,7 +547,7 @@ We can implement this function by simply pattern matching on the two data constr
         pure rest
 ```
 
-In each case, the expression `rest` has the type `Content Unit`, and represents the remainder of the interpreted computation. We can complete each case by returning the `rest` action.
+In each case, the expression `rest` has the type `Content Unit` and represents the remainder of the interpreted computation. We can complete each case by returning the `rest` action.
 
 That's it! We can test our new monadic API in PSCi, as follows:
 
@@ -574,14 +574,14 @@ unit
 
 A monad in which every action returns something of type `Unit` is not particularly interesting. In fact, aside from an arguably nicer syntax, our monad adds no extra functionality over a `Monoid`.
 
-Let's illustrate the power of the free monad construction by extending our language with a new monadic action which returns a non-trivial result.
+Let's illustrate the power of the free monad construction by extending our language with a new monadic action that returns a non-trivial result.
 
-Suppose we want to generate HTML documents which contain hyperlinks to different sections of the document using _anchors_. We can accomplish this already, by generating anchor names by hand and including them at least twice in the document: once at the definition of the anchor itself, and once in each hyperlink. However, this approach has some basic issues:
+Suppose we want to generate HTML documents that contain hyperlinks to different sections of the document using _anchors_. We can accomplish this by generating anchor names by hand and including them at least twice in the document: once at the anchor's definition and once in each hyperlink. However, this approach has some basic issues:
 
 - The developer might fail to generate unique anchor names.
 - The developer might mistype one or more instances of the anchor name.
 
-In the interest of protecting the developer from their own mistakes, we can introduce a new type which represents anchor names, and provide a monadic action for generating new unique names.
+To protect the developer from their mistakes, we can introduce a new type that represents anchor names and provide a monadic action for generating new unique names.
 
 The first step is to add a new type for names:
 
@@ -594,7 +594,7 @@ runName (Name n) = n
 
 Again, we define this as a newtype around `String`, but we must be careful not to export the data constructor in the module's export lists.
 
-Next, we define an instance for the `IsValue` type class for our new type, so that we are able to use names in attribute values:
+Next, we define an instance for the `IsValue` type class for our new type so that we can use names in attribute values:
 
 ```haskell
 instance IsValue Name where
@@ -650,9 +650,9 @@ newName :: Content Name
 newName = liftF $ NewName id
 ```
 
-Notice that we provide the `id` function as our continuation, meaning that we return the result of type `Name` unchanged.
+Notice that we provide the `id` function as our continuation, meaning we return the result of type `Name` unchanged.
 
-Finally, we need to update our interpretation function, to interpret the new action. We previously used the `Writer String` monad to interpret our computations, but that monad does not have the ability to generate new names, so we must switch to something else. The `WriterT` monad transformer can be used with the `State` monad to combine the effects we need. We can define our interpretation monad as a type synonym to keep our type signatures short:
+Finally, we need to update our interpretation function to interpret the new action. We previously used the `Writer String` monad to interpret our computations, but that monad cannot generate new names, so we must switch to something else. The `WriterT` monad transformer can be used with the `State` monad to combine the effects we need. We can define our interpretation monad as a type synonym to keep our type signatures short:
 
 ```haskell
 type Interp = WriterT String (State Int)
@@ -660,7 +660,7 @@ type Interp = WriterT String (State Int)
 
 Here, the state of type `Int` will act as an incrementing counter, used to generate unique names.
 
-Because the `Writer` and `WriterT` monads use the same type class members to abstract their actions, we do not need to change any actions - we only need to replace every reference to `Writer String` with `Interp`. We do, however, need to modify the handler used to run our computation. Instead of just `execWriter`, we now need to use `evalState` as well:
+Because the `Writer` and `WriterT` monads use the same type class members to abstract their actions, we do not need to change any actions – we only need to replace every reference to `Writer String` with `Interp`. However, we need to modify the handler used to run our computation. Instead of just `execWriter`, we now need to use `evalState` as well:
 
 ```haskell
 render :: Element -> String
@@ -679,7 +679,7 @@ renderContentItem (NewName k) = do
 
 Here, we are given a continuation `k` of type `Name -> Content a`, and we need to construct an interpretation of type `Content a`. Our interpretation is simple: we use `get` to read the state, use that state to generate a unique name, then use `put` to increment the state. Finally, we pass our new name to the continuation to complete the computation.
 
-With that, we can try out our new functionality in PSCi, by generating a unique name inside the `Content` monad, and using it as both the name of an element and the target of a hyperlink:
+With that, we can try out our new functionality in PSCi, by generating a unique name inside the `Content` monad and using it as both the name of an element and the target of a hyperlink:
 
 ```text
 > import Prelude
@@ -699,15 +699,14 @@ With that, we can try out our new functionality in PSCi, by generating a unique 
 unit
 ```
 
-You can verify that multiple calls to `newName` do in fact result in unique names.
+You can verify that multiple calls to `newName` do, in fact, result in unique names.
 
 ## Exercises
 
  1. (Medium) We can simplify the API further by hiding the `Element` type from its users. Make these changes in the following steps:
      - Combine functions like `p` and `img` (with return type `Element`) with the `elem` action to create new actions with return type `Content Unit`.
      - Change the `render` function to accept an argument of type `Content Unit` instead of `Element`.
- 1. (Medium) Hide the implementation of the `Content` monad by using a `newtype` instead of a type synonym. You should not export the data
-     constructor for your `newtype`.
+ 1. (Medium) Hide the implementation of the `Content` monad using a `newtype` instead of a type synonym. You should not export the data constructor for your `newtype`.
  1. (Difficult) Modify the `ContentF` type to support a new action
 
      ```haskell
@@ -720,13 +719,13 @@ You can verify that multiple calls to `newName` do in fact result in unique name
 
 ## Conclusion
 
-In this chapter, we developed a domain-specific language for creating HTML documents, by incrementally improving a naive implementation using some standard techniques:
+In this chapter, we developed a domain-specific language for creating HTML documents by incrementally improving a naive implementation using some standard techniques:
 
-- We used _smart constructors_ to hide the details of our data representation, only permitting the user to create documents which were _correct-by-construction_.
-- We used an _user-defined infix binary operator_ to improve the syntax of the language.
+- We used _smart constructors_ to hide the details of our data representation, only permitting the user to create documents that were _correct-by-construction_.
+- We used a _user-defined infix binary operator_ to improve the syntax of the language.
 - We used _phantom types_ to encode additional information in the types of our data, preventing the user from providing attribute values of the wrong type.
-- We used the _free monad_ to turn our array representation of a collection of content into a monadic representation supporting do notation. We then extended this representation to support a new monadic action, and interpreted the monadic computations using standard monad transformers.
+- We used the _free monad_ to turn our array representation of a collection of content into a monadic representation supporting do notation. We then extended this representation to support a new monadic action and interpreted the monadic computations using standard monad transformers.
 
 These techniques all leverage PureScript's module and type systems, either to prevent the user from making mistakes or to improve the syntax of the domain-specific language.
 
-The implementation of domain-specific languages in functional programming languages is an area of active research, but hopefully this provides a useful introduction some simple techniques, and illustrates the power of working in a language with expressive types.
+Implementing domain-specific languages in functional programming languages is an area of active research. Still, hopefully, this provides a useful introduction to some simple techniques and illustrates the power of working in a language with expressive types.

--- a/text/chapter2.md
+++ b/text/chapter2.md
@@ -24,7 +24,7 @@ Now that you've installed the necessary development tools, clone this book's rep
 git clone https://github.com/purescript-contrib/purescript-book.git
 ```
 
-The book repo contains PureScript example code and unit tests for the exercises that accompany each chapter. There's some initial setup required to reset the exercise solutions so they are ready to be solved by you. Use the `resetSolutions.sh` script to simplify this process. While you're at it, you should also strip out all the anchor comments with the `removeAnchors.sh` script (these anchors are used for copying code snippets into the book's rendered markdown, and you probably don't need this clutter in your local repo):
+The book repo contains PureScript example code and unit tests for the exercises that accompany each chapter. There's some initial setup required to reset the exercise solutions so they are ready to be solved by you. Use the `resetSolutions.sh` script to simplify this process. While at it, you should also strip out all the anchor comments with the `removeAnchors.sh` script (these anchors are used for copying code snippets into the book's rendered markdown, and you probably don't need this clutter in your local repo):
 
 ```sh
 cd purescript-book
@@ -51,11 +51,11 @@ You should see the following successful test output:
 All 2 tests passed! 🎉
 ```
 
-Note that the `answer` function (found in `src/Euler.purs`) has been modified to find the multiples of 3 and 5 below any integer. The test suite (found in `test/Main.purs`) for this `answer` function is more comprehensive than the test in the earlier getting-started guide. Don't worry about understanding how this test framework code works while reading these early chapters.
+Note that the `answer` function (found in `src/Euler.purs`) has been modified to find the multiples of 3 and 5 below any integer. The test suite (located in `test/Main.purs`) for this `answer` function is more comprehensive than the test in the earlier getting-started guide. Don't worry about understanding how this test framework code works while reading these early chapters.
 
 The remainder of the book contains lots of exercises. If you write your solutions in the `Test.MySolutions` module (`test/MySolutions.purs`), you can check your work against the provided test suite.
 
-Let's work through this next exercise together in test-driven-development style.
+Let's work through this next exercise together in a test-driven-development style.
 
 ## Exercise
 
@@ -63,7 +63,7 @@ Let's work through this next exercise together in test-driven-development style.
 
 ## Solution
 
-We'll start by enabling the tests for this exercise. Move the start of the block-comment down a few lines as shown below. Block comments start with `{-` and end with `-}`:
+We'll start by enabling the tests for this exercise. Move the start of the block-comment down a few lines, as shown below. Block comments start with `{-` and end with `-}`:
 
 ```hs
 {{#include ../exercises/chapter2/test/Main.purs:diagonalTests}}
@@ -82,7 +82,7 @@ at test/Main.purs:21:27 - 21:35 (line 21, column 27 - line 21, column 35)
   Unknown value diagonal
 ```
 
-Let's first take a look at what happens with a faulty version of this function. Add the following code to `test/MySolutions.purs`:
+Let's first look at what happens with a faulty version of this function. Add the following code to `test/MySolutions.purs`:
 
 ```hs
 import Data.Number (sqrt)
@@ -130,8 +130,8 @@ Success! Now you're ready to try these next exercises on your own.
 
 In this chapter, we installed the PureScript compiler and the Spago tool. We also learned how to write solutions to exercises and check these for correctness.
 
-There will be many more exercises in the chapters ahead, and working through those really helps with learning the material. If you're stumped by any of the exercises, please reach out to any of the community resources listed in the [Getting Help](https://book.purescript.org/chapter1.html#getting-help) section of this book, or even file an issue in this [book's repo](https://github.com/purescript-contrib/purescript-book/issues). This reader feedback on which exercises could be made more approachable helps us improve the book.
+There will be many more exercises in the chapters ahead, and working through those helps with learning the material. If any of the exercises stumps you, please reach out to any of the community resources listed in the [Getting Help](https://book.purescript.org/chapter1.html#getting-help) section of this book, or even file an issue in this [book's repo](https://github.com/purescript-contrib/purescript-book/issues). This reader feedback on which exercises could be made more approachable helps us improve the book.
 
-Once you solve all the exercises in a chapter, you may compare your answers against those in the `no-peeking/Solutions.purs`. No peeking please without putting in an honest effort to solve these yourself though. And even if you are stuck, try asking a community member for help first, as we would prefer to give you a small hint rather than spoil the exercise. If you found a more elegant solution (that still only requires knowledge of covered content), please send us a PR.
+Once you solve all the exercises in a chapter, you may compare your answers against those in the `no-peeking/Solutions.purs`. No peeking, please, without putting in an honest effort to solve these yourself. And even if you are stuck, try asking a community member for help first, as we would prefer to give you a small hint rather than spoil the exercise. If you found a more elegant solution (that only requires knowledge of the covered content), please send us a PR.
 
 The repo is continuously being revised, so be sure to check for updates before starting each new chapter.

--- a/text/chapter3.md
+++ b/text/chapter3.md
@@ -19,7 +19,7 @@ The source code for this chapter is contained in the file `src/Data/AddressBook.
 Here, we import several modules:
 
 - The `Control.Plus` module, which defines the `empty` value.
-- The `Data.List` module, which is provided by the `lists` package which can be installed using Spago. It contains a few functions which we will need for working with linked lists.
+- The `Data.List` module, provided by the `lists` package, which can be installed using Spago. It contains a few functions that we will need for working with linked lists.
 - The `Data.Maybe` module, which defines data types and functions for working with optional values.
 
 Notice that the imports for these modules are listed explicitly in parentheses. This is generally a good practice, as it helps to avoid conflicting imports.
@@ -33,7 +33,7 @@ $ spago build
 
 ## Simple Types
 
-PureScript defines three built-in types which correspond to JavaScript's primitive types: numbers, strings and booleans. These are defined in the `Prim` module, which is implicitly imported by every module. They are called `Number`, `String`, and `Boolean`, respectively, and you can see them in PSCi by using the `:type` command to print the types of some simple values:
+PureScript defines three built-in types corresponding to JavaScript's primitive types: numbers, strings, and booleans. These are defined in the `Prim` module, which is implicitly imported by every module. They are called `Number`, `String`, and `Boolean`, respectively, and you can see them in PSCi by using the `:type` command to print the types of some simple values:
 
 ```text
 $ spago repl
@@ -48,7 +48,7 @@ String
 Boolean
 ```
 
-PureScript defines some other built-in types: integers, characters, arrays, records, and functions.
+PureScript defines other built-in types: integers, characters, arrays, records, and functions.
 
 Integers are differentiated from floating point values of type `Number` by the lack of a decimal point:
 
@@ -77,7 +77,7 @@ Array Boolean
 Could not match type Int with type Boolean.
 ```
 
-The error in the last example is an error from the type checker, which unsuccessfully attempted to _unify_ (i.e. make equal) the types of the two elements.
+The last example shows an error from the type checker, which failed to _unify_ (i.e., make equal) the types of the two elements.
 
 Records correspond to JavaScript's objects, and record literals have the same syntax as JavaScript's object literals:
 
@@ -90,7 +90,7 @@ Records correspond to JavaScript's objects, and record literals have the same sy
 }
 ```
 
-This type indicates that the specified object has two _fields_, a `name` field which has type `String`, and an `interests` field, which has type `Array String`, i.e. an array of `String`s.
+This type indicates that the specified object has two _fields_: a `name` field with the type `String` and an `interests` field with the type `Array String`, i.e., an array of `String`s.
 
 Fields of records can be accessed using a dot, followed by the label of the field to access:
 
@@ -120,7 +120,7 @@ add :: Int -> Int -> Int
 add x y = x + y
 ```
 
-Alternatively, functions can be defined inline, by using a backslash character followed by a space-delimited list of argument names. To enter a multi-line declaration in PSCi, we can enter "paste mode" by using the `:paste` command. In this mode, declarations are terminated using the _Control-D_ key sequence:
+Alternatively, functions can be defined inline using a backslash character followed by a space-delimited list of argument names. To enter a multi-line declaration in PSCi, we can enter "paste mode" using the `:paste` command. In this mode, declarations are terminated using the _Control-D_ key sequence:
 
 ```text
 > :paste
@@ -145,15 +145,15 @@ In the previous section, we saw the types of some functions defined in the Prelu
 forall a b c. (a -> b -> c) -> b -> a -> c
 ```
 
-The keyword `forall` here indicates that `flip` has a _universally quantified type_. It means that we can substitute any types for `a`, `b` and `c`, and `flip` will work with those types.
+The keyword `forall` here indicates that `flip` has a _universally quantified type_. It means we can substitute any types for `a`, `b`, and `c`, and `flip` will work with those types.
 
-For example, we might choose the type `a` to be `Int`, `b` to be `String` and `c` to be `String`. In that case we could _specialize_ the type of `flip` to
+For example, we might choose the type `a` to be `Int`, `b` to be `String`, and `c` to be `String`. In that case, we could _specialize_ the type of `flip` to
 
 ```text
 (Int -> String -> String) -> String -> Int -> String
 ```
 
-We don't have to indicate in code that we want to specialize a quantified type - it happens automatically. For example, we can just use `flip` as if it had this type already:
+We don't have to indicate in code that we want to specialize a quantified type – it happens automatically. For example, we can use `flip` as if it had this type already:
 
 ```text
 > flip (\n s -> show n <> s) "Ten" 10
@@ -161,7 +161,7 @@ We don't have to indicate in code that we want to specialize a quantified type -
 "10Ten"
 ```
 
-While we can choose any types for `a`, `b` and `c`, we have to be consistent. The type of the function we passed to `flip` had to be consistent with the types of the other arguments. That is why we passed the string `"Ten"` as the second argument, and the number `10` as the third. It would not work if the arguments were reversed:
+While we can choose any types for `a`, `b`, and `c`, we have to be consistent. The type of function passed to `flip` had to be consistent with the types of the other arguments. That is why we passed the string `"Ten"` as the second argument and the number `10` as the third. It would not work if the arguments were reversed:
 
 ```text
 > flip (\n s -> show n <> s) 10 "Ten"
@@ -175,14 +175,14 @@ PureScript code is _indentation-sensitive_, just like Haskell, but unlike JavaSc
 
 If a declaration spans multiple lines, then any lines except the first must be indented past the indentation level of the first line.
 
-Therefore, the following is valid PureScript code:
+Therefore, the following is a valid PureScript code:
 
 ```haskell
 add x y z = x +
   y + z
 ```
 
-But this is not valid code:
+But this is not a valid code:
 
 ```haskell
 add x y z = x +
@@ -200,7 +200,7 @@ Generally, any declarations defined in the same block should be indented at the 
 … ^D
 ```
 
-but this is not:
+But this is not:
 
 ```text
 > :paste
@@ -230,7 +230,7 @@ A good first step when tackling a new problem in PureScript is to write out type
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:Entry}}
 ```
 
-This defines a _type synonym_ called `Entry` - the type `Entry` is equivalent to the type on the right of the equals symbol: a record type with three fields - `firstName`, `lastName` and `address`. The two name fields will have type `String`, and the `address` field will have type `Address`, defined as follows:
+This defines a _type synonym_ called `Entry` – the type `Entry` is equivalent to the type on the right of the equals symbol: a record type with three fields – `firstName`, `lastName`, and `address`. The two name fields will have the type `String`, and the `address` field will have the type `Address`, defined as follows:
 
 ```haskell
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:Address}}
@@ -238,19 +238,19 @@ This defines a _type synonym_ called `Entry` - the type `Entry` is equivalent to
 
 Note that records can contain other records.
 
-Now let's define a third type synonym, for our address book data structure, which will be represented simply as a linked list of entries:
+Now let's define a third type synonym for our address book data structure, which will be represented simply as a linked list of entries:
 
 ```haskell
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:AddressBook}}
 ```
 
-Note that `List Entry` is not the same as `Array Entry`, which represents an _array_ of entries.
+Note that `List Entry` differs from `Array Entry`, which represents an _array_ of entries.
 
 ## Type Constructors and Kinds
 
 `List` is an example of a _type constructor_. Values do not have the type `List` directly, but rather `List a` for some type `a`. That is, `List` takes a _type argument_ `a` and _constructs_ a new type `List a`.
 
-Note that just like function application, type constructors are applied to other types simply by juxtaposition: the type `List Entry` is in fact the type constructor `List` _applied_ to the type `Entry` - it represents a list of entries.
+Note that just like function application, type constructors are applied to other types simply by juxtaposition: the type `List Entry` is, in fact, the type constructor `List` _applied_ to the type `Entry` – it represents a list of entries.
 
 If we try to incorrectly define a value of type `List` (by using the type annotation operator `::`), we will see a new type of error:
 
@@ -290,7 +290,7 @@ Let's write our first function, which will render an address book entry as a str
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:showEntry_signature}}
 ```
 
-This type signature says that `showEntry` is a function, which takes an `Entry` as an argument and returns a `String`. Here is the code for `showEntry`:
+This type signature says that `showEntry` is a function that takes an `Entry` as an argument and returns a `String`. Here is the code for `showEntry`:
 
 ```haskell
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:showEntry_implementation}}
@@ -347,7 +347,7 @@ Let's also test `showEntry` by creating an address book entry record containing 
 
 ## Creating Address Books
 
-Now let's write some utility functions for working with address books. We will need a value which represents an empty address book: an empty list.
+Now let's write some utility functions for working with address books. We will need a value representing an empty address book: an empty list.
 
 ```haskell
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:emptyBook}}
@@ -359,9 +359,9 @@ We will also need a function for inserting a value into an existing address book
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:insertEntry_signature}}
 ```
 
-This type signature says that `insertEntry` takes an `Entry` as its first argument, and an `AddressBook` as a second argument, and returns a new `AddressBook`.
+This type signature says that `insertEntry` takes an `Entry` as its first argument, an `AddressBook` as a second argument, and returns a new `AddressBook`.
 
-We don't modify the existing `AddressBook` directly. Instead, we return a new `AddressBook` which contains the same data. As such, `AddressBook` is an example of an _immutable data structure_. This is an important idea in PureScript - mutation is a side-effect of code, and inhibits our ability to reason effectively about its behavior, so we prefer pure functions and immutable data where possible.
+We don't modify the existing `AddressBook` directly. Instead, we return a new `AddressBook`, which contains the same data. As such, `AddressBook` is an example of an _immutable data structure_. This is an important idea in PureScript – mutation is a side-effect of code and inhibits our ability to reason effectively about its behavior, so we prefer pure functions and immutable data where possible.
 
 To implement `insertEntry`, we can use the `Cons` function from `Data.List`. To see its type, open PSCi and use the `:type` command:
 
@@ -374,7 +374,7 @@ $ spago repl
 forall a. a -> List a -> List a
 ```
 
-This type signature says that `Cons` takes a value of some type `a`, and a list of elements of type `a`, and returns a new list with entries of the same type. Let's specialize this with `a` as our `Entry` type:
+This type signature says that `Cons` takes a value of some type `a`, takes a list of elements of type `a`, and returns a new list with entries of the same type. Let's specialize this with `a` as our `Entry` type:
 
 ```haskell
 Entry -> List Entry -> List Entry
@@ -394,11 +394,11 @@ Here is our implementation of `insertEntry`:
 insertEntry entry book = Cons entry book
 ```
 
-This brings the two arguments `entry` and `book` into scope, on the left hand side of the equals symbol, and then applies the `Cons` function to create the result.
+This brings the two arguments `entry` and `book` into scope – on the left-hand side of the equals symbol – and then applies the `Cons` function to create the result.
 
 ## Curried Functions
 
-Functions in PureScript take exactly one argument. While it looks like the `insertEntry` function takes two arguments, it is in fact an example of a _curried function_.
+Functions in PureScript take exactly one argument. While it looks like the `insertEntry` function takes two arguments, it is an example of a _curried function_.
 
 The `->` operator in the type of `insertEntry` associates to the right, which means that the compiler parses the type as
 
@@ -406,9 +406,9 @@ The `->` operator in the type of `insertEntry` associates to the right, which me
 Entry -> (AddressBook -> AddressBook)
 ```
 
-That is, `insertEntry` is a function which returns a function! It takes a single argument, an `Entry`, and returns a new function, which in turn takes a single `AddressBook` argument and returns a new `AddressBook`.
+That is, `insertEntry` is a function that returns a function! It takes a single argument, an `Entry`, and returns a new function, which in turn takes a single `AddressBook` argument and returns a new `AddressBook`.
 
-This means that we can _partially apply_ `insertEntry` by specifying only its first argument, for example. In PSCi, we can see the result type:
+This means we can _partially apply_ `insertEntry` by specifying only its first argument, for example. In PSCi, we can see the result type:
 
 ```text
 > :type insertEntry entry
@@ -423,16 +423,16 @@ As expected, the return type was a function. We can apply the resulting function
 AddressBook
 ```
 
-Note though that the parentheses here are unnecessary - the following is equivalent:
+Note though, that the parentheses here are unnecessary – the following is equivalent:
 
 ```text
 > :type insertEntry entry emptyBook
 AddressBook
 ```
 
-This is because function application associates to the left, and this explains why we can just specify function arguments one after the other, separated by whitespace.
+This is because function application associates to the left, which explains why we can specify function arguments one after the other, separated by whitespace.
 
-The `->` operator in function types is a _type constructor_ for functions. It takes two type arguments, the function's argument type and the return type. The left and right operands respectively.
+The `->` operator in function types is a _type constructor_ for functions. It takes two type arguments: the function's argument type and the return type – the left and right operands, respectively.
 
 Note that in the rest of the book, I will talk about things like "functions of two arguments". However, it is to be understood that this means a curried function, taking a first argument and returning a function that takes the second.
 
@@ -443,7 +443,7 @@ insertEntry :: Entry -> AddressBook -> AddressBook
 insertEntry entry book = Cons entry book
 ```
 
-If we explicitly parenthesize the right-hand side, we get `(Cons entry) book`. That is, `insertEntry entry` is a function whose argument is just passed along to the `(Cons entry)` function. But if two functions have the same result for every input, then they are the same function! So we can remove the argument `book` from both sides:
+If we explicitly parenthesize the right-hand side, we get `(Cons entry) book`. That is, `insertEntry entry` is a function whose argument is just passed along to the `(Cons entry)` function. But if two functions have the same result for every input, then they are the same! So we can remove the argument `book` from both sides:
 
 ```haskell
 insertEntry :: Entry -> AddressBook -> AddressBook
@@ -456,9 +456,9 @@ But now, by the same argument, we can remove `entry` from both sides:
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:insertEntry}}
 ```
 
-This process is called _eta conversion_, and can be used (along with some other techniques) to rewrite functions in _point-free form_, which means functions defined without reference to their arguments.
+This process, called _eta conversion_, can be used (along with other techniques) to rewrite functions in _point-free form_, which means functions defined without reference to their arguments.
 
-In the case of `insertEntry`, _eta conversion_ has resulted in a very clear definition of our function - "`insertEntry` is just cons on lists". However, it is arguable whether point-free form is better in general.
+In the case of `insertEntry`, _eta conversion_ has resulted in a very clear definition of our function – "`insertEntry` is just cons on lists". However, it is arguable whether the point-free form is better in general.
 
 ## Property Accessors
 
@@ -494,11 +494,11 @@ For example:
 
 ## Querying the Address Book
 
-The last function we need to implement for our minimal address book application will look up a person by name and return the correct `Entry`. This will be a nice application of building programs by composing small functions - a key idea from functional programming.
+The last function we need to implement for our minimal address book application will look up a person by name and return the correct `Entry`. This will be a nice application of building programs by composing small functions – a key idea from functional programming.
 
-We can first filter the address book, keeping only those entries with the correct first and last names. Then we can simply return the head (i.e. first) element of the resulting list.
+We can filter the address book, keeping only those entries with the correct first and last names. Then we can return the head (i.e., first) element of the resulting list.
 
-With this high-level specification of our approach, we can calculate the type of our function. First open PSCi, and find the types of the `filter` and `head` functions:
+With this high-level specification of our approach, we can calculate the type of our function. First, open PSCi, and find the types of the `filter` and `head` functions:
 
 ```text
 $ spago repl
@@ -515,9 +515,9 @@ forall a. List a -> Maybe a
 
 Let's pick apart these two types to understand their meaning.
 
-`filter` is a curried function of two arguments. Its first argument is a function, which takes an element of the list and returns a `Boolean` value as a result. Its second argument is a list of elements, and the return value is another list.
+`filter` is a curried function of two arguments. Its first argument is a function, which takes an element of the list and returns a `Boolean` value. Its second argument is a list of elements, and the return value is another list.
 
-`head` takes a list as its argument, and returns a type we haven't seen before: `Maybe a`. `Maybe a` represents an optional value of type `a`, and provides a type-safe alternative to using `null` to indicate a missing value in languages like JavaScript. We will see it again in more detail in later chapters.
+`head` takes a list as its argument and returns a type we haven't seen before: `Maybe a`. `Maybe a` represents an optional value of type `a`, and provides a type-safe alternative to using `null` to indicate a missing value in languages like JavaScript. We will see it again in more detail in later chapters.
 
 The universally quantified types of `filter` and `head` can be _specialized_ by the PureScript compiler, to the following types:
 
@@ -527,7 +527,7 @@ filter :: (Entry -> Boolean) -> AddressBook -> AddressBook
 head :: AddressBook -> Maybe Entry
 ```
 
-We know that we will need to pass the first and last names that we want to search for, as arguments to our function.
+We know that we will need to pass the first and last names that we want to search for as arguments to our function.
 
 We also know that we will need a function to pass to `filter`. Let's call this function `filterEntry`. `filterEntry` will have type `Entry -> Boolean`. The application `filter filterEntry` will then have type `AddressBook -> AddressBook`. If we pass the result of this function to the `head` function, we get our result of type `Maybe Entry`.
 
@@ -537,7 +537,7 @@ Putting these facts together, a reasonable type signature for our function, whic
 {{#include ../exercises/chapter3/src/Data/AddressBook.purs:findEntry_signature}}
 ```
 
-This type signature says that `findEntry` takes two strings, the first and last names, and a `AddressBook`, and returns an optional `Entry`. The optional result will contain a value only if the name is found in the address book.
+This type signature says that `findEntry` takes two strings: the first and last names, takes an `AddressBook`, and returns an optional `Entry`. The optional result will contain a value only if the name is found in the address book.
 
 And here is the definition of `findEntry`:
 
@@ -552,36 +552,36 @@ Let's go over this code step by step.
 
 `findEntry` brings three names into scope: `firstName` and `lastName`, both representing strings, and `book`, an `AddressBook`.
 
-The right hand side of the definition combines the `filter` and `head` functions: first, the list of entries is filtered, and the `head` function is applied to the result.
+The right-hand side of the definition combines the `filter` and `head` functions: first, the list of entries is filtered, and the `head` function is applied to the result.
 
 The predicate function `filterEntry` is defined as an auxiliary declaration inside a `where` clause. This way, the `filterEntry` function is available inside the definition of our function, but not outside it. Also, it can depend on the arguments to the enclosing function, which is essential here because `filterEntry` uses the `firstName` and `lastName` arguments to filter the specified `Entry`.
 
-Note that, just like for top-level declarations, it was not necessary to specify a type signature for `filterEntry`. However, doing so is recommended as a form of documentation.
+Note that, just like for top-level declarations, it was unnecessary to specify a type signature for `filterEntry`. However, doing so is recommended as a form of documentation.
 
 ## Infix Function Application
 
-Most of the functions discussed so far used _prefix_ function application, where the function name was put _before_ the arguments. For example, when using the `insertEntry` function to add an `Entry` (`john`) to an empty `AddressBook`, we might write:
+Most functions discussed so far used _prefix_ function application, where the function name was put _before_ the arguments. For example, when using the `insertEntry` function to add an `Entry` (`john`) to an empty `AddressBook`, we might write:
 
 ```haskell
 > book1 = insertEntry john emptyBook
 ```
 
-However, this chapter has also included examples of _infix_ [binary operators](https://github.com/purescript/documentation/blob/master/language/Syntax.md#binary-operators), such as  the `==` operator in the definition of `filterEntry`, where the operator is put _between_ the two arguments. These infix operators are actually defined in the PureScript source as infix aliases for their underlying _prefix_ implementations. For example, `==` is defined as an infix alias for the prefix `eq` function with the line:
+However, this chapter has also included examples of _infix_ [binary operators](https://github.com/purescript/documentation/blob/master/language/Syntax.md#binary-operators), such as the `==` operator in the definition of `filterEntry`, where the operator is put _between_ the two arguments. These infix operators are defined in the PureScript source as infix aliases for their underlying _prefix_ implementations. For example, `==` is defined as an infix alias for the prefix `eq` function with the line:
 
 ```haskell
 infix 4 eq as ==
 ```
 
-and therefore `entry.firstName == firstName` in `filterEntry` could be replaced with the `eq entry.firstName firstName`. We'll cover a few more examples of defining infix operators later in this section.
+Therefore `entry.firstName == firstName` in `filterEntry` could be replaced with the `eq entry.firstName firstName`. We'll cover a few more examples of defining infix operators later in this section.
 
-There are situations where putting a prefix function in an infix position as an operator leads to more readable code. One example is the `mod` function:
+In some situations, putting a prefix function in an infix position as an operator leads to more readable code. One example is the `mod` function:
 
 ```text
 > mod 8 3
 2
 ```
 
-The above usage works fine, but is awkward to read. A more familiar phrasing is "eight mod three", which you can achieve by wrapping a prefix function in backticks (\`):
+The above usage works fine but is awkward to read. A more familiar phrasing is "eight mod three", which you can achieve by wrapping a prefix function in backticks (\`):
 
 ```text
 > 8 `mod` 3
@@ -614,7 +614,7 @@ This new operator lets us rewrite the above `book4` example as:
 book5 = john ++ (peggy ++ (ned ++ emptyBook))
 ```
 
-and the right associativity of our new `++` operator lets us get rid of the parentheses without changing the meaning:
+The right associativity of our new `++` operator lets us get rid of the parentheses without changing the meaning:
 
 ```haskell
 book6 = john ++ peggy ++ ned ++ emptyBook
@@ -630,7 +630,7 @@ book7 = insertEntry john $ insertEntry peggy $ insertEntry ned emptyBook
 
 Substituting `$` for parens is usually easier to type and (arguably) easier to read. A mnemonic to remember the meaning of this symbol is to think of the dollar sign as being drawn from two parens that are also being crossed-out, suggesting the parens are now unnecessary.
 
-Note that `$` isn't special syntax that's hardcoded into the language. It's simply the infix operator for a regular function called `apply`, which is defined in `Data.Function` as follows:
+Note that `$` isn't a special syntax hardcoded into the language. It's simply the infix operator for a regular function called `apply`, which is defined in `Data.Function` as follows:
 
 ```haskell
 apply :: forall a b. (a -> b) -> a -> b
@@ -709,26 +709,26 @@ filter filterEntry >>> head
 
 Either way, this gives a clear definition of the `findEntry` function: "`findEntry` is the composition of a filtering function and the `head` function".
 
-I will let you make your own decision which definition is easier to understand, but it is often useful to think of functions as building blocks in this way - each function executing a single task, and solutions assembled using function composition.
+I will let you decide which definition is easier to understand, but it is often useful to think of functions as building blocks in this way: each function executes a single task, and solutions are assembled using function composition.
 
 ## Exercises
 
  1. (Easy) Test your understanding of the `findEntry` function by writing down the types of each of its major subexpressions. For example, the type of the `head` function as used is specialized to `AddressBook -> Maybe Entry`. _Note_: There is no test for this exercise.
  1. (Medium) Write a function `findEntryByStreet :: String -> AddressBook -> Maybe Entry` which looks up an `Entry` given a street address. _Hint_ reusing the existing code in `findEntry`. Test your function in PSCi and by running `spago test`.
  1. (Medium) Rewrite `findEntryByStreet` to replace `filterEntry` with the composition (using `<<<` or `>>>`) of: a property accessor (using the `_.` notation); and a function that tests whether its given string argument is equal to the given street address.
- 1. (Medium) Write a function `isInBook` which tests whether a name appears in a `AddressBook`, returning a Boolean value. _Hint_: Use PSCi to find the type of the `Data.List.null` function, which tests whether a list is empty or not.
- 1. (Difficult) Write a function `removeDuplicates` which removes "duplicate" address book entries. We'll consider entries duplicated if they share the same first and last names, while ignoring `address` fields. _Hint_: Use PSCi to find the type of the `Data.List.nubByEq` function, which removes duplicate elements from a list based on an equality predicate. Note that the first element in each set of duplicates (closest to list head) is the one that is kept.
+ 1. (Medium) Write a function `isInBook` that tests whether a name appears in a `AddressBook`, returning a Boolean value. _Hint_: Use PSCi to find the type of the `Data.List.null` function, which tests whether a list is empty or not.
+ 1. (Difficult) Write a function `removeDuplicates` which removes "duplicate" address book entries. We'll consider entries duplicated if they share the same first and last names, while ignoring `address` fields. _Hint_: Use PSCi to find the type of the `Data.List.nubByEq` function, which removes duplicate elements from a list based on an equality predicate. Note that the first element in each set of duplicates (closest to the list head) is the one that is kept.
 
 ## Conclusion
 
-In this chapter, we covered several new functional programming concepts:
+In this chapter, we covered several new functional programming concepts and learned how to:
 
-- How to use the interactive mode PSCi to experiment with functions and test ideas.
-- The role of types as both a correctness tool, and an implementation tool.
-- The use of curried functions to represent functions of multiple arguments.
-- Creating programs from smaller components by composition.
-- Structuring code neatly using `where` expressions.
-- How to avoid null values by using the `Maybe` type.
-- Using techniques like eta conversion and function composition to refactor code into a clear specification.
+- Use the interactive mode PSCi to experiment with functions and test ideas.
+- Use types as both a correctness tool and an implementation tool.
+- Use curried functions to represent functions of multiple arguments.
+- Create programs from smaller components by composition.
+- Structure code neatly using `where` expressions.
+- Avoid null values by using the `Maybe` type.
+- Use techniques like eta conversion and function composition to refactor code into a clear specification.
 
 In the following chapters, we'll build on these ideas.

--- a/text/chapter4.md
+++ b/text/chapter4.md
@@ -1,12 +1,12 @@
-# Recursion, Maps And Folds
+# Recursion, Maps, And Folds
 
 ## Chapter Goals
 
 In this chapter, we will look at how recursive functions can be used to structure algorithms. Recursion is a basic technique used in functional programming, which we will use throughout this book.
 
-We will also cover some standard functions from PureScript's standard libraries. We will see the `map` and `fold` functions, as well as some useful special cases, like `filter` and `concatMap`.
+We will also cover some standard functions from PureScript's standard libraries. We will `map`, `fold`, and some useful special cases, like `filter` and `concatMap`.
 
-The motivating example for this chapter is a library of functions for working with a virtual filesystem. We will apply the techniques learned in this chapter to write functions which compute properties of the files represented by a model of a filesystem.
+The motivating example for this chapter is a library of functions for working with a virtual filesystem. We will apply the techniques learned in this chapter to write functions that compute properties of the files represented by a model of a filesystem.
 
 ## Project Setup
 
@@ -34,9 +34,9 @@ Here is the usual _factorial function_ example:
 {{#include ../exercises/chapter4/test/Examples.purs:factorial}}
 ```
 
-Here, we can see how the factorial function is computed by reducing the problem to a subproblem - that of computing the factorial of a smaller integer. When we reach zero, the answer is immediate.
+Here, we can see how the factorial function is computed by reducing the problem to a subproblem – computing the factorial of a smaller integer. When we reach zero, the answer is immediate.
 
-Here is another common example, which computes the _Fibonacci function_:
+Here is another common example that computes the _Fibonacci function_:
 
 ```haskell
 {{#include ../exercises/chapter4/test/Examples.purs:fib}}
@@ -44,7 +44,7 @@ Here is another common example, which computes the _Fibonacci function_:
 
 Again, this problem is solved by considering the solutions to subproblems. In this case, there are two subproblems, corresponding to the expressions `fib (n - 1)` and `fib (n - 2)`. When these two subproblems are solved, we assemble the result by adding the partial results.
 
-Note that, while the above examples of `factorial` and `fib` work as intended, a more idiomatic implementation would use pattern matching instead of `if`/`then`/`else`. Pattern matching techniques are discussed in a later chapter.
+> Note that, while the above examples of `factorial` and `fib` work as intended, a more idiomatic implementation would use pattern matching instead of `if`/`then`/`else`. Pattern-matching techniques are discussed in a later chapter.
 
 ## Recursion on Arrays
 
@@ -61,22 +61,22 @@ import Data.Maybe (fromMaybe)
 {{#include ../exercises/chapter4/test/Examples.purs:length}}
 ```
 
-In this function, we use an `if .. then .. else` expression to branch based on the emptiness of the array. The `null` function returns `true` on an empty array. Empty arrays have length zero, and a non-empty array has a length that is one more than the length of its tail.
+In this function, we use an `if .. then .. else` expression to branch based on the emptiness of the array. The `null` function returns `true` on an empty array. Empty arrays have a length of zero, and a non-empty array has a length that is one more than the length of its tail.
 
-The `tail` function returns a `Maybe` wrapping the given array without its first element. If the array is empty (i.e. it doesn't have a tail) `Nothing` is returned. The `fromMaybe` function takes a default value and a `Maybe` value. If the latter is `Nothing` it returns the default, in the other case it returns the value wrapped by `Just`.
+The `tail` function returns a `Maybe` wrapping the given array without its first element. If the array is empty (i.e., it doesn't have a tail), `Nothing` is returned. The `fromMaybe` function takes a default value and a `Maybe` value. If the latter is `Nothing` it returns the default; in the other case, it returns the value wrapped by `Just`.
 
-This example is obviously a very impractical way to find the length of an array in JavaScript, but should provide enough help to allow you to complete the following exercises:
+This example is a very impractical way to find the length of an array in JavaScript, but it should provide enough help to allow you to complete the following exercises:
 
 ## Exercises
 
- 1. (Easy) Write a recursive function `isEven` which returns `true` if and only if its input is an even integer.
- 2. (Medium) Write a recursive function `countEven` which counts the number of even integers in an array. _Hint_: the function `head` (also available in `Data.Array`) can be used to find the first element in a non-empty array.
+ 1. (Easy) Write a recursive function `isEven` that returns `true` if and only if its input is an even integer.
+ 2. (Medium) Write a recursive function `countEven` that counts the number of even integers in an array. _Hint_: the function `head` (also available in `Data.Array`) can be used to find the first element in a non-empty array.
 
 ## Maps
 
-The `map` function is an example of a recursive function on arrays. It is used to transform the elements of an array by applying a function to each element in turn. Therefore, it changes the _contents_ of the array, but preserves its _shape_ (i.e. its length).
+The `map` function is an example of a recursive function on arrays. It is used to transform the elements of an array by applying a function to each element in turn. Therefore, it changes the _contents_ of the array but preserves its _shape_ (i.e., its length).
 
-When we cover _type classes_ later in the book we will see that the `map` function is an example of a more general pattern of shape-preserving functions which transform a class of type constructors called _functors_.
+When we cover _type classes_ later in the book, we will see that the `map` function is an example of a more general pattern of shape-preserving functions which transform a class of type constructors called _functors_.
 
 Let's try out the `map` function in PSCi:
 
@@ -88,7 +88,7 @@ $ spago repl
 [2, 3, 4, 5, 6]
 ```
 
-Notice how `map` is used - we provide a function which should be "mapped over" the array in the first argument, and the array itself in its second.
+Notice how `map` is used – we provide a function that should be "mapped over" the array in the first argument, and the array itself in its second.
 
 ## Infix Operators
 
@@ -101,7 +101,7 @@ The `map` function can also be written between the mapping function and the arra
 
 This syntax is called _infix function application_, and any function can be made infix in this way. It is usually most appropriate for functions with two arguments.
 
-There is an operator which is equivalent to the `map` function when used with arrays, called `<$>`. This operator can be used infix like any other binary operator:
+There is an operator which is equivalent to the `map` function when used with arrays, called `<$>`.
 
 ```text
 > (\n -> n + 1) <$> [1, 2, 3, 4, 5]
@@ -129,7 +129,7 @@ This type says that we can choose any two types, `a` and `b`, with which to appl
 ["1","2","3","4","5"]
 ```
 
-Even though the infix operator `<$>` looks like special syntax, it is in fact just an alias for a regular PureScript function. The function is simply _applied_ using infix syntax. In fact, the function can be used like a regular function by enclosing its name in parentheses. This means that we can used the parenthesized name `(<$>)` in place of `map` on arrays:
+Even though the infix operator `<$>` looks like special syntax, it is in fact just an alias for a regular PureScript function. The function is simply _applied_ using infix syntax. In fact, the function can be used like a regular function by enclosing its name in parentheses. This means that we can use the parenthesized name `(<$>)` in place of `map` on arrays:
 
 ```text
 > (<$>) show [1, 2, 3, 4, 5]
@@ -201,7 +201,7 @@ forall a. Array (Array a) -> Array a
 [1, 2, 3, 4, 5, 6]
 ```
 
-There is a related function called `concatMap` which is like a combination of the `concat` and `map` functions. Where `map` takes a function from values to values (possibly of a different type), `concatMap` takes a function from values to arrays of values.
+There is a related function called `concatMap` which is a combination of the `concat` and `map` functions. Where `map` takes a function from values to values (possibly of a different type), `concatMap` takes a function from values to arrays of values.
 
 Let's see it in action:
 
@@ -225,7 +225,7 @@ Note how `concatMap` concatenates its results. It calls the provided function on
 
 Suppose we wanted to find the factors of a number `n`. One simple way to do this would be by brute force: we could generate all pairs of numbers between 1 and `n`, and try multiplying them together. If the product was `n`, we would have found a pair of factors of `n`.
 
-We can perform this computation using an array comprehension. We will do so in steps, using PSCi as our interactive development environment.
+We can perform this computation using array comprehension. We will do so in steps, using PSCi as our interactive development environment.
 
 The first step is to generate an array of pairs of numbers below `n`, which we can do using `concatMap`.
 
@@ -288,7 +288,7 @@ Excellent! We've managed to find the correct set of factor pairs without duplica
 
 However, we can improve the readability of our code considerably. `map` and `concatMap` are so fundamental, that they (or rather, their generalizations `map` and `bind`) form the basis of a special syntax called _do notation_.
 
-_Note_: Just like `map` and `concatMap` allowed us to write _array comprehensions_, the more general operators `map` and `bind` allow us to write so-called _monad comprehensions_. We'll see plenty more examples of _monads_ later in the book, but in this chapter, we will only consider arrays.
+> _Note_: Just like `map` and `concatMap` allowed us to write _array comprehensions_, the more general operators `map` and `bind` allow us to write so-called _monad comprehensions_. We'll see plenty more examples of _monads_ later in the book, but in this chapter, we will only consider arrays.
 
 We can rewrite our `factors` function using do notation as follows:
 
@@ -296,11 +296,11 @@ We can rewrite our `factors` function using do notation as follows:
 {{#include ../exercises/chapter4/test/Examples.purs:factors}}
 ```
 
-The keyword `do` introduces a block of code which uses do notation. The block consists of expressions of a few types:
+The keyword `do` introduces a block of code that uses do notation. The block consists of expressions of a few types:
 
-- Expressions which bind elements of an array to a name. These are indicated with the backwards-facing arrow `<-`, with a name on the left, and an expression on the right whose type is an array.
-- Expressions which do not bind elements of the array to names. The `do` _result_ is an example of this kind of expression and is illustrated in the last line, `pure [i, j]`.
-- Expressions which give names to expressions, using the `let` keyword.
+- Expressions that bind elements of an array to a name. These are indicated with the backwards-facing arrow `<-`, with a name on the left, and an expression on the right whose type is an array.
+- Expressions that do not bind elements of the array to names. The `do` _result_ is an example of this kind of expression and is illustrated in the last line, `pure [i, j]`.
+- Expressions that give names to expressions, using the `let` keyword.
 
 This new notation hopefully makes the structure of the algorithm clearer. If you mentally replace the arrow `<-` with the word "choose", you might read it as follows: "choose an element `i` between 1 and n, then choose an element `j` between `i` and `n`, and return `[i, j]`".
 
@@ -311,7 +311,7 @@ In the last line, we use the `pure` function. This function can be evaluated in 
 [[1, 2]]
 ```
 
-In the case of arrays, `pure` simply constructs a singleton array. In fact, we could modify our `factors` function to use this form, instead of using `pure`:
+In the case of arrays, `pure` simply constructs a singleton array. We can modify our `factors` function to use this form, instead of using `pure`:
 
 ```haskell
 {{#include ../exercises/chapter4/test/Examples.purs:factorsV2}}
@@ -356,22 +356,22 @@ For our purposes, the following calculations tell us everything we need to know 
 0
 ```
 
-That is, if `guard` is passed an expression which evaluates to `true`, then it returns an array with a single element. If the expression evaluates to `false`, then its result is empty.
+If we pass an expression to `guard` that evaluates to `true`, then it returns an array with a single element. If the expression evaluates to `false`, then its result is empty.
 
 This means that if the guard fails, then the current branch of the array comprehension will terminate early with no results. This means that a call to `guard` is equivalent to using `filter` on the intermediate array. Depending on the application, you might prefer to use `guard` instead of a `filter`. Try the two definitions of `factors` to verify that they give the same results.
 
 ## Exercises
 
- 1. (Easy) Write a function `isPrime` which tests if its integer argument is prime or not. _Hint_: Use the `factors` function.
- 1. (Medium) Write a function `cartesianProduct` which uses do notation to find the _cartesian product_ of two arrays, i.e. the set of all pairs of elements `a`, `b`, where `a` is an element of the first array, and `b` is an element of the second.
- 1. (Medium) Write a function `triples :: Int -> Array (Array Int)` which takes a number `n` and returns all Pythagorean triples whose components (the `a`, `b` and `c` values) are each less than or equal to `n`. A _Pythagorean triple_ is an array of numbers `[a, b, c]` such that `a² + b² = c²`. _Hint_: Use the `guard` function in an array comprehension.
- 1. (Difficult) Write a function `primeFactors` which produces the [prime factorization](https://www.mathsisfun.com/prime-factorization.html) of `n`, i.e. the array of prime integers whose product is `n`. _Hint_: for an integer greater than 1, break the problem down into two subproblems: finding the first factor, and finding the remaining factors.
+ 1. (Easy) Write a function `isPrime`, which tests whether its integer argument is prime. _Hint_: Use the `factors` function.
+ 1. (Medium) Write a function `cartesianProduct` which uses do notation to find the _cartesian product_ of two arrays, i.e., the set of all pairs of elements `a`, `b`, where `a` is an element of the first array, and `b` is an element of the second.
+ 1. (Medium) Write a function `triples :: Int -> Array (Array Int)`, which takes a number `n` and returns all Pythagorean triples whose components (the `a`, `b`, and `c` values) are each less than or equal to `n`. A _Pythagorean triple_ is an array of numbers `[a, b, c]` such that `a² + b² = c²`. _Hint_: Use the `guard` function in an array comprehension.
+ 1. (Difficult) Write a function `primeFactors` which produces the [prime factorization](https://www.mathsisfun.com/prime-factorization.html) of `n`, i.e., the array of prime integers whose product is `n`. _Hint_: for an integer greater than 1, break the problem into two subproblems: finding the first factor and the remaining factors.
 
 ## Folds
 
-Left and right folds over arrays provide another class of interesting functions which can be implemented using recursion.
+Left and right folds over arrays provide another class of interesting functions that can be implemented using recursion.
 
-Start by importing the `Data.Foldable` module, and inspecting the types of the `foldl` and `foldr` functions using PSCi:
+Start by importing the `Data.Foldable` module and inspecting the types of the `foldl` and `foldr` functions using PSCi:
 
 ```text
 > import Data.Foldable
@@ -383,7 +383,7 @@ forall a b f. Foldable f => (b -> a -> b) -> b -> f a -> b
 forall a b f. Foldable f => (a -> b -> b) -> b -> f a -> b
 ```
 
-These types are actually more general than we are interested in right now. For the purposes of this chapter, we can assume that PSCi had given the following (more specific) answer:
+These types are more general than we are interested in right now. For this chapter, we can assume that PSCi has given the following (more specific) answer:
 
 ```text
 > :type foldl
@@ -393,11 +393,11 @@ forall a b. (b -> a -> b) -> b -> Array a -> b
 forall a b. (a -> b -> b) -> b -> Array a -> b
 ```
 
-In both of these cases, the type `a` corresponds to the type of elements of our array. The type `b` can be thought of as the type of an "accumulator", which will accumulate a result as we traverse the array.
+In both cases, the type `a` corresponds to the type of elements of our array. The type `b` can be thought of as the type of an "accumulator", which will accumulate a result as we traverse the array.
 
 The difference between the `foldl` and `foldr` functions is the direction of the traversal. `foldl` folds the array "from the left", whereas `foldr` folds the array "from the right".
 
-Let's see these functions in action. Let's use `foldl` to sum an array of integers. The type `a` will be `Int`, and we can also choose the result type `b` to be `Int`. We need to provide three arguments: a function `Int -> Int -> Int`, which will add the next element to the accumulator, an initial value for the accumulator of type `Int`, and an array of `Int`s to add. For the first argument, we can just use the addition operator, and the initial value of the accumulator will be zero:
+Let's see these functions in action. Let's use `foldl` to sum an array of integers. The type `a` will be `Int`, and we can also choose the result type `b` to be `Int`. We need to provide three arguments: a function `Int -> Int -> Int`, which will add the next element to the accumulator, an initial value for the accumulator of type `Int`, and an array of `Int`s to add. For the first argument, we can use the addition operator, and the initial value of the accumulator will be zero:
 
 ```text
 > foldl (+) 0 (1 .. 5)
@@ -411,7 +411,7 @@ In this case, it didn't matter whether we used `foldl` or `foldr`, because the r
 15
 ```
 
-Let's write an example where the choice of folding function does matter, in order to illustrate the difference. Instead of the addition function, let's use string concatenation to build a string:
+Let's write an example where the choice of folding function matters to illustrate the difference. Instead of the addition function, let's use string concatenation to build a string:
 
 ```text
 > foldl (\acc n -> acc <> show n) "" [1,2,3,4,5]
@@ -427,7 +427,7 @@ This illustrates the difference between the two functions. The left fold express
 ((((("" <> show 1) <> show 2) <> show 3) <> show 4) <> show 5)
 ```
 
-whereas the right fold is equivalent to this:
+Whereas the right fold is equivalent to this:
 
 ```text
 ((((("" <> show 5) <> show 4) <> show 3) <> show 2) <> show 1)
@@ -435,9 +435,9 @@ whereas the right fold is equivalent to this:
 
 ## Tail Recursion
 
-Recursion is a powerful technique for specifying algorithms, but comes with a problem: evaluating recursive functions in JavaScript can lead to stack overflow errors if our inputs are too large.
+Recursion is a powerful technique for specifying algorithms but comes with a problem: evaluating recursive functions in JavaScript can lead to stack overflow errors if our inputs are too large.
 
-It is easy to verify this problem, with the following code in PSCi:
+It is easy to verify this problem with the following code in PSCi:
 
 ```text
 > :paste
@@ -454,13 +454,13 @@ It is easy to verify this problem, with the following code in PSCi:
 RangeError: Maximum call stack size exceeded
 ```
 
-This is a problem. If we are going to adopt recursion as a standard technique from functional programming, then we need a way to deal with possibly unbounded recursion.
+This is a problem. If we adopt recursion as a standard technique from functional programming, we need a way to deal with possibly unbounded recursion.
 
-PureScript provides a partial solution to this problem in the form of _tail recursion optimization_.
+PureScript provides a partial solution to this problem through _tail recursion optimization_.
 
-_Note_: more complete solutions to the problem can be implemented in libraries using so-called _trampolining_, but that is beyond the scope of this chapter. The interested reader can consult the documentation for the [`free`](https://pursuit.purescript.org/packages/purescript-free) and [`tailrec`](https://pursuit.purescript.org/packages/purescript-tailrec) packages.
+> _Note_: more complete solutions to the problem can be implemented in libraries using so-called _trampolining_, but that is beyond the scope of this chapter. The interested reader can consult the documentation for the [`free`](https://pursuit.purescript.org/packages/purescript-free) and [`tailrec`](https://pursuit.purescript.org/packages/purescript-tailrec) packages.
 
-The key observation which enables tail recursion optimization is the following: a recursive call in _tail position_ to a function can be replaced with a _jump_, which does not allocate a stack frame. A call is in _tail position_ when it is the last call made before a function returns. This is the reason why we observed a stack overflow in the example - the recursive call to `f` was _not_ in tail position.
+The key observation that enables tail recursion optimization: a recursive call in _tail position_ to a function can be replaced with a _jump_, which does not allocate a stack frame. A call is in _tail position_ when it is the last call made before a function returns. This is why we observed a stack overflow in the example – the recursive call to `f` was _not_ in tail position.
 
 In practice, the PureScript compiler does not replace the recursive call with a jump, but rather replaces the entire recursive function with a _while loop_.
 
@@ -470,13 +470,13 @@ Here is an example of a recursive function with all recursive calls in tail posi
 {{#include ../exercises/chapter4/test/Examples.purs:factorialTailRec}}
 ```
 
-Notice that the recursive call to `factorialTailRec` is the last thing that happens in this function - it is in tail position.
+Notice that the recursive call to `factorialTailRec` is the last thing in this function – it is in tail position.
 
 ## Accumulators
 
-One common way to turn a function which is not tail recursive into a tail recursive function is to use an _accumulator parameter_. An accumulator parameter is an additional parameter which is added to a function which _accumulates_ a return value, as opposed to using the return value to accumulate the result.
+One common way to turn a not tail recursive function into a tail recursive is to use an _accumulator parameter_. An accumulator parameter is an additional parameter added to a function that _accumulates_ a return value, as opposed to using the return value to accumulate the result.
 
-For example, consider again the `length` function presented in the beginning of the chapter:
+For example, consider again the `length` function presented at the beginning of the chapter:
 
 ```haskell
 length :: forall a. Array a -> Int
@@ -492,15 +492,15 @@ This implementation is not tail recursive, so the generated JavaScript will caus
 {{#include ../exercises/chapter4/test/Examples.purs:lengthTailRec}}
 ```
 
-In this case, we delegate to the helper function `length'`, which is tail recursive - its only recursive call is in the last case, and is in tail position. This means that the generated code will be a _while loop_, and will not blow the stack for large inputs.
+In this case, we delegate to the helper function `length'`, which is tail recursive – its only recursive call is in the last case, in tail position. This means that the generated code will be a _while loop_ and not blow the stack for large inputs.
 
-To understand the implementation of `lengthTailRec`, note that the helper function `length'` essentially uses the accumulator parameter to maintain an additional piece of state - the partial result. It starts out at 0, and grows by adding 1 for every element in the input array.
+To understand the implementation of `lengthTailRec`, note that the helper function `length'` essentially uses the accumulator parameter to maintain an additional piece of state – the partial result. It starts at 0 and grows by adding 1 for every element in the input array.
 
-Note also that while we might think of the accumulator as "state", there is no direct mutation going on.
+Note also that while we might think of the accumulator as a "state", there is no direct mutation.
 
 ## Prefer Folds to Explicit Recursion
 
-If we can write our recursive functions using tail recursion, then we can benefit from tail recursion optimization, so it becomes tempting to try to write all of our functions in this form. However, it is often easy to forget that many functions can be written directly as a fold over an array or similar data structure. Writing algorithms directly in terms of combinators such as `map` and `fold` has the added advantage of code simplicity - these combinators are well-understood, and as such, communicate the _intent_ of the algorithm much better than explicit recursion.
+If we can write our recursive functions using tail recursion, we can benefit from tail recursion optimization, so it becomes tempting to try to write all of our functions in this form. However, it is often easy to forget that many functions can be written directly as a fold over an array or similar data structure. Writing algorithms directly in terms of combinators such as `map` and `fold` has the added advantage of code simplicity – these combinators are well-understood, and as such, communicate the _intent_ of the algorithm much better than explicit recursion.
 
 For example, we can reverse an array using `foldr`:
 
@@ -527,15 +527,15 @@ Writing `reverse` in terms of `foldl` will be left as an exercise for the reader
 
 ## A Virtual Filesystem
 
-In this section, we're going to apply what we've learned, writing functions which will work with a model of a filesystem. We will use maps, folds and filters to work with a predefined API.
+In this section, we'll apply what we've learned, writing functions that will work with a model of a filesystem. We will use maps, folds, and filters to work with a predefined API.
 
-The `Data.Path` module defines an API for a virtual filesystem, as follows:
+The `Data.Path` module defines an API for a virtual filesystem as follows:
 
 - There is a type `Path` which represents a path in the filesystem.
 - There is a path `root` which represents the root directory.
 - The `ls` function enumerates the files in a directory.
 - The `filename` function returns the file name for a `Path`.
-- The `size` function returns the file size for a `Path` which represents a file.
+- The `size` function returns the file size for a `Path` representing a file.
 - The `isDirectory` function tests whether a `Path` is a file or a directory.
 
 In terms of types, we have the following type definitions:
@@ -569,17 +569,17 @@ true
 [/bin/,/etc/,/home/]
 ```
 
-The `Test.Examples` module defines functions which use the `Data.Path` API. You do not need to modify the `Data.Path` module, or understand its implementation. We will work entirely in the `Test.Examples` module.
+The `Test.Examples` module defines functions that use the `Data.Path` API. You do not need to modify the `Data.Path` module, or understand its implementation. We will work entirely in the `Test.Examples` module.
 
 ## Listing All Files
 
-Let's write a function which performs a deep enumeration of all files inside a directory. This function will have the following type:
+Let's write a function that performs a deep enumeration of all files inside a directory. This function will have the following type:
 
 ```haskell
 {{#include ../exercises/chapter4/test/Examples.purs:allFiles_signature}}
 ```
 
-We can define this function by recursion. First, we can use `ls` to enumerate the immediate children of the directory. For each child, we can recursively apply `allFiles`, which will return an array of paths. `concatMap` will allow us to apply `allFiles` and flatten the results at the same time.
+We can define this function by recursion. First, we can use `ls` to enumerate the immediate children of the directory. For each child, we can recursively apply `allFiles`, which will return an array of paths. `concatMap` will allow us to apply `allFiles` and flatten the results simultaneously.
 
 Finally, we use the cons operator `:` to include the current file:
 
@@ -587,7 +587,7 @@ Finally, we use the cons operator `:` to include the current file:
 {{#include ../exercises/chapter4/test/Examples.purs:allFiles_implementation}}
 ```
 
-_Note_: the cons operator `:` actually has poor performance on immutable arrays, so it is not recommended in general. Performance can be improved by using other data structures, such as linked lists and sequences.
+> _Note_: the cons operator `:` has poor performance on immutable arrays, so it is not generally recommended. Performance can be improved by using other data structures, such as linked lists and sequences.
 
 Let's try this function in PSCi:
 
@@ -602,7 +602,7 @@ Let's try this function in PSCi:
 
 Great! Now let's see if we can write this function using an array comprehension using do notation.
 
-Recall that a backwards arrow corresponds to choosing an element from an array. The first step is to choose an element from the immediate children of the argument. Then we simply call the function recursively for that file. Since we are using do notation, there is an implicit call to `concatMap` which concatenates all of the recursive results.
+Recall that a backwards arrow corresponds to choosing an element from an array. The first step is to choose an element from the immediate children of the argument. Then we call the function recursively for that file. Since we use do notation, there is an implicit call to `concatMap`, which concatenates all of the recursive results.
 
 Here is the new version:
 
@@ -610,7 +610,7 @@ Here is the new version:
 {{#include ../exercises/chapter4/test/Examples.purs:allFiles_2}}
 ```
 
-Try out the new version in PSCi - you should get the same result. I'll let you decide which version you find clearer.
+Try out the new version in PSCi – you should get the same result. I'll let you decide which version you find clearer.
 
 ## Exercises
 
@@ -626,8 +626,8 @@ Try out the new version in PSCi - you should get the same result. I'll let you d
      ```
 
      _Hint_: Try to write this function as an array comprehension using do notation.
- 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. _Note_: consider the cases where there are zero or one files in the `Path` by returning an empty array or a one-element array respectively.
+ 3. (Difficult) Write a function `largestSmallest` which takes a `Path` and returns an array containing the single largest and single smallest files in the `Path`. _Note_: consider the cases where there are zero or one files in the `Path` by returning an empty or one-element array, respectively.
 
 ## Conclusion
 
-In this chapter, we covered the basics of recursion in PureScript, as a means of expressing algorithms concisely. We also introduced user-defined infix operators, standard functions on arrays such as maps, filters and folds, and array comprehensions which combine these ideas. Finally, we showed the importance of using tail recursion in order to avoid stack overflow errors, and how to use accumulator parameters to convert functions to tail recursive form.
+In this chapter, we covered the basics of recursion in PureScript to express algorithms concisely. We also introduced user-defined infix operators, standard functions on arrays such as maps, filters, and folds, and array comprehensions that combine these ideas. Finally, we showed the importance of using tail recursion to avoid stack overflow errors and how to use accumulator parameters to convert functions to tail recursive form.

--- a/text/chapter5.md
+++ b/text/chapter5.md
@@ -2,19 +2,19 @@
 
 ## Chapter Goals
 
-This chapter will introduce two new concepts: algebraic data types, and pattern matching. We will also briefly cover an interesting feature of the PureScript type system: row polymorphism.
+This chapter will introduce two new concepts: algebraic data types and pattern matching. We will also briefly cover an interesting feature of the PureScript type system: row polymorphism.
 
-Pattern matching is a common technique in functional programming and allows the developer to write compact functions which express potentially complex ideas, by breaking their implementation down into multiple cases.
+Pattern matching is a common technique in functional programming and allows the developer to write compact functions, which express potentially complex ideas by breaking their implementation down into multiple cases.
 
-Algebraic data types are a feature of the PureScript type system which enable a similar level of expressiveness in the language of types - they are closely related to pattern matching.
+Algebraic data types are a feature of the PureScript type system, which enables a similar level of expressiveness in the language of types – they are closely related to pattern matching.
 
-The goal of the chapter will be to write a library to describe and manipulate simple vector graphics using algebraic types and pattern matching.
+The chapter's goal will be to write a library to describe and manipulate simple vector graphics using algebraic types and pattern matching.
 
 ## Project Setup
 
 The source code for this chapter is defined in the file `src/Data/Picture.purs`.
 
-The `Data.Picture` module defines a data type `Shape` for simple shapes, and a type `Picture` for collections of shapes, along with functions for working with those types.
+The `Data.Picture` module defines a data type `Shape` for simple shapes and a type `Picture` for collections of shapes, along with functions for working with those types.
 
 The module imports the `Data.Foldable` module, which provides functions for folding data structures:
 
@@ -28,21 +28,21 @@ The `Data.Picture` module also imports the `Number` module, but this time using 
 {{#include ../exercises/chapter5/src/Data/Picture.purs:picture_import_as}}
 ```
 
-This makes the types and functions in that module available for use, but only by using the _qualified name_, like `Number.max`. This can be useful to avoid overlapping imports, or just to make it clearer which modules certain things are imported from.
+This makes the types and functions in that module available for use, but only by using the _qualified name_, like `Number.max`. This can be useful to avoid overlapping imports or clarify which modules certain things are imported from.
 
-_Note_: it is not necessary to use the same module name as the original module for a qualified import. Shorter qualified names like `import Data.Number as N` are possible, and quite common.
+> _Note_: Using the same module name as the original module for a qualified import is unnecessary  – shorter qualified names like `import Data.Number as N` are possible and quite common.
 
 ## Simple Pattern Matching
 
-Let's begin by looking at an example. Here is a function which computes the greatest common divisor of two integers using pattern matching:
+Let's begin by looking at an example. Here is a function that computes the greatest common divisor of two integers using pattern matching:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:gcd}}
 ```
 
-This algorithm is called the Euclidean Algorithm. If you search for its definition online, you will likely find a set of mathematical equations which look a lot like the code above. This is one benefit of pattern matching: it allows you to define code by cases, writing simple, declarative code which looks like a specification of a mathematical function.
+This algorithm is called the Euclidean Algorithm. If you search for its definition online, you will likely find a set of mathematical equations that look like the code above. One benefit of pattern matching is that it allows you to define code by cases, writing simple, declarative code that looks like a mathematical function specification.
 
-A function written using pattern matching works by pairing sets of conditions with their results. Each line is called an _alternative_ or a _case_. The expressions on the left of the equals sign are called _patterns_, and each case consists of one or more patterns, separated by spaces. Cases describe which conditions the arguments must satisfy before the expression on the right of the equals sign should be evaluated and returned. Each case is tried in order, and the first case whose patterns match their inputs determines the return value.
+A function written using pattern matching works by pairing sets of conditions with their results. Each line is called an _alternative_ or a _case_. The expressions on the left of the equals sign are called _patterns_, and each case consists of one or more patterns separated by spaces. Cases describe which conditions the arguments must satisfy before the expression on the right of the equals sign should be evaluated and returned. Each case is tried in order, and the first case whose patterns match their inputs determines the return value.
 
 For example, the `gcd` function is evaluated using the following steps:
 
@@ -50,7 +50,7 @@ For example, the `gcd` function is evaluated using the following steps:
 - If not, the second case is tried: if the first argument is zero, the function returns `m` (the second argument).
 - Otherwise, the function evaluates and returns the expression in the last line.
 
-Note that patterns can bind values to names - each line in the example binds one or both of the names `n` and `m` to the input values. As we learn about different kinds of patterns, we will see that different types of patterns correspond to different ways to choose names from the input arguments.
+Note that patterns can bind values to names – each line in the example binds one or both of the names `n` and `m` to the input values. As we learn about different patterns, we will see that different patterns correspond to different ways to choose names from the input arguments.
 
 ## Simple Patterns
 
@@ -61,10 +61,10 @@ The example code above demonstrates two types of patterns:
 
 There are other types of simple patterns:
 
-- `Number`, `String`, `Char` and `Boolean` literals
-- Wildcard patterns, indicated with an underscore (`_`), which match any argument, and which do not bind any names.
+- `Number`, `String`, `Char`, and `Boolean` literals
+- Wildcard patterns, indicated with an underscore (`_`), match any argument and do not bind any names.
 
-Here are two more examples which demonstrate using these simple patterns:
+Here are two more examples that demonstrate using these simple patterns:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:fromString}}
@@ -76,15 +76,15 @@ Try these functions in PSCi.
 
 ## Guards
 
-In the Euclidean algorithm example, we used an `if .. then .. else` expression to switch between the two alternatives when `m > n` and `m <= n`. Another option in this case would be to use a _guard_.
+In the Euclidean algorithm example, we used an `if .. then .. else` expression to switch between the two alternatives when `m > n` and `m <= n`. Another option, in this case, would be to use a _guard_.
 
-A guard is a boolean-valued expression which must be satisfied in addition to the constraints imposed by the patterns. Here is the Euclidean algorithm rewritten to use a guard:
+A guard is a boolean-valued expression that must be satisfied in addition to the constraints imposed by the patterns. Here is the Euclidean algorithm rewritten to use a guard:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:gcdV2}}
 ```
 
-In this case, the third line uses a guard to impose the extra condition that the first argument is strictly larger than the second. The guard in the final line uses the expression `otherwise`, which might seem like a keyword, but is in fact just a regular binding in `Prelude`:
+In this case, the third line uses a guard to impose the extra condition that the first argument is strictly larger than the second. The guard in the final line uses the expression `otherwise`, which might seem like a keyword but is, in fact, just a regular binding in `Prelude`:
 
 ```text
 > :type otherwise
@@ -94,7 +94,7 @@ Boolean
 true
 ```
 
-As this example demonstrates, guards appear on the left of the equals symbol, separated from the list of patterns by a pipe character (`|`).
+This example demonstrates that guards appear on the left of the equals symbol, separated from the list of patterns by a pipe character (`|`).
 
 ## Exercises
 
@@ -110,13 +110,13 @@ _Array literal patterns_ provide a way to match arrays of a fixed length. For ex
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:isEmpty}}
 ```
 
-Here is another function which matches arrays of length five, binding each of its five elements in a different way:
+Here is another function that matches arrays of length five, binding each of its five elements differently:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:takeFive}}
 ```
 
-The first pattern only matches arrays with five elements, whose first and second elements are 0 and 1 respectively. In that case, the function returns the product of the third and fourth elements. In every other case, the function returns zero. For example, in PSCi:
+The first pattern only matches arrays with five elements, whose first and second elements are 0 and 1, respectively. In that case, the function returns the product of the third and fourth elements. In every other case, the function returns zero. For example, in PSCi:
 
 ```text
 > :paste
@@ -134,15 +134,15 @@ The first pattern only matches arrays with five elements, whose first and second
 0
 ```
 
-Array literal patterns allow us to match arrays of a fixed length, but PureScript does _not_ provide any means of matching arrays of an unspecified length, since destructuring immutable arrays in these sorts of ways can lead to poor performance. If you need a data structure which supports this sort of matching, the recommended approach is to use `Data.List`. Other data structures exist which provide improved asymptotic performance for different operations.
+Array literal patterns allow us to match arrays of a fixed length. Still, PureScript does _not_ provide any means of matching arrays of an unspecified length since destructuring immutable arrays in these sorts of ways can lead to poor performance. If you need a data structure that supports this sort of matching, the recommended approach is to use `Data.List`. Other data structures exist which provide improved asymptotic performance for different operations.
 
 ## Record Patterns and Row Polymorphism
 
-_Record patterns_ are used to match - you guessed it - records.
+_Record patterns_ are used to match – you guessed it – records.
 
 Record patterns look just like record literals, but instead of values on the right of the colon, we specify a binder for each field.
 
-For example: this pattern matches any record which contains fields called `first` and `last`, and binds their values to the names `x` and `y` respectively:
+For example, this pattern matches any record which contains fields called `first` and `last`, and binds their values to the names `x` and `y`, respectively:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:showPerson}}
@@ -167,7 +167,7 @@ What is the type variable `r` here? Well, if we try `showPerson` in PSCi, we see
 "Freeman, Phil"
 ```
 
-We are able to append additional fields to the record, and the `showPerson` function will still work. As long as the record contains the `first` and `last` fields of type `String`, the function application is well-typed. However, it is _not_ valid to call `showPerson` with too _few_ fields:
+We can append additional fields to the record, and the `showPerson` function will still work. As long as the record contains the `first` and `last` fields of type `String`, the function application is well-typed. However, it is _not_ valid to call `showPerson` with too _few_ fields:
 
 ```text
 > showPerson { first: "Phil" }
@@ -183,11 +183,11 @@ Note that we could have also written
 > showPerson p = p.last <> ", " <> p.first
 ```
 
-and PSCi would have inferred the same type.
+And PSCi would have inferred the same type.
 
 ## Record Puns
 
-Recall that the `showPerson` function matches a record inside its argument, binding the `first` and `last` fields to values named `x` and `y`. We could alternatively just reuse the field names themselves, and simplify this sort of pattern match as follows:
+Recall that the `showPerson` function matches a record inside its argument, binding the `first` and `last` fields to values named `x` and `y`. We could alternatively reuse the field names themselves and simplify this sort of pattern match as follows:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:showPersonV2}}
@@ -201,11 +201,11 @@ It is also possible to use record puns to _construct_ records. For example, if w
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:unknownPerson}}
 ```
 
-This may improve readability of code in some circumstances.
+This may improve the readability of code in some circumstances.
 
 ## Nested Patterns
 
-Array patterns and record patterns both combine smaller patterns to build larger patterns. For the most part, the examples above have only used simple patterns inside array patterns and record patterns, but it is important to note that patterns can be arbitrarily _nested_, which allows functions to be defined using conditions on potentially complex data types.
+Array patterns and record patterns both combine smaller patterns to build larger patterns. For the most part, the examples above have only used simple patterns inside array patterns and record patterns. Still, it is important to note that patterns can be arbitrarily _nested_, which allows functions to be defined using conditions on potentially complex data types.
 
 For example, this code combines two record patterns:
 
@@ -223,19 +223,19 @@ For example, this function sorts two-element arrays, naming the two elements, bu
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:sortPair}}
 ```
 
-This way, we save ourselves from allocating a new array if the pair is already sorted. Note that if the input array does not contain _exactly_ two elements, then this function simply returns it unchanged, even if it's unsorted.
+This way, we save ourselves from allocating a new array if the pair is already sorted. Note that if the input array does not contain _exactly_ two elements, then this function returns it unchanged, even if it's unsorted.
 
 ## Exercises
 
 1. (Easy) Write a function `sameCity` which uses record patterns to test whether two `Person` records belong to the same city.
-1. (Medium) What is the most general type of the `sameCity` function, taking into account row polymorphism? What about the `livesInLA` function defined above? _Note_: There is no test for this exercise.
-1. (Medium) Write a function `fromSingleton` which uses an array literal pattern to extract the sole member of a singleton array. If the array is not a singleton, your function should return a provided default value. Your function should have type `forall a. a -> Array a -> a`
+1. (Medium) What is the most general type of the `sameCity` function, considering row polymorphism? What about the `livesInLA` function defined above? _Note_: There is no test for this exercise.
+1. (Medium) Write a function `fromSingleton` that uses an array literal pattern to extract the sole member of a singleton array. If the array is not a singleton, your function should return a provided default value. Your function should have type `forall a. a -> Array a -> a`
 
 ## Case Expressions
 
-Patterns do not only appear in top-level function declarations. It is possible to use patterns to match on an intermediate value in a computation, using a `case` expression. Case expressions provide a similar type of utility to anonymous functions: it is not always desirable to give a name to a function, and a `case` expression allows us to avoid naming a function just because we want to use a pattern.
+Patterns do not only appear in top-level function declarations. It is possible to use patterns to match on an intermediate value in a computation using a `case` expression. Case expressions provide a similar type of utility to anonymous functions: it is not always desirable to give a name to a function, and a `case` expression allows us to avoid naming a function just because we want to use a pattern.
 
-Here is an example. This function computes "longest zero suffix" of an array (the longest suffix which sums to zero):
+Here is an example. This function computes the "longest zero suffix" of an array (the longest suffix which sums to zero):
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:lzsImport}}
@@ -253,11 +253,11 @@ For example:
 [-1, -2, 3]
 ```
 
-This function works by case analysis. If the array is empty, our only option is to return an empty array. If the array is non-empty, we first use a `case` expression to split into two cases. If the sum of the array is zero, we return the whole array. If not, we recurse on the tail of the array.
+This function works by case analysis. If the array is empty, our only option is to return an empty array. If the array is non-empty, we first use a `case` expression to split it into two cases. If the sum of the array is zero, we return the whole array. If not, we recurse on the tail of the array.
 
 ## Pattern Match Failures and Partial Functions
 
-If patterns in a case expression are tried in order, then what happens in the case when none of the patterns in a case alternatives match their inputs? In this case, the case expression will fail at runtime with a _pattern match failure_.
+If patterns in a case expression are tried in order, what happens when none of the patterns in a case alternatives match their inputs? In this case, the case expression will fail at runtime with a _pattern match failure_.
 
 We can see this behavior with a simple example:
 
@@ -267,7 +267,7 @@ We can see this behavior with a simple example:
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:partialFunction}}
 ```
 
-This function contains only a single case, which only matches a single input, `true`. If we compile this file, and test in PSCi with any other argument, we will see an error at runtime:
+This function contains only a single case, which only matches a single input, `true`. If we compile this file and test in PSCi with any other argument, we will see an error at runtime:
 
 ```text
 > partialFunction false
@@ -275,11 +275,11 @@ This function contains only a single case, which only matches a single input, `t
 Failed pattern match
 ```
 
-Functions which return a value for any combination of inputs are called _total_ functions, and functions which do not are called _partial_.
+Functions that return a value for any combination of inputs are called _total_ functions, and functions that do not are called _partial_.
 
 It is generally considered better to define total functions where possible. If it is known that a function does not return a result for some valid set of inputs, it is usually better to return a value capable of indicating failure, such as type `Maybe a` for some `a`, using `Nothing` when it cannot return a valid result. This way, the presence or absence of a value can be indicated in a type-safe way.
 
-The PureScript compiler will generate an error if it can detect that your function is not total due to an incomplete pattern match. The `unsafePartial` function can be used to silence these errors (if you are sure that your partial function is safe!) If we removed the call to the `unsafePartial` function above, then the compiler would generate the following error:
+The PureScript compiler will generate an error if it can detect that your function is not total due to an incomplete pattern match. The `unsafePartial` function can be used to silence these errors (if you are sure your partial function is safe!) If we removed the call to the `unsafePartial` function above, then the compiler would generate the following error:
 
 ```text
 A case expression could not be determined to cover all inputs.
@@ -304,9 +304,9 @@ then PSCi infers a curious type:
 Partial => Boolean -> Boolean
 ```
 
-We will see more types which involve the `=>` symbol later on in the book (they are related to _type classes_), but for now, it suffices to observe that PureScript keeps track of partial functions using the type system, and that we must explicitly tell the type checker when they are safe.
+We will see more types that involve the `=>` symbol later on in the book (they are related to _type classes_), but for now, it suffices to observe that PureScript keeps track of partial functions using the type system and that we must explicitly tell the type checker when they are safe.
 
-The compiler will also generate a warning in certain cases when it can detect that cases are _redundant_ (that is, a case only matches values which would have been matched by a prior case):
+The compiler will also generate a warning in certain cases when it can detect that cases are _redundant_ (that is, a case only matches values which a prior case would have matched):
 
 ```haskell
 redundantCase :: Boolean -> Boolean
@@ -323,7 +323,7 @@ A case expression contains unreachable cases:
   false
 ```
 
-_Note_: PSCi does not show warnings, so to reproduce this example, you will need to save this function as a file and compile it using `spago build`.
+> _Note_: PSCi does not show warnings, so to reproduce this example, you will need to save this function as a file and compile it using `spago build`.
 
 ## Algebraic Data Types
 
@@ -333,9 +333,9 @@ However, we'll first consider a motivating example, which will provide the basis
 
 Suppose we wanted to define a type to represent some simple shapes: lines, rectangles, circles, text, etc. In an object oriented language, we would probably define an interface or abstract class `Shape`, and one concrete subclass for each type of shape that we wanted to be able to work with.
 
-However, this approach has one major drawback: to work with `Shape`s abstractly, it is necessary to identify all of the operations one might wish to perform, and to define them on the `Shape` interface. It becomes difficult to add new operations without breaking modularity.
+However, this approach has one major drawback: to work with `Shape`s abstractly, it is necessary to identify all of the operations one might wish to perform and to define them on the `Shape` interface. It becomes difficult to add new operations without breaking modularity.
 
-Algebraic data types provide a type-safe way to solve this sort of problem, if the set of shapes is known in advance. It is possible to define new operations on `Shape` in a modular way, and still maintain type-safety.
+Algebraic data types provide a type-safe way to solve this problem if the set of shapes is known in advance. It is possible to define new operations on `Shape` in a modular way and still maintain type-safety.
 
 Here is how `Shape` might be represented as an algebraic data type:
 
@@ -345,9 +345,9 @@ Here is how `Shape` might be represented as an algebraic data type:
 {{#include ../exercises/chapter5/src/Data/Picture.purs:Point}}
 ```
 
-This declaration defines `Shape` as a sum of different constructors, and for each constructor identifies the data that is included. A `Shape` is either a `Circle` which contains a center `Point` and a radius (a number), or a `Rectangle`, or a `Line`, or `Text`. There are no other ways to construct a value of type `Shape`.
+This declaration defines `Shape` as a sum of different constructors, and for each constructor identifies the included data. A `Shape` is either a `Circle` that contains a center `Point` and a radius (a number), or a `Rectangle`, or a `Line`, or `Text`. There are no other ways to construct a value of type `Shape`.
 
-An algebraic data type is introduced using the `data` keyword, followed by the name of the new type and any type arguments. The type's constructors (i.e. its _data constructors_) are defined after the equals symbol, and are separated by pipe characters (`|`). The data carried by an ADT's constructors doesn't have to be restricted to primitive types: constructors can include records, arrays, or even other ADTs.
+An algebraic data type is introduced using the `data` keyword, followed by the name of the new type and any type arguments. The type's constructors (i.e., its _data constructors_) are defined after the equals symbol and separated by pipe characters (`|`). The data carried by an ADT's constructors doesn't have to be restricted to primitive types: constructors can include records, arrays, or even other ADTs.
 
 Let's see another example from PureScript's standard libraries. We saw the `Maybe` type, which is used to define optional values, earlier in the book. Here is its definition from the `maybe` package:
 
@@ -357,7 +357,7 @@ data Maybe a = Nothing | Just a
 
 This example demonstrates the use of a type parameter `a`. Reading the pipe character as the word "or", its definition almost reads like English: "a value of type `Maybe a` is either `Nothing`, or `Just` a value of type `a`".
 
-Note that we don't use the syntax `forall a.` anywhere in our data definition. `forall` syntax is necessary for functions, but is not used when defining ADTs with `data` or type aliases with `type`.
+Note that we don't use the syntax `forall a.` anywhere in our data definition. `forall` syntax is necessary for functions but is not used when defining ADTs with `data` or type aliases with `type`.
 
 Data constructors can also be used to define recursive data structures. Here is one more example, defining a data type of singly-linked lists of elements of type `a`:
 
@@ -391,8 +391,8 @@ Each constructor can be used as a pattern, and the arguments to the constructor 
 
 ## Exercises
 
-1. (Easy) Write a function `circleAtOrigin` which constructs a `Circle` (of type `Shape`) centered at the origin with radius `10.0`.
-1. (Medium) Write a function `doubleScaleAndCenter` which scales the size of a `Shape` by a factor of `2.0` and centers it at the origin.
+1. (Easy) Write a function `circleAtOrigin` which constructs a `Circle` (of type `Shape`) centered at the origin with a radius `10.0`.
+1. (Medium) Write a function `doubleScaleAndCenter`  that scales the size of a `Shape` by a factor of `2.0` and centers it at the origin.
 1. (Medium) Write a function `shapeText` which extracts the text from a `Shape`. It should return `Maybe String`, and use the `Nothing` constructor if the input is not constructed using `Text`.
 
 ## Newtypes
@@ -452,13 +452,13 @@ Note that while a newtype can only have a single constructor, and the constructo
 newtype CouldError err a = CouldError (Either err a)
 ```
 
-Also note that the constructor of a newtype often has the same name as the newtype itself, but this is not a requirement. For example, unique names are also valid:
+Also, note that the constructor of a newtype often has the same name as the newtype itself, but this is not a requirement. For example, unique names are also valid:
 
 ```haskell
 {{#include ../exercises/chapter5/src/ChapterExamples.purs:Coulomb}}
 ```
 
-In this case, `Coulomb` is the _type constructor_ (of zero arguments) and `MakeCoulomb` is the _data constructor_. These constructors live in different namespaces, even when the names are identical, such as with the `Volt` example. This is true for all ADTs. Note that although the type constructor and data constructor can have different names, in practice it is idiomatic for them to share the same name. This is the case with `Amp` and `Volt` types above.
+In this case, `Coulomb` is the _type constructor_ (of zero arguments), and `MakeCoulomb` is the _data constructor_. These constructors live in different namespaces, even when the names are identical, such as with the `Volt` example. This is true for all ADTs. Note that although the type constructor and data constructor can have different names, in practice, it is idiomatic for them to share the same name. This is the case with `Amp` and `Volt` types above.
 
 Another application of newtypes is to attach different _behavior_ to an existing type without changing its representation at runtime. We cover that use case in the next chapter when we discuss _type classes_.
 
@@ -476,7 +476,7 @@ A wattage in `Watt`s can be calculated as the product of a given current in `Amp
 
 Let's use the data types we have defined above to create a simple library for using vector graphics.
 
-Define a type synonym for a `Picture` - just an array of `Shape`s:
+Define a type synonym for a `Picture` – just an array of `Shape`s:
 
 ```haskell
 {{#include ../exercises/chapter5/src/Data/Picture.purs:Picture}}
@@ -530,8 +530,8 @@ The accumulating function `combine` is defined in a `where` block. `combine` tak
 
 In this chapter, we covered pattern matching, a basic but powerful technique from functional programming. We saw how to use simple patterns as well as array and record patterns to match parts of deep data structures.
 
-This chapter also introduced algebraic data types, which are closely related to pattern matching. We saw how algebraic data types allow concise descriptions of data structures, and provide a modular way to extend data types with new operations.
+This chapter also introduced algebraic data types, which are closely related to pattern matching. We saw how algebraic data types allow concise descriptions of data structures and provide a modular way to extend data types with new operations.
 
-Finally, we covered _row polymorphism_, a powerful type of abstraction which allows many idiomatic JavaScript functions to be given a type.
+Finally, we covered _row polymorphism_, a powerful type of abstraction that allows many idiomatic JavaScript functions to be given a type.
 
 In the rest of the book, we will use ADTs and pattern matching extensively, so it will pay dividends to become familiar with them now. Try creating your own algebraic data types and writing functions to consume them using pattern matching.

--- a/text/chapter6.md
+++ b/text/chapter6.md
@@ -2,9 +2,9 @@
 
 ## Chapter Goals
 
-This chapter will introduce a powerful form of abstraction which is enabled by PureScript's type system - type classes.
+This chapter will introduce a powerful form of abstraction enabled by PureScript's type system – type classes.
 
-This motivating example for this chapter will be a library for hashing data structures. We will see how the machinery of type classes allow us to hash complex data structures without having to think directly about the structure of the data itself.
+This motivating example for this chapter will be a library for hashing data structures. We will see how the machinery of type classes allows us to hash complex data structures without having to think directly about the structure of the data itself.
 
 We will also see a collection of standard type classes from PureScript's Prelude and standard libraries. PureScript code leans heavily on the power of type classes to express ideas concisely, so it will be beneficial to familiarize yourself with these classes.
 
@@ -19,7 +19,7 @@ The project has the following dependencies:
 - `maybe`, which defines the `Maybe` data type, which represents optional values.
 - `tuples`, which defines the `Tuple` data type, which represents pairs of values.
 - `either`, which defines the `Either` data type, which represents disjoint unions.
-- `strings`, which defines functions which operate on strings.
+- `strings`, which defines functions that operate on strings.
 - `functions`, which defines some helper functions for defining PureScript functions.
 
 The module `Data.Hashable` imports several modules provided by these packages.
@@ -47,7 +47,7 @@ instance Show Boolean where
   show false = "false"
 ```
 
-This code declares a type class instance called `showBoolean` - in PureScript, type class instances can be named to aid the readability of the generated JavaScript. We say that the `Boolean` type _belongs to the `Show` type class_.
+This code declares a type class instance called `showBoolean` – in PureScript, type class instances can be named to aid the readability of the generated JavaScript. We say that the `Boolean` type _belongs to the `Show` type class_.
 
 We can try out the `Show` type class in PSCi, by showing a few values with different types:
 
@@ -78,7 +78,7 @@ These examples demonstrate how to `show` values of various primitive types, but 
 "(Just \"testing\")"
 ```
 
-The output of `show` should be a string that you can paste back into the repl (or `.purs` file) to recreate the item being shown. Here we'll use `logShow`, which just calls `show` then `log`, to render the string without quotes. Ignore the `unit` print - that will covered in Chapter 8 when we examine `Effect`s, like `log`.
+The output of `show` should be a string that you can paste back into the repl (or `.purs` file) to recreate the item being shown. Here we'll use `logShow`, which just calls `show` and then `log`, to render the string without quotes. Ignore the `unit` print – that will be covered in Chapter 8 when we examine `Effect`s, like `log`.
 
 ```text
 > import Effect.Console
@@ -105,9 +105,9 @@ The inferred type
 has type variables which are not mentioned in the body of the type. Consider adding a type annotation.
 ```
 
-The problem here is not that there is no `Show` instance for the type we intended to `show`, but rather that PSCi was unable to infer the type. This is indicated by the _unknown type_ `a` in the inferred type.
+The problem here is not that there is no `Show` instance for the type we intended to `show`, but rather that PSCi could not infer the type. This is indicated by the _unknown type_ `a` in the inferred type.
 
-We can annotate the expression with a type, using the `::` operator, so that PSCi can choose the correct type class instance:
+We can annotate the expression with a type using the `::` operator, so that PSCi can choose the correct type class instance:
 
 ```text
 > show (Left 10 :: Either Int String)
@@ -141,14 +141,14 @@ In this section, we'll look at some standard type classes defined in the Prelude
 
 ### Eq
 
-The `Eq` type class defines the `eq` function, which tests two values for equality. The `==` operator is actually just an alias for `eq`.
+The `Eq` type class defines the `eq` function, which tests two values for equality. The `==` operator is actually an alias for `eq`.
 
 ```haskell
 class Eq a where
   eq :: a -> a -> Boolean
 ```
 
-Note that in either case, the two arguments must have the same type: it does not make sense to compare two values of different types for equality.
+In either case, the two arguments must have the same type: it does not make sense to compare two values of different types for equality.
 
 Try out the `Eq` type class in PSCi:
 
@@ -162,7 +162,7 @@ true
 
 ### Ord
 
-The `Ord` type class defines the `compare` function, which can be used to compare two values, for types which support ordering. The comparison operators `<` and `>` along with their non-strict companions `<=` and `>=`, can be defined in terms of `compare`.
+The `Ord` type class defines the `compare` function, which can be used to compare two values, for types that support ordering. The comparison operators `<` and `>` along with their non-strict companions `<=` and `>=`, can be defined in terms of `compare`.
 
 _Note_: In the example below, the class signature contains `<=`. This usage of `<=` in this context indicates that Eq is a subclass of Ord and is not intended to represent the use of `<=` as a comparison operator. See the section [Superclasses](#superclasses) below.
 
@@ -173,11 +173,11 @@ class Eq a <= Ord a where
   compare :: a -> a -> Ordering
 ```
 
-The `compare` function compares two values, and returns an `Ordering`, which has three alternatives:
+The `compare` function compares two values and returns an `Ordering`, which has three alternatives:
 
-- `LT` - if the first argument is less than the second.
-- `EQ` - if the first argument is equal to the second.
-- `GT` - if the first argument is greater than the second.
+- `LT` – if the first argument is less than the second.
+- `EQ` – if the first argument is equal to the second.
+- `GT` – if the first argument is greater than the second.
 
 Again, we can try out the `compare` function in PSCi:
 
@@ -191,15 +191,15 @@ LT
 
 ### Field
 
-The `Field` type class identifies those types which support numeric operators such as addition, subtraction, multiplication and division. It is provided to abstract over those operators, so that they can be reused where appropriate.
+The `Field` type class identifies those types which support numeric operators such as addition, subtraction, multiplication, and division. It is provided to abstract over those operators, so that they can be reused where appropriate.
 
-_Note_: Just like the `Eq` and `Ord` type classes, the `Field` type class has special support in the PureScript compiler, so that simple expressions such as `1 + 2 * 3` get translated into simple JavaScript, as opposed to function calls which dispatch based on a type class implementation.
+> _Note_: Just like the `Eq` and `Ord` type classes, the `Field` type class has special support in the PureScript compiler, so that simple expressions such as `1 + 2 * 3` get translated into simple JavaScript, as opposed to function calls which dispatch based on a type class implementation.
 
 ```haskell
 class EuclideanRing a <= Field a
 ```
 
-The `Field` type class is composed from several more general _superclasses_. This allows us to talk abstractly about types which support some but not all of the `Field` operations. For example, a type of natural numbers would be closed under addition and multiplication, but not necessarily under subtraction, so that type might have an instance of the `Semiring` class (which is a superclass of `Num`), but not an instance of `Ring` or `Field`.
+The `Field` type class is composed from several more general _superclasses_. This allows us to talk abstractly about types that support some but not all of the `Field` operations. For example, a type of natural numbers would be closed under addition and multiplication, but not necessarily under subtraction, so that type might have an instance of the `Semiring` class (which is a superclass of `Num`), but not an instance of `Ring` or `Field`.
 
 Superclasses will be explained later in this chapter, but the full [numeric type class hierarchy](https://a-guide-to-the-purescript-numeric-hierarchy.readthedocs.io/en/latest/introduction.html) ([cheatsheet](https://harry.garrood.me/numeric-hierarchy-overview/)) is beyond the scope of this chapter. The interested reader is encouraged to read the documentation for the superclasses of `Field` in `prelude`.
 
@@ -212,7 +212,7 @@ class Semigroup a where
   append :: a -> a -> a
 ```
 
-Strings form a semigroup under regular string concatenation, and so do arrays. Several other standard instances are provided by the `prelude` package.
+Strings form a semigroup under regular string concatenation, and so do arrays. The `prelude` package provides several other standard instances.
 
 The `<>` concatenation operator, which we have already seen, is provided as an alias for `append`.
 
@@ -225,7 +225,7 @@ class Semigroup m <= Monoid m where
 
 Again, strings and arrays are simple examples of monoids.
 
-A `Monoid` type class instance for a type describes how to _accumulate_ a result with that type, by starting with an "empty" value, and combining new results. For example, we can write a function which concatenates an array of values in some monoid by using a fold. In PSCi:
+A `Monoid` type class instance for a type describes how to _accumulate_ a result with that type by starting with an "empty" value and combining new results. For example, we can write a function that concatenates an array of values in some monoid using a fold. In PSCi:
 
 ```haskell
 > import Prelude
@@ -256,9 +256,9 @@ class Foldable f where
   foldMap :: forall a m. Monoid m => (a -> m) -> f a -> m
 ```
 
-It is instructive to specialize to the case where `f` is the array type constructor. In this case, we can replace `f a` with `Array a` for any a, and we notice that the types of `foldl` and `foldr` become the types that we saw when we first encountered folds over arrays.
+It is instructive to specialize to the case where `f` is the array type constructor. In this case, we can replace `f a` with `Array a` for any a, and we notice that the types of `foldl` and `foldr` become the types we saw when we first encountered folds over arrays.
 
-What about `foldMap`? Well, that becomes `forall a m. Monoid m => (a -> m) -> Array a -> m`. This type signature says that we can choose any type `m` for our result type, as long as that type is an instance of the `Monoid` type class. If we can provide a function which turns our array elements into values in that monoid, then we can accumulate over our array using the structure of the monoid, and return a single value.
+What about `foldMap`? Well, that becomes `forall a m. Monoid m => (a -> m) -> Array a -> m`. This type signature says that we can choose any type `m` for our result type, as long as that type is an instance of the `Monoid` type class. If we can provide a function that turns our array elements into values in that monoid, then we can accumulate over our array using the structure of the monoid and return a single value.
 
 Let's try out `foldMap` in PSCi:
 
@@ -269,13 +269,13 @@ Let's try out `foldMap` in PSCi:
 "12345"
 ```
 
-Here, we choose the monoid for strings, which concatenates strings together, and the `show` function which renders an `Int` as a `String`. Then, passing in an array of integers, we see that the results of `show`ing each integer have been concatenated into a single `String`.
+Here, we choose the monoid for strings, which concatenates strings together, and the `show` function, which renders an `Int` as a `String`. Then, passing in an array of integers, we see that the results of `show`ing each integer have been concatenated into a single `String`.
 
-But arrays are not the only types which are foldable. `foldable-traversable` also defines `Foldable` instances for types like `Maybe` and `Tuple`, and other libraries like `lists` define `Foldable` instances for their own data types. `Foldable` captures the notion of an _ordered container_.
+But arrays are not the only types that are foldable. `foldable-traversable` also defines `Foldable` instances for types like `Maybe` and `Tuple`, and other libraries like `lists` define `Foldable` instances for their own data types. `Foldable` captures the notion of an _ordered container_.
 
-### Functor, and Type Class Laws
+### Functor and Type Class Laws
 
-The Prelude also defines a collection of type classes which enable a functional style of programming with side-effects in PureScript: `Functor`, `Applicative` and `Monad`. We will cover these abstractions later in the book, but for now, let's look at the definition of the `Functor` type class, which we have seen already in the form of the `map` function:
+The Prelude also defines a collection of type classes that enable a functional style of programming with side-effects in PureScript: `Functor`, `Applicative`, and `Monad`. We will cover these abstractions later in the book, but for now, let's look at the definition of the `Functor` type class, which we have seen already in the form of the `map` function:
 
 ```haskell
 class Functor f where
@@ -308,7 +308,7 @@ Type class instances for `Functor` are expected to adhere to a set of _laws_, ca
 
 The first law is the _identity law_. It states that lifting the identity function (the function which returns its argument unchanged) over a structure just returns the original structure. This makes sense since the identity function does not modify its input.
 
-The second law is the _composition law_. It states that mapping one function over a structure, and then mapping a second, is the same thing as mapping the composition of the two functions over the structure.
+The second law is the _composition law_. It states that mapping one function over a structure and then mapping a second is the same as mapping the composition of the two functions over the structure.
 
 Whatever "lifting" means in the general sense, it should be true that any reasonable definition of lifting a function over a data structure should obey these rules.
 
@@ -344,7 +344,7 @@ The following newtype represents a complex number:
 
 ## Type Class Constraints
 
-Types of functions can be constrained by using type classes. Here is an example: suppose we want to write a function which tests if three values are equal, by using equality defined using an `Eq` type class instance.
+Types of functions can be constrained by using type classes. Here is an example: suppose we want to write a function that tests if three values are equal, by using equality defined using an `Eq` type class instance.
 
 ```haskell
 threeAreEqual :: forall a. Eq a => a -> a -> a -> Boolean
@@ -384,7 +384,7 @@ To see this, try using one of the standard type classes like `Semiring` in PSCi:
 forall a. Semiring a => a -> a
 ```
 
-Here, we might have annotated this function as `Int -> Int`, or `Number -> Number`, but PSCi shows us that the most general type works for any `Semiring`, allowing us to use our function with both `Int`s and `Number`s.
+Here, we might have annotated this function as `Int -> Int` or `Number -> Number`, but PSCi shows us that the most general type works for any `Semiring`, allowing us to use our function with both `Int`s and `Number.
 
 ## Instance Dependencies
 
@@ -397,8 +397,7 @@ instance Show a => Show (Array a) where
   ...
 ```
 
-If a type class instance depends on multiple other instances, those instances should be grouped in parentheses and separated by
-commas on the left hand side of the `=>` symbol:
+If a type class instance depends on multiple other instances, those instances should be grouped in parentheses and separated by commas on the left-hand side of the `=>` symbol:
 
 ```haskell
 instance (Show a, Show b) => Show (Either a b) where
@@ -417,23 +416,23 @@ When the program is compiled, the correct type class instance for `Show` is chos
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:NonEmpty}}
     ```
 
-    Write an `Eq` instance for the type `NonEmpty a` which reuses the instances for `Eq a` and `Eq (Array a)`. _Note:_ you may instead derive the `Eq` instance.
+    Write an `Eq` instance for the type `NonEmpty a` that reuses the instances for `Eq a` and `Eq (Array a)`. _Note:_ you may instead derive the `Eq` instance.
 
 1. (Medium) Write a `Semigroup` instance for `NonEmpty a` by reusing the `Semigroup` instance for `Array`.
 
 1. (Medium) Write a `Functor` instance for `NonEmpty`.
 
-1. (Medium) Given any type `a` with an instance of `Ord`, we can add a new "infinite" value which is greater than any other value:
+1. (Medium) Given any type `a` with an instance of `Ord`, we can add a new "infinite" value that is greater than any other value:
 
     ```haskell
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:Extended}}
     ```
 
-    Write an `Ord` instance for `Extended a` which reuses the `Ord` instance for `a`.
+    Write an `Ord` instance for `Extended a` that reuses the `Ord` instance for `a`.
 
 1. (Difficult) Write a `Foldable` instance for `NonEmpty`. _Hint_: reuse the `Foldable` instance for arrays.
 
-1. (Difficult) Given a type constructor `f` which defines an ordered container (and so has a `Foldable` instance), we can create a new container type which includes an extra element at the front:
+1. (Difficult) Given a type constructor `f` which defines an ordered container (and so has a `Foldable` instance), we can create a new container type that includes an extra element at the front:
 
     ```haskell
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:OneMore}}
@@ -446,13 +445,13 @@ When the program is compiled, the correct type class instance for `Show` is chos
       ...
     ```
 
-1. (Medium) Write a `dedupShapes :: Array Shape -> Array Shape` function which removes duplicate `Shape`s from an array using the `nubEq` function.
+1. (Medium) Write a `dedupShapes :: Array Shape -> Array Shape` function that removes duplicate `Shape`s from an array using the `nubEq` function.
 
 1. (Medium) Write a `dedupShapesFast` function which is the same as `dedupShapes`, but uses the more efficient `nub` function.
 
-## Multi Parameter Type Classes
+## Multi-Parameter Type Classes
 
-It's not the case that a type class can only take a single type as an argument. This is the most common case, but in fact, a type class can be parameterized by _zero or more_ type arguments.
+It's not the case that a type class can only take a single type as an argument. This is the most common case, but a type class can be parameterized by _zero or more_ type arguments.
 
 Let's see an example of a type class with two type arguments.
 
@@ -473,13 +472,13 @@ instance Stream String Char where
   uncons = String.uncons
 ```
 
-The `Stream` module defines a class `Stream` which identifies types which look like streams of elements, where elements can be pulled from the front of the stream using the `uncons` function.
+The `Stream` module defines a class `Stream` which identifies types that look like streams of elements, where elements can be pulled from the front of the stream using the `uncons` function.
 
 Note that the `Stream` type class is parameterized not only by the type of the stream itself, but also by its elements. This allows us to define type class instances for the same stream type but different element types.
 
 The module defines two type class instances: an instance for arrays, where `uncons` removes the head element of the array using pattern matching, and an instance for String, which removes the first character from a String.
 
-We can write functions which work over arbitrary streams. For example, here is a function which accumulates a result in some `Monoid` based on the elements of a stream:
+We can write functions that work over arbitrary streams. For example, here is a function that accumulates a result in some `Monoid` based on the elements of a stream:
 
 ```haskell
 import Prelude
@@ -496,7 +495,7 @@ Try using `foldStream` in PSCi for different types of `Stream` and different typ
 
 ## Functional Dependencies
 
-Multi-parameter type classes can be very useful, but can easily lead to confusing types and even issues with type inference. As a simple example, consider writing a generic `tail` function on streams using the `Stream` class given above:
+Multi-parameter type classes can be very useful but can easily lead to confusing types and even issues with type inference. As a simple example, consider writing a generic `tail` function on streams using the `Stream` class given above:
 
 ```haskell
 genericTail xs = map _.tail (uncons xs)
@@ -528,7 +527,7 @@ has type variables which are not mentioned in the body of the type. Consider add
 
 Here, we might expect the compiler to choose the `streamString` instance. After all, a `String` is a stream of `Char`s, and cannot be a stream of any other type of elements.
 
-The compiler is unable to make that deduction automatically, and cannot commit to the `streamString` instance. However, we can help the compiler by adding a hint to the type class definition:
+The compiler cannot make that deduction automatically or commit to the `streamString` instance. However, we can help the compiler by adding a hint to the type class definition:
 
 ```haskell
 class Stream stream element | stream -> element where
@@ -547,13 +546,13 @@ forall stream element. Stream stream element => stream -> Maybe stream
 (Just "esting")
 ```
 
-Functional dependencies can be quite useful when using multi-parameter type classes to design certain APIs.
+Functional dependencies can be useful when designing certain APIs using multi-parameter type classes.
 
 ## Nullary Type Classes
 
-We can even define type classes with zero type arguments! These correspond to compile-time assertions about our functions, allowing us to track global properties of our code in the type system.
+We can even define type classes with zero-type arguments! These correspond to compile-time assertions about our functions, allowing us to track the global properties of our code in the type system.
 
-An important example is the `Partial` class which we saw earlier when discussing partial functions. Take for example the functions `head` and `tail` defined in `Data.Array.Partial` that allow us to get the head or tail of an array without wrapping them in a `Maybe`, so they can fail if the array is empty:
+An important example is the `Partial` class we saw earlier when discussing partial functions. Take, for example, the functions `head` and `tail` defined in `Data.Array.Partial` that allow us to get the head or tail of an array without wrapping them in a `Maybe`, so they can fail if the array is empty:
 
 ```haskell
 head :: forall a. Partial => Array a -> a
@@ -600,23 +599,23 @@ Just as we can express relationships between type class instances by making an i
 
 We say that one type class is a superclass of another if every instance of the second class is required to be an instance of the first, and we indicate a superclass relationship in the class definition by using a backwards facing double arrow ( `<=` ).
 
-We've [already seen an example of superclass relationships](#ord): the `Eq` class is a superclass of `Ord`, and the `Semigroup` class is a superclass of `Monoid`. For every type class instance of the `Ord` class, there must be a corresponding `Eq` instance for the same type. This makes sense, since in many cases, when the `compare` function reports that two values are incomparable, we often want to use the `Eq` class to determine if they are in fact equal.
+We've [already seen an example of superclass relationships](#ord): the `Eq` class is a superclass of `Ord`, and the `Semigroup` class is a superclass of `Monoid`. For every type class instance of the `Ord` class, there must be a corresponding `Eq` instance for the same type. This makes sense since, in many cases, when the `compare` function reports that two values are incomparable, we often want to use the `Eq` class to determine if they are equal.
 
-In general, it makes sense to define a superclass relationship when the laws for the subclass mention the members of the superclass. For example, it is reasonable to assume, for any pair of `Ord` and `Eq` instances, that if two values are equal under the `Eq` instance, then the `compare` function should return `EQ`. In other words, `a == b` should be true exactly when `compare a b` evaluates to `EQ`. This relationship on the level of laws justifies the superclass relationship between `Eq` and `Ord`.
+In general, it makes sense to define a superclass relationship when the laws for the subclass mention the superclass members. For example, for any pair of Ord and Eq instances, it is reasonable to assume that if two values are equal under the `Eq` instance, then the `compare` function should return `EQ`. In other words, `a == b` should be true exactly when `compare a b` evaluates to `EQ`. This relationship on the level of laws justifies the superclass relationship between `Eq` and `Ord`.
 
-Another reason to define a superclass relationship is in the case where there is a clear "is-a" relationship between the two classes. That is, every member of the subclass _is a_ member of the superclass as well.
+Another reason to define a superclass relationship is when there is a clear "is-a" relationship between the two classes. That is, every member of the subclass _is a_ member of the superclass as well.
 
 ## Exercises
 
-1. (Medium) Define a partial function `unsafeMaximum :: Partial => Array Int -> Int` which finds the maximum of a non-empty array of integers. Test out your function in PSCi using `unsafePartial`. _Hint_: Use the `maximum` function from `Data.Foldable`.
+1. (Medium) Define a partial function `unsafeMaximum :: Partial => Array Int -> Int` that finds the maximum of a non-empty array of integers. Test out your function in PSCi using `unsafePartial`. _Hint_: Use the `maximum` function from `Data.Foldable`.
 
-1. (Medium) The `Action` class is a multi-parameter type class which defines an action of one type on another:
+1. (Medium) The `Action` class is a multi-parameter type class that defines an action of one type on another:
 
     ```haskell
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:Action}}
     ```
 
-    An _action_ is a function which describes how monoidal values are used to determine how to modify a value of another type. There are two laws for the `Action` type class:
+    An _action_ is a function that describes how monoidal values are used to determine how to modify a value of another type. There are two laws for the `Action` type class:
 
     - `act mempty a = a`
     - `act (m1 <> m2) a = act m1 (act m2 a)`
@@ -633,7 +632,7 @@ Another reason to define a superclass relationship is in the case where there is
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:monoidMultiply}}
     ```
 
-    Write an instance which implements this action:
+    Write an instance that implements this action:
 
     ```haskell
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:Multiply_Action}}
@@ -642,9 +641,9 @@ Another reason to define a superclass relationship is in the case where there is
 
     Remember, your instance must satisfy the laws listed above.
 
-1. (Difficult) There are actually multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of a same instance, so you will have to replace your original implementation. _Note_: the tests cover 4 implementations.
+1. (Difficult) There are multiple ways to implement an instance of `Action Multiply Int`. How many can you think of? Purescript does not allow multiple implementations of the same instance, so you will have to replace your original implementation. _Note_: the tests cover 4 implementations.
 
-1. (Medium) Write an `Action` instance which repeats an input string some number of times:
+1. (Medium) Write an `Action` instance that repeats an input string some number of times:
 
     ```haskell
     {{#include ../exercises/chapter6/test/no-peeking/Solutions.purs:actionMultiplyString}}
@@ -671,14 +670,14 @@ Another reason to define a superclass relationship is in the case where there is
 
 In the last section of this chapter, we will use the lessons from the rest of the chapter to create a library for hashing data structures.
 
-Note that this library is for demonstration purposes only, and is not intended to provide a robust hashing mechanism.
+> Note that this library is for demonstration purposes only and is not intended to provide a robust hashing mechanism.
 
 What properties might we expect of a hash function?
 
-- A hash function should be deterministic, and map equal values to equal hash codes.
+- A hash function should be deterministic and map equal values to equal hash codes.
 - A hash function should distribute its results approximately uniformly over some set of hash codes.
 
-The first property looks a lot like a law for a type class, whereas the second property is more along the lines of an informal contract, and certainly would not be enforceable by PureScript's type system. However, this should provide the intuition for the following type class:
+The first property looks a lot like a law for a type class, whereas the second property is more along the lines of an informal contract and certainly would not be enforceable by PureScript's type system. However, this should provide the intuition for the following type class:
 
 ```haskell
 {{#include ../exercises/chapter6/src/Data/Hashable.purs:Hashable}}
@@ -696,15 +695,15 @@ We will need a way to combine hash codes in a deterministic way:
 
 The `combineHashes` function will mix two hash codes and redistribute the result over the interval 0-65535.
 
-Let's write a function which uses the `Hashable` constraint to restrict the types of its inputs. One common task which requires a hashing function is to determine if two values hash to the same hash code. The `hashEqual` relation provides such a capability:
+Let's write a function that uses the `Hashable` constraint to restrict the types of its inputs. One common task which requires a hashing function is to determine if two values hash to the same hash code. The `hashEqual` relation provides such a capability:
 
 ```haskell
 {{#include ../exercises/chapter6/src/Data/Hashable.purs:hashEqual}}
 ```
 
-This function uses the `on` function from `Data.Function` to define hash-equality in terms of equality of hash codes, and should read like a declarative definition of hash-equality: two values are "hash-equal" if they are equal after each value has been passed through the `hash` function.
+This function uses the `on` function from `Data.Function` to define hash-equality in terms of equality of hash codes, and should read like a declarative definition of hash-equality: two values are "hash-equal" if they are equal after each value passed through the `hash` function.
 
-Let's write some `Hashable` instances for some primitive types. Let's start with an instance for integers. Since a `HashCode` is really just a wrapped integer, this is simple - we can use the `hashCode` helper function:
+Let's write some `Hashable` instances for some primitive types. Let's start with an instance for integers. Since a `HashCode` is really just a wrapped integer, this is simple – we can use the `hashCode` helper function:
 
 ```haskell
 {{#include ../exercises/chapter6/src/Data/Hashable.purs:hashInt}}
@@ -734,16 +733,16 @@ Notice how we build up instances using the simpler instances we have already wri
 {{#include ../exercises/chapter6/src/Data/Hashable.purs:hashString}}
 ```
 
-How can we prove that these `Hashable` instances satisfy the type class law that we stated above? We need to make sure that equal values have equal hash codes. In cases like `Int`, `Char`, `String` and `Boolean`, this is simple because there are no values of those types which are equal in the sense of `Eq` but not equal identically.
+How can we prove that these `Hashable` instances satisfy the type class law that we stated above? We need to make sure that equal values have equal hash codes. In cases like `Int`, `Char`, `String`, and `Boolean`, this is simple because there are no values of those types that are equal in the sense of `Eq` but not equal identically.
 
-What about some more interesting types? To prove the type class law for the `Array` instance, we can use induction on the length of the array. The only array with length zero is `[]`. Any two non-empty arrays are equal only if they have equal head elements and equal tails, by the definition of `Eq` on arrays. By the inductive hypothesis, the tails have equal hashes, and we know that the head elements have equal hashes if the `Hashable a` instance must satisfy the law. Therefore, the two arrays have equal hashes, and so the `Hashable (Array a)` obeys the type class law as well.
+What about some more interesting types? To prove the type class law for the `Array` instance, we can use induction on the length of the array. The only array with a length zero is `[]`. Any two non-empty arrays are equal only if they have equal head elements and equal tails, by the definition of `Eq` on arrays. By the inductive hypothesis, the tails have equal hashes, and we know that the head elements have equal hashes if the `Hashable a` instance must satisfy the law. Therefore, the two arrays have equal hashes, and so the `Hashable (Array a)` obeys the type class law as well.
 
 The source code for this chapter includes several other examples of `Hashable` instances, such as instances for the `Maybe` and `Tuple` type.
 
 ## Exercises
 
  1. (Easy) Use PSCi to test the hash functions for each of the defined instances. _Note_: There is no provided unit test for this exercise.
- 1. (Medium) Write a function `arrayHasDuplicates` which tests if an array has any duplicate elements based on both hash and value equality. First check for hash equality with the `hashEqual` function, then check for value equality with `==` if a duplicate pair of hashes is found. _Hint_: the `nubByEq` function in `Data.Array` should make this task much simpler.
+ 1. (Medium) Write a function `arrayHasDuplicates`, which tests if an array has any duplicate elements based on both hash and value equality. First, check for hash equality with the `hashEqual` function, then check for value equality with `==` if a duplicate pair of hashes is found. _Hint_: the `nubByEq` function in `Data.Array` should make this task much simpler.
  1. (Medium) Write a `Hashable` instance for the following newtype which satisfies the type class law:
 
     ```haskell
@@ -757,6 +756,6 @@ The source code for this chapter includes several other examples of `Hashable` i
 
 ## Conclusion
 
-In this chapter, we've been introduced to _type classes_, a type-oriented form of abstraction which enables powerful forms of code reuse. We've seen a collection of standard type classes from the PureScript standard libraries, and defined our own library based on a type class for computing hash codes.
+In this chapter, we've been introduced to _type classes_, a type-oriented form of abstraction that enables powerful forms of code reuse. We've seen a collection of standard type classes from the PureScript standard libraries and defined our own library based on a type class for computing hash codes.
 
-This chapter also gave an introduction to the notion of type class laws, a technique for proving properties about code which uses type classes for abstraction. Type class laws are part of a larger subject called _equational reasoning_, in which the properties of a programming language and its type system are used to enable logical reasoning about its programs. This is an important idea, and will be a theme which we will return to throughout the rest of the book.
+This chapter also introduced type class laws, a technique for proving properties about code that uses type classes for abstraction. Type class laws are part of a larger subject called _equational reasoning_, in which the properties of a programming language and its type system are used to enable logical reasoning about its programs. This is an important idea and a theme that we will return to throughout the rest of the book.

--- a/text/chapter7.md
+++ b/text/chapter7.md
@@ -2,11 +2,11 @@
 
 ## Chapter Goals
 
-In this chapter, we will meet an important new abstraction - the _applicative functor_, described by the `Applicative` type class. Don't worry if the name sounds confusing - we will motivate the concept with a practical example - validating form data. This technique allows us to convert code which usually involves a lot of boilerplate checking into a simple, declarative description of our form.
+In this chapter, we will meet an important new abstraction – the _applicative functor_, described by the `Applicative` type class. Don't worry if the name sounds confusing – we will motivate the concept with a practical example – validating form data. This technique allows us to convert code which usually involves a lot of boilerplate checking into a simple, declarative description of our form.
 
 We will also meet another type class, `Traversable`, which describes _traversable functors_, and see how this concept also arises very naturally from solutions to real-world problems.
 
-The example code for this chapter will be a continuation of the address book example from chapter 3. This time, we will extend our address book data types, and write functions to validate values for those types. The understanding is that these functions could be used, for example in a web user interface, to display errors to the user as part of a data entry form.
+The example code for this chapter will be a continuation of the address book example from Chapter 3. This time, we will extend our address book data types and write functions to validate values for those types. The understanding is that these functions could be used, for example, in a web user interface, to display errors to the user as part of a data entry form.
 
 ## Project Setup
 
@@ -17,13 +17,13 @@ The project has a number of dependencies, many of which we have seen before. The
 - `control`, which defines functions for abstracting control flow using type classes like `Applicative`.
 - `validation`, which defines a functor for _applicative validation_, the subject of this chapter.
 
-The `Data.AddressBook` module defines data types and `Show` instances for the types in our project, and the `Data.AddressBook.Validation` module contains validation rules for those types.
+The `Data.AddressBook` module defines data types and `Show` instances for the types in our project and the `Data.AddressBook.Validation` module contains validation rules for those types.
 
 ## Generalizing Function Application
 
 To explain the concept of an _applicative functor_, let's consider the type constructor `Maybe` that we met earlier.
 
-The source code for this module defines a function `address` which has the following type:
+The source code for this module defines a function `address` that has the following type:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook.purs:address_anno}}
@@ -57,7 +57,7 @@ with type
   String
 ```
 
-Of course, this is an expected type error - `address` takes strings as arguments, not values of type `Maybe String`.
+Of course, this is an expected type error – `address` takes strings as arguments, not values of type `Maybe String`.
 
 However, it is reasonable to expect that we should be able to "lift" the `address` function to work with optional values described by the `Maybe` type. In fact, we can, and the `Control.Apply` provides the function `lift3` function which does exactly what we need:
 
@@ -95,7 +95,7 @@ In the `Maybe` example above, the type constructor `f` is `Maybe`, so that `lift
 forall a b c d. (a -> b -> c -> d) -> Maybe a -> Maybe b -> Maybe c -> Maybe d
 ```
 
-This type says that we can take any function with three arguments, and lift it to give a new function whose argument and result types are wrapped with `Maybe`.
+This type says that we can take any function with three arguments and lift it to give a new function whose argument and result types are wrapped with `Maybe`.
 
 Certainly, this is not possible for every type constructor `f`, so what is it about the `Maybe` type which allowed us to do this? Well, in specializing the type above, we removed a type class constraint on `f` from the `Apply` type class. `Apply` is defined in the Prelude as follows:
 
@@ -125,9 +125,9 @@ instance Apply Maybe where
 
 This type class instance says that we can apply an optional function to an optional value, and the result is defined only if both are defined.
 
-Now we'll see how `map` and `apply` can be used together to lift functions of arbitrary number of arguments.
+Now we'll see how `map` and `apply` can be used together to lift functions of an arbitrary number of arguments.
 
-For functions of one argument, we can just use `map` directly.
+For functions of one argument, we can use `map` directly.
 
 For functions of two arguments, we have a curried function `g` with type `a -> b -> c`, say. This is equivalent to the type `a -> (b -> c)`, so we can apply `map` to `g` to get a new function of type `f a -> f (b -> c)` for any type constructor `f` with a `Functor` instance. Partially applying this function to the first lifted argument (of type `f a`), we get a new wrapped function of type `f (b -> c)`. If we also have an `Apply` instance for `f`, we can then use `apply` to apply the second lifted argument (of type `f b`) to get our final value of type `f c`.
 
@@ -146,7 +146,7 @@ lift3 :: forall a b c d f
 lift3 f x y z = f <$> x <*> y <*> z
 ```
 
-It is left as an exercise for the reader to verify the types involved in this expression.
+> It is left as an exercise for the reader to verify the types involved in this expression.
 
 As an example, we can try lifting the address function over `Maybe`, directly using the `<$>` and `<*>` functions:
 
@@ -160,7 +160,7 @@ Nothing
 
 Try lifting some other functions of various numbers of arguments over `Maybe` in this way.
 
-Alternatively _applicative do notation_ can be used for the same purpose in a way that looks similar to the familiar _do notation_. Here is `lift3` using _applicative do notation_. Note `ado` is used instead of `do`, and `in` is used on the final line to denote the yielded value:
+Alternatively, _applicative do notation_ can be used for the same purpose in a way that looks similar to the familiar _do notation_. Here is `lift3` using _applicative do notation_. Note `ado` is used instead of `do`, and `in` is used on the final line to denote the yielded value:
 
 ```haskell
 lift3 :: forall a b c d f
@@ -195,17 +195,17 @@ instance Applicative Maybe where
   pure x = Just x
 ```
 
-If we think of applicative functors as functors which allow lifting of functions, then `pure` can be thought of as lifting functions of zero arguments.
+If we think of applicative functors as functors that allow lifting of functions, then `pure` can be thought of as lifting functions of zero arguments.
 
 ## Intuition for Applicative
 
 Functions in PureScript are pure and do not support side-effects. Applicative functors allow us to work in larger "programming languages" which support some sort of side-effect encoded by the functor `f`.
 
-As an example, the functor `Maybe` represents the side effect of possibly-missing values. Some other examples include `Either err`, which represents the side effect of possible errors of type `err`, and the arrow functor `r ->` which represents the side-effect of reading from a global configuration. For now, we'll only consider the `Maybe` functor.
+As an example, the functor `Maybe` represents the side effect of possibly-missing values. Some other examples include `Either err`, which represents the side effect of possible errors of type `err`, and the arrow functor `r ->`, which represents the side-effect of reading from a global configuration. For now, we'll only consider the `Maybe` functor.
 
 If the functor `f` represents this larger programming language with effects, then the `Apply` and `Applicative` instances allow us to lift values and function applications from our smaller programming language (PureScript) into the new language.
 
-`pure` lifts pure (side-effect free) values into the larger language, and for functions, we can use `map` and `apply` as described above.
+`pure` lifts pure (side-effect free) values into the larger language; for functions, we can use `map` and `apply` as described above.
 
 This raises a question: if we can use `Applicative` to embed PureScript functions and values into this new language, then how is the new language any larger? The answer depends on the functor `f`. If we can find expressions of type `f a` which cannot be expressed as `pure x` for some `x`, then that expression represents a term which only exists in the larger language.
 
@@ -226,7 +226,7 @@ Here is a simple example function defined in PSCi, which joins three names to fo
 Freeman, Phillip A
 ```
 
-Now suppose that this function forms the implementation of a (very simple!) web service with the three arguments provided as query parameters. We want to make sure that the user provided each of the three parameters, so we might use the `Maybe` type to indicate the presence or otherwise absence of a parameter. We can lift `fullName` over `Maybe` to create an implementation of the web service which checks for missing parameters:
+Suppose that this function forms the implementation of a (very simple!) web service with the three arguments provided as query parameters. We want to ensure that the user provided each of the three parameters, so we might use the Maybe type to indicate the presence or absence of a parameter. We can lift `fullName` over `Maybe` to create an implementation of the web service which checks for missing parameters:
 
 ```text
 > import Data.Maybe
@@ -238,7 +238,7 @@ Just ("Freeman, Phillip A")
 Nothing
 ```
 
-or with _applicative do_
+Or with _applicative do_:
 
 ```text
 > import Data.Maybe
@@ -263,7 +263,7 @@ Nothing
 
 Note that the lifted function returns `Nothing` if any of the arguments was `Nothing`.
 
-This is good, because now we can send an error response back from our web service if the parameters are invalid. However, it would be better if we could indicate which field was incorrect in the response.
+This is good because now we can send an error response back from our web service if the parameters are invalid. However, it would be better if we could indicate which field was incorrect in the response.
 
 Instead of lifting over `Maybe`, we can lift over `Either String`, which allows us to return an error message. First, let's write an operator to convert optional inputs into computations which can signal an error using `Either String`:
 
@@ -288,7 +288,7 @@ Now we can lift over `Either String`, providing an appropriate error message for
 … ^D
 ```
 
-or with _applicative do_
+Or with _applicative do_:
 
 ```text
 > :paste
@@ -303,7 +303,7 @@ or with _applicative do_
 Maybe String -> Maybe String -> Maybe String -> Either String String
 ```
 
-Now our function takes three optional arguments using `Maybe`, and returns either a `String` error message or a `String` result.
+Now our function takes three optional arguments using `Maybe, and returns either a`String` error message or a `String` result.
 
 We can try out the function with different inputs:
 
@@ -318,7 +318,7 @@ We can try out the function with different inputs:
 (Left "Last name was missing")
 ```
 
-In this case, we see the error message corresponding to the first missing field, or a successful result if every field was provided. However, if we are missing multiple inputs, we still only see the first error:
+In this case, we see the error message corresponding to the first missing field or a successful result if every field was provided. However, if we are missing multiple inputs, we still only see the first error:
 
 ```text
 > fullNameEither Nothing Nothing Nothing
@@ -329,11 +329,11 @@ This might be good enough, but if we want to see a list of _all_ missing fields 
 
 ## Combining Effects
 
-As an example of working with applicative functors abstractly, this section will show how to write a function which will generically combine side-effects encoded by an applicative functor `f`.
+As an example of working with applicative functors abstractly, this section will show how to write a function that generically combines side-effects encoded by an applicative functor `f`.
 
 What does this mean? Well, suppose we have a list of wrapped arguments of type `f a` for some `a`. That is, suppose we have a list of type `List (f a)`. Intuitively, this represents a list of computations with side-effects tracked by `f`, each with return type `a`. If we could run all of these computations in order, we would obtain a list of results of type `List a`. However, we would still have side-effects tracked by `f`. That is, we expect to be able to turn something of type `List (f a)` into something of type `f (List a)` by "combining" the effects inside the original list.
 
-For any fixed list size `n`, there is a function of `n` arguments which builds a list of size `n` out of those arguments. For example, if `n` is `3`, the function is `\x y z -> x : y : z : Nil`. This function has type `a -> a -> a -> List a`. We can use the `Applicative` instance for `List` to lift this function over `f`, to get a function of type `f a -> f a -> f a -> f (List a)`. But, since we can do this for any `n`, it makes sense that we should be able to perform the same lifting for any _list_ of arguments.
+For any fixed list size `n`, there is a function of `n` arguments that builds a list of size `n` out of those arguments. For example, if `n` is `3`, the function is `\x y z -> x : y : z : Nil`. This function has type `a -> a -> a -> List a`. We can use the `Applicative` instance for `List` to lift this function over `f`, to get a function of type `f a -> f a -> f a -> f (List a)`. But, since we can do this for any `n`, it makes sense that we should be able to perform the same lifting for any _list_ of arguments.
 
 That means that we should be able to write a function
 
@@ -372,21 +372,21 @@ We can test this function in PSCi, using the `Maybe` type constructor as an exam
 Nothing
 ```
 
-When specialized to `Maybe`, our function returns a `Just` only if every list element was `Just`, otherwise it returns `Nothing`. This is consistent with our intuition of working in a larger language supporting optional values - a list of computations which return optional results only has a result itself if every computation contained a result.
+When specialized to `Maybe`, our function returns a `Just` only if every list element is `Just`; otherwise, it returns `Nothing`. This is consistent with our intuition of working in a larger language supporting optional values – a list of computations that produce optional results only has a result itself if every computation contained a result.
 
-But the `combineList` function works for any `Applicative`! We can use it to combine computations which possibly signal an error using `Either err`, or which read from a global configuration using `r ->`.
+But the `combineList` function works for any `Applicative`! We can use it to combine computations that possibly signal an error using `Either err`, or which read from a global configuration using `r ->`.
 
-We will see the `combineList` function again later, when we consider `Traversable` functors.
+We will see the `combineList` function again later when we consider `Traversable` functors.
 
 ## Exercises
 
- 1. (Medium) Write versions of the numeric operators `+`, `-`, `*` and `/` which work with optional arguments (i.e. arguments wrapped in `Maybe`) and return a value wrapped in `Maybe`. Name these functions `addMaybe`, `subMaybe`, `mulMaybe`, and `divMaybe`. _Hint_: Use `lift2`.
+ 1. (Medium) Write versions of the numeric operators `+`, `-`, `*`, and `/` which work with optional arguments (i.e., arguments wrapped in `Maybe`) and return a value wrapped in `Maybe`. Name these functions `addMaybe`, `subMaybe`, `mulMaybe`, and `divMaybe`. _Hint_: Use `lift2`.
  1. (Medium) Extend the above exercise to work with all `Apply` types (not just `Maybe`). Name these new functions `addApply`, `subApply`, `mulApply`, and `divApply`.
- 1. (Difficult) Write a function `combineMaybe` which has type `forall a f. Applicative f => Maybe (f a) -> f (Maybe a)`. This function takes an optional computation with side-effects, and returns a side-effecting computation which has an optional result.
+ 1. (Difficult) Write a function `combineMaybe` which has type `forall a f. Applicative f => Maybe (f a) -> f (Maybe a)`. This function takes an optional computation with side-effects and returns a side-effecting computation with an optional result.
 
 ## Applicative Validation
 
-The source code for this chapter defines several data types which might be used in an address book application. The details are omitted here, but the key functions which are exported by the `Data.AddressBook` module have the following types:
+The source code for this chapter defines several data types which might be used in an address book application. The details are omitted here, but the key functions exported by the `Data.AddressBook` module have the following types:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook.purs:address_anno}}
@@ -396,13 +396,13 @@ The source code for this chapter defines several data types which might be used 
 {{#include ../exercises/chapter7/src/Data/AddressBook.purs:person_anno}}
 ```
 
-where `PhoneType` is defined as an algebraic data type:
+Where `PhoneType` is defined as an algebraic data type:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook.purs:PhoneType}}
 ```
 
-These functions can be used to construct a `Person` representing an address book entry. For example, the following value is defined in `Data.AddressBook`:
+These functions can construct a `Person` representing an address book entry. For example, the following value is defined in `Data.AddressBook`:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook.purs:examplePerson}}
@@ -440,26 +440,26 @@ We saw in a previous section how we could use the `Either String` functor to val
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validatePerson1}}
 ```
 
-or with _applicative do_
+Or with _applicative do_:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validatePerson1Ado}}
 ```
 
-In the first two lines, we use the `nonEmpty1` function to validate a non-empty string. `nonEmpty1` returns an error indicated with the `Left` constructor if its input is empty, otherwise it returns the value wrapped with the `Right` constructor.
+In the first two lines, we use the `nonEmpty1` function to validate a non-empty string. `nonEmpty1` returns an error indicated with the `Left` constructor if its input is empty. Otherwise, it returns the value wrapped with the `Right` constructor.
 
 The final lines do not perform any validation but simply provide the `address` and `phones` fields to the `person` function as the remaining arguments.
 
-This function can be seen to work in PSCi, but has a limitation which we have seen before:
+This function can be seen to work in PSCi, but it has a limitation that we have seen before:
 
 ```text
 > validatePerson $ person "" "" (address "" "" "") []
 (Left "Field cannot be empty")
 ```
 
-The `Either String` applicative functor only provides the first error encountered. Given the input here, we would prefer to see two errors - one for the missing first name, and a second for the missing last name.
+The `Either String` applicative functor only provides the first error encountered. Given the input here, we would prefer to see two errors – one for the missing first name and a second for the missing last name.
 
-There is another applicative functor which is provided by the `validation` library. This functor is called `V`, and it provides the ability to return errors in any _semigroup_. For example, we can use `V (Array String)` to return an array of `String`s as errors, concatenating new errors onto the end of the array.
+There is another applicative functor that the `validation` library provides. This functor is called `V`, and it can return errors in any _semigroup_. For example, we can use `V (Array String)` to return an array of `String`s as errors, concatenating new errors onto the end of the array.
 
 The `Data.AddressBook.Validation` module uses the `V (Array String)` applicative functor to validate the data structures in the `Data.AddressBook` module.
 
@@ -475,13 +475,13 @@ Here is an example of a validator taken from the `Data.AddressBook.Validation` m
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validateAddress}}
 ```
 
-or with _applicative do_
+Or with _applicative do_:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validateAddressAdo}}
 ```
 
-`validateAddress` validates an `Address` structure. It checks that the `street` and `city` fields are non-empty, and checks that the string in the `state` field has length 2.
+`validateAddress` validates an `Address` structure. It checks that the `street` and `city` fields are non-empty and that the string in the `state` field has length 2.
 
 Notice how the `nonEmpty` and `lengthIs` validator functions both use the `invalid` function provided by the `Data.Validation` module to indicate an error. Since we are working in the `Array String` semigroup, `invalid` takes an array of strings as its argument.
 
@@ -521,7 +521,7 @@ Again, notice how `pure` is used to indicate successful validation, and `invalid
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validatePhoneNumber}}
 ```
 
-or with _applicative do_
+Or with _applicative do_:
 
 ```haskell
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validatePhoneNumberAdo}}
@@ -540,7 +540,7 @@ invalid (["Field 'Number' did not match the required format"])
 ## Exercises
 
  1. (Easy) Write a regular expression `stateRegex :: Regex` to check that a string only contains two alphabetic characters. _Hint_: see the source code for `phoneNumberRegex`.
- 1. (Medium) Write a regular expression `nonEmptyRegex :: Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com) which has a great cheatsheet and interactive test environment.
+ 1. (Medium) Write a regular expression `nonEmptyRegex :: Regex` to check that a string is not entirely whitespace. _Hint_: If you need help developing this regex expression, check out [RegExr](https://regexr.com), which has a great cheatsheet and interactive test environment.
  1. (Medium) Write a function `validateAddressImproved` that is similar to `validateAddress`, but uses the above `stateRegex` to validate the `state` field and `nonEmptyRegex` to validate the `street` and `city` fields. _Hint_: see the source for `validatePhoneNumber` for an example of how to use `matches`.
 
 ## Traversable Functors
@@ -559,7 +559,7 @@ or with _applicative do_
 {{#include ../exercises/chapter7/src/Data/AddressBook/Validation.purs:validatePersonAdo}}
 ```
 
-`validatePhoneNumbers` uses a new function we haven't seen before - `traverse`.
+`validatePhoneNumbers` uses a new function we haven't seen before – `traverse`.
 
 `traverse` is defined in the `Data.Traversable` module, in the `Traversable` type class:
 
@@ -571,7 +571,7 @@ class (Functor t, Foldable t) <= Traversable t where
 
 `Traversable` defines the class of _traversable functors_. The types of its functions might look a little intimidating, but `validatePerson` provides a good motivating example.
 
-Every traversable functor is both a `Functor` and `Foldable` (recall that a _foldable functor_ was a type constructor which supported a fold operation, reducing a structure to a single value). In addition, a traversable functor provides the ability to combine a collection of side-effects which depend on its structure.
+Every traversable functor is both a `Functor` and `Foldable` (recall that a _foldable functor_ was a type constructor that supported a fold operation, reducing a structure to a single value). In addition, a traversable functor can combine a collection of side-effects that depend on its structure.
 
 This may sound complicated, but let's simplify things by specializing to the case of arrays. The array type constructor is traversable, which means that there is a function:
 
@@ -587,7 +587,7 @@ Still not clear? Let's specialize further to the case where `m` is the `V Errors
 traverse :: forall a b. (a -> V Errors b) -> Array a -> V Errors (Array b)
 ```
 
-This type signature says that if we have a validation function `m` for a type `a`, then `traverse m` is a validation function for arrays of type `Array a`. But that's exactly what we need to be able to validate the `phones` field of the `Person` data structure! We pass `validatePhoneNumber` to `traverse` to create a validation function which validates each element successively.
+This type signature says that if we have a validation function `m` for a type `a`, then `traverse m` is a validation function for arrays of type `Array a`. But that's exactly what we need to be able to validate the `phones` field of the `Person` data structure! We pass `validatePhoneNumber` to `traverse` to create a validation function that validates each element successively.
 
 In general, `traverse` walks over the elements of a data structure, performing computations with side-effects and accumulating a result.
 
@@ -603,7 +603,7 @@ In fact, the `combineList` function that we wrote earlier is just a special case
 combineList :: forall f a. Applicative f => List (f a) -> f (List a)
 ```
 
-Traversable functors capture the idea of traversing a data structure, collecting a set of effectful computations, and combining their effects. In fact, `sequence` and `traverse` are equally important to the definition of `Traversable` - each can be implemented in terms of each other. This is left as an exercise for the interested reader.
+Traversable functors capture the idea of traversing a data structure, collecting a set of effectful computations, and combining their effects. In fact, `sequence` and `traverse` are equally important to the definition of `Traversable` – each can be implemented in terms of the other. This is left as an exercise for the interested reader.
 
 The `Traversable` instance for lists given in the `Data.List` module is:
 
@@ -616,7 +616,7 @@ traverse f (Cons x xs) = Cons <$> f x <*> traverse f xs
 
 (The actual definition was later modified to improve stack safety. You can read more about that change [here](https://github.com/purescript/purescript-lists/pull/87).)
 
-In the case of an empty list, we can simply return an empty list using `pure`. If the list is non-empty, we can use the function `f` to create a computation of type `f b` from the head element. We can also call `traverse` recursively on the tail. Finally, we can lift the `Cons` constructor over the applicative functor `m` to combine the two results.
+In the case of an empty list, we can return an empty list using `pure`. If the list is non-empty, we can use the function `f` to create a computation of type `f b` from the head element. We can also call `traverse` recursively on the tail. Finally, we can lift the `Cons` constructor over the applicative functor `m` to combine the two results.
 
 But there are more examples of traversable functors than just arrays and lists. The `Maybe` type constructor we saw earlier also has an instance for `Traversable`. We can try it in PSCi:
 
@@ -635,9 +635,9 @@ invalid (["Field 'Example' cannot be empty"])
 pure ((Just "Testing"))
 ```
 
-These examples show that traversing the `Nothing` value returns `Nothing` with no validation, and traversing `Just x` uses the validation function to validate `x`. That is, `traverse` takes a validation function for type `a` and returns a validation function for `Maybe a`, i.e. a validation function for optional values of type `a`.
+These examples show that traversing the `Nothing` value returns `Nothing` with no validation, and traversing `Just x` uses the validation function to validate `x`. That is, `traverse` takes a validation function for type `a` and returns a validation function for `Maybe a`, i.e., a validation function for optional values of type `a`.
 
-Other traversable functors include `Array`, and `Tuple a` and `Either a` for any type `a`. Generally, most "container" data type constructors have `Traversable` instances. As an example, the exercises will include writing a `Traversable` instance for a type of binary trees.
+Other traversable functors include `Array`, `Tuple a`, and `Either a` for any type `a`. Generally, most "container" data type constructors have `Traversable` instances. As an example, the exercises will include writing a `Traversable` instance for a type of binary trees.
 
 ## Exercises
 
@@ -647,17 +647,17 @@ Other traversable functors include `Array`, and `Tuple a` and `Either a` for any
      data Tree a = Leaf | Branch (Tree a) a (Tree a)
      ```
 
-     Recall from the previous chapter that you may either write these instances manually or let the compiler derive them for you.
+     Recall from the previous chapter that you may either write these instances manually or let the compiler derive them.
 
-     There are many "correct" formatting options for `Show` output. The test for this exercise expects the following whitespace style. This happens to match the default formatting of generic show, so you only need to make note of this if you're planning on writing this instance manually.
+     There are many "correct" formatting options for `Show` output. The test for this exercise expects the following whitespace style. This matches the default formatting of the generic show, so you only need to note this if you're planning on writing this instance manually.
 
      ```haskell
      (Branch (Branch Leaf 8 Leaf) 42 Leaf)
      ```
 
- 1. (Medium) Write a `Traversable` instance for `Tree a`, which combines side-effects from left-to-right. _Hint_: There are some additional instance dependencies that need to be defined for `Traversable`.
+ 1. (Medium) Write a `Traversable` instance for `Tree a`, which combines side-effects left-to-right. _Hint_: There are some additional instance dependencies that need to be defined for `Traversable`.
 
- 1. (Medium) Write a function `traversePreOrder :: forall a m b. Applicative m => (a -> m b) -> Tree a -> m (Tree b)` that performs a pre-order traversal of the tree. This means the order of effect execution is root-left-right, instead of left-root-right as was done for the previous in-order traverse exercise. _Hint_: No additional instances need to be defined, and you don't need to call any of the the functions defined earlier. Applicative do notation (`ado`) is the easiest way to write this function.
+ 1. (Medium) Write a function `traversePreOrder :: forall a m b. Applicative m => (a -> m b) -> Tree a -> m (Tree b)` that performs a pre-order traversal of the tree. This means the order of effect execution is root-left-right, instead of left-root-right as was done for the previous in-order traverse exercise. _Hint_: No additional instances need to be defined, and you don't need to call any of the functions defined earlier. Applicative do notation (`ado`) is the easiest way to write this function.
 
  1. (Medium) Write a function `traversePostOrder` that performs a post-order traversal of the tree where effects are executed left-right-root.
 
@@ -671,11 +671,11 @@ Other traversable functors include `Array`, and `Tuple a` and `Either a` for any
 
 In the discussion above, I chose the word "combine" to describe how applicative functors "combine side-effects". However, in all the examples given, it would be equally valid to say that applicative functors allow us to "sequence" effects. This would be consistent with the intuition that traversable functors provide a `sequence` function to combine effects in sequence based on a data structure.
 
-However, in general, applicative functors are more general than this. The applicative functor laws do not impose any ordering on the side-effects that their computations perform. In fact, it would be valid for an applicative functor to perform its side-effects in parallel.
+However, in general, applicative functors are more general than this. The applicative functor laws do not impose any ordering on the side-effects that their computations perform. It would be valid for an applicative functor to perform its side-effects in parallel.
 
 For example, the `V` validation functor returned an _array_ of errors, but it would work just as well if we picked the `Set` semigroup, in which case it would not matter what order we ran the various validators. We could even run them in parallel over the data structure!
 
-As a second example, the `parallel` package provides a type class `Parallel` which supports _parallel computations_. `Parallel` provides a function `parallel` which uses some `Applicative` functor to compute the result of its input computation _in parallel_:
+As a second example, the `parallel` package provides a type class `Parallel` which supports _parallel computations_. `Parallel` provides a function `parallel` that uses some `Applicative` functor to compute the result of its input computation _in parallel_:
 
 ```haskell
 f <$> parallel computation1
@@ -686,16 +686,16 @@ This computation would start computing values asynchronously using `computation1
 
 We will see this idea in more detail when we apply applicative functors to the problem of _callback hell_ later in the book.
 
-Applicative functors are a natural way to capture side-effects which can be combined in parallel.
+Applicative functors are a natural way to capture side-effects that can be combined in parallel.
 
 ## Conclusion
 
 In this chapter, we covered a lot of new ideas:
 
-- We introduced the concept of an _applicative functor_ which generalizes the idea of function application to type constructors which capture some notion of side-effect.
-- We saw how applicative functors gave a solution to the problem of validating data structures, and how by switching the applicative functor we could change from reporting a single error to reporting all errors across a data structure.
+- We introduced the concept of an _applicative functor_ which generalizes the idea of function application to type constructors that captures some notion of side-effect.
+- We saw how applicative functors solved the problem of validating data structures and how by switching the applicative functor, we could change from reporting a single error to reporting all errors across a data structure.
 - We met the `Traversable` type class, which encapsulates the idea of a _traversable functor_, or a container whose elements can be used to combine values with side-effects.
 
-Applicative functors are an interesting abstraction which provide neat solutions to a number of problems. We will see them a few more times throughout the book. In this case, the validation applicative functor provided a way to write validators in a declarative style, allowing us to define _what_ our validators should validate and not _how_ they should perform that validation. In general, we will see that applicative functors are a useful tool for the design of _domain specific languages_.
+Applicative functors are an interesting abstraction that provides neat solutions to a number of problems. We will see them a few more times throughout the book. In this case, the validation applicative functor provided a way to write validators in a declarative style, allowing us to define _what_ our validators should validate and not _how_ they should perform that validation. In general, we will see that applicative functors are a useful tool for the design of _domain specific languages.
 
 In the next chapter, we will see a related idea, the class of _monads_, and extend our address book example to run in the browser!

--- a/text/chapter8.md
+++ b/text/chapter8.md
@@ -2,16 +2,16 @@
 
 ## Chapter Goals
 
-In the last chapter, we introduced applicative functors, an abstraction which we used to deal with _side-effects_: optional values, error messages and validation. This chapter will introduce another abstraction for dealing with side-effects in a more expressive way: _monads_.
+In the last chapter, we introduced applicative functors, an abstraction we used to deal with _side-effects_: optional values, error messages, and validation. This chapter will introduce another abstraction for dealing with side-effects more expressively: _monads_.
 
-The goal of this chapter is to explain why monads are a useful abstraction, and their connection with _do notation_.
+The goal of this chapter is to explain why monads are a useful abstraction and their connection with _do notation_.
 
 ## Project Setup
 
 The project adds the following dependencies:
 
-- `effect` - defines the `Effect` monad, the subject of the second half of the chapter. This dependency is often listed in every starter project (it's been a dependency of every chapter so far), so you'll rarely have to explicitly install it.
-- `react-basic-hooks` - a web framework that we will use for our Address Book app.
+- `effect` – defines the `Effect` monad, the subject of the second half of the chapter. This dependency is often listed in every starter project (it's been a dependency of every chapter so far), so you'll rarely have to install it explicitly.
+- `react-basic-hooks` – a web framework we will use for our Address Book app.
 
 ## Monads and Do Notation
 
@@ -21,9 +21,9 @@ Consider the following example. Suppose we throw two dice and want to count the 
 
 - _Choose_ the value `x` of the first throw.
 - _Choose_ the value `y` of the second throw.
-- If the sum of `x` and `y` is `n` then return the pair `[x, y]`, else fail.
+- If the sum of `x` and `y` is `n`, return the pair `[x, y]`, else fail.
 
-Array comprehensions allow us to write this non-deterministic algorithm in a natural way:
+Array comprehensions allow us to write this non-deterministic algorithm naturally:
 
 ```hs
 import Prelude
@@ -48,7 +48,7 @@ We can see that this function works in PSCi:
 
 In the last chapter, we formed an intuition for the `Maybe` applicative functor, embedding PureScript functions into a larger programming language supporting _optional values_. In the same way, we can form an intuition for the _array monad_, embedding PureScript functions into a larger programming language supporting _non-deterministic choice_.
 
-In general, a _monad_ for some type constructor `m` provides a way to use do notation with values of type `m a`. Note that in the array comprehension above, every line contains a computation of type `Array a` for some type `a`. In general, every line of a do notation block will contain a computation of type `m a` for some type `a` and our monad `m`. The monad `m` must be the same on every line (i.e. we fix the side-effect), but the types `a` can differ (i.e. individual computations can have different result types).
+Generally, a _monad_ for some type constructor `m` provides a way to use do notation with values of type `m a`. Note that in the array comprehension above, every line contains a computation of type `Array a` for some type `a`. In general, every line of a do notation block will contain a computation of type `m a` for some type `a` and our monad `m`. The monad `m` must be the same on every line (i.e., we fix the side-effect), but the types `a` can differ (i.e., individual computations can have different result types).
 
 Here is another example of do notation, this time applied to the type constructor `Maybe`. Suppose we have some type `XML` representing XML nodes, and a function
 
@@ -56,9 +56,9 @@ Here is another example of do notation, this time applied to the type constructo
 child :: XML -> String -> Maybe XML
 ```
 
-which looks for a child element of a node, and returns `Nothing` if no such element exists.
+Which looks for a child element of a node and returns `Nothing` if no such element exists.
 
-In this case, we can look for a deeply-nested element by using do notation. Suppose we wanted to read a user's city from a user profile which had been encoded as an XML document:
+In this case, we can look for a deeply-nested element using do notation. Suppose we wanted to read a user's city from a user profile that had been encoded as an XML document:
 
 ```hs
 userCity :: XML -> Maybe XML
@@ -69,7 +69,7 @@ userCity root = do
   pure city
 ```
 
-The `userCity` function looks for a child element `profile`, an element `address` inside the `profile` element, and finally an element `city` inside the `address` element. If any of these elements are missing, the return value will be `Nothing`. Otherwise, the return value is constructed using `Just` from the `city` node.
+The `userCity` function looks for a child element `profile`, an element `address` inside the `profile` element, and finally, an element `city` inside the `address` element. If any of these elements are missing, the return value will be `Nothing`. Otherwise, the return value is constructed using `Just` from the `city` node.
 
 Remember, the `pure` function in the last line is defined for every `Applicative` functor. Since `pure` is defined as `Just` for the `Maybe` applicative functor, it would be equally valid to change the last line to `Just city`.
 
@@ -86,7 +86,7 @@ class (Applicative m, Bind m) <= Monad m
 
 The key function here is `bind`, defined in the `Bind` type class. Just like for the `<$>` and `<*>` operators in the `Functor` and `Apply` type classes, the Prelude defines an infix alias `>>=` for the `bind` function.
 
-The `Monad` type class extends `Bind` with the operations of the `Applicative` type class that we have already seen.
+The `Monad` type class extends `Bind` with the operations of the `Applicative` type class we've already seen.
 
 It will be useful to see some examples of the `Bind` type class. A sensible definition for `Bind` on arrays can be given as follows:
 
@@ -107,7 +107,7 @@ instance Bind Maybe where
 
 This definition confirms the intuition that missing values are propagated through a do notation block.
 
-Let's see how the `Bind` type class is related to do notation. Consider a simple do notation block which starts by binding a value from the result of some computation:
+Let's see how the `Bind` type class is related to do notation. Consider a simple do notation block that starts by binding a value from the result of some computation:
 
 ```hs
 do value <- someComputation
@@ -139,7 +139,7 @@ userCity root =
         pure city
 ```
 
-It is worth noting that code expressed using do notation is often much clearer than the equivalent code using the `>>=` operator. However, writing binds explicitly using `>>=` can often lead to opportunities to write code in _point-free_ form - but the usual warnings about readability apply.
+Notably, code expressed using do notation is often much clearer than the equivalent code using the `>>=` operator. However, writing binds explicitly using `>>=` can often lead to opportunities to write code in _point-free_ form – but the usual warnings about readability apply.
 
 ## Monad Laws
 
@@ -188,11 +188,11 @@ c2 = do
   m3
 ```
 
-Each of these computations involves three monadic expression `m1`, `m2` and `m3`. In each case, the result of `m1` is eventually bound to the name `x`, and the result of `m2` is bound to the name `y`.
+Each of these computations involves three monadic expressions `m1`, `m2`, and `m3`. In each case, the result of `m1` is eventually bound to the name `x`, and the result of `m2` is bound to the name `y`.
 
 In `c1`, the two expressions `m1` and `m2` are grouped into their own do notation block.
 
-In `c2`, all three expressions `m1`, `m2` and `m3` appear in the same do notation block.
+In `c2`, all three expressions `m1`, `m2`, and `m3` appear in the same do notation block.
 
 The associativity law tells us that it is safe to simplify nested do notation blocks in this way.
 
@@ -208,9 +208,9 @@ c3 = do
 
 ## Folding With Monads
 
-As an example of working with monads abstractly, this section will present a function which works with any type constructor in the `Monad` type class. This should serve to solidify the intuition that monadic code corresponds to programming "in a larger language" with side-effects, and also illustrate the generality which programming with monads brings.
+As an example of working with monads abstractly, this section will present a function that works with any type constructor in the `Monad` type class. This should solidify the intuition that monadic code corresponds to programming "in a larger language" with side-effects, and also illustrate the generality which programming with monads brings.
 
-The function we will write is called `foldM`. It generalizes the `foldl` function that we met earlier to a monadic context. Here is its type signature:
+The function we will write is called `foldM`. It generalizes the `foldl` function we met earlier to a monadic context. Here is its type signature:
 
 ```hs
 foldM :: forall m a b. Monad m => (a -> b -> m a) -> a -> List b -> m a
@@ -221,9 +221,9 @@ Notice that this is the same as the type of `foldl`, except for the appearance o
 
 Intuitively, `foldM` performs a fold over a list in some context supporting some set of side-effects.
 
-For example, if we picked `m` to be `Maybe`, then our fold would be allowed to fail by returning `Nothing` at any stage - every step returns an optional result, and the result of the fold is therefore also optional.
+For example, if we picked `m` to be `Maybe`, then our fold would be allowed to fail by returning `Nothing` at any stage – every step returns an optional result, and the result of the fold is therefore also optional.
 
-If we picked `m` to be the `Array` type constructor, then every step of the fold would be allowed to return zero or more results, and the fold would proceed to the next step independently for each result. At the end, the set of results would consist of all folds over all possible paths. This corresponds to a traversal of a graph!
+If we picked `m` to be the `Array` type constructor, then every step of the fold would be allowed to return zero or more results, and the fold would proceed to the next step independently for each result. In the end, the set of results would consist of all folds over all possible paths. This corresponds to a traversal of a graph!
 
 To write `foldM`, we can simply break the input list into cases.
 
@@ -245,9 +245,9 @@ foldM f a (b : bs) = do
   foldM f a' bs
 ```
 
-Note that this implementation is almost identical to that of `foldl` on lists, with the exception of do notation.
+Note that this implementation is almost identical to that of `foldl` on lists, except for do notation.
 
-We can define and test this function in PSCi. Here is an example - suppose we defined a "safe division" function on integers, which tested for division by zero and used the `Maybe` type constructor to indicate failure:
+We can define and test this function in PSCi. Here is an example – suppose we defined a "safe division" function on integers, which tested for division by zero and used the `Maybe` type constructor to indicate failure:
 
 ```hs
 {{#include ../exercises/chapter8/test/Examples.purs:safeDivide}}
@@ -266,7 +266,7 @@ Then we can use `foldM` to express iterated safe division:
 Nothing
 ```
 
-The `foldM safeDivide` function returns `Nothing` if a division by zero was attempted at any point. Otherwise it returns the result of repeatedly dividing the accumulator, wrapped in the `Just` constructor.
+The `foldM safeDivide` function returns `Nothing` if a division by zero was attempted at any point. Otherwise, it returns the result of repeatedly dividing the accumulator, wrapped in the `Just` constructor.
 
 ## Monads and Applicatives
 
@@ -284,11 +284,11 @@ ap mf ma = do
 
 If `m` is a law-abiding member of the `Monad` type class, then there is a valid `Apply` instance for `m` given by `ap`.
 
-The interested reader can check that `ap` agrees with `apply` for the monads we have already encountered: `Array`, `Maybe` and `Either e`.
+The interested reader can check that `ap` agrees with `apply` for the monads we have already encountered: `Array`, `Maybe`, and `Either e`.
 
 If every monad is also an applicative functor, then we should be able to apply our intuition for applicative functors to every monad. In particular, we can reasonably expect a monad to correspond, in some sense, to programming "in a larger language" augmented with some set of additional side-effects. We should be able to lift functions of arbitrary arities, using `map` and `apply`, into this new language.
 
-But monads allow us to do more than we could do with just applicative functors, and the key difference is highlighted by the syntax of do notation. Consider the `userCity` example again, in which we looked for a user's city in an XML document which encoded their user profile:
+But monads allow us to do more than we could do with just applicative functors, and the key difference is highlighted by the syntax of do notation. Consider the `userCity` example again, in which we looked for a user's city in an XML document that encoded their user profile:
 
 ```hs
 userCity :: XML -> Maybe XML
@@ -303,11 +303,11 @@ Do notation allows the second computation to depend on the result `prof` of the 
 
 Try writing `userCity` using only `pure` and `apply`: you will see that it is impossible. Applicative functors only allow us to lift function arguments which are independent of each other, but monads allow us to write computations which involve more interesting data dependencies.
 
-In the last chapter, we saw that the `Applicative` type class can be used to express parallelism. This was precisely because the function arguments being lifted were independent of one another. Since the `Monad` type class allows computations to depend on the results of previous computations, the same does not apply - a monad has to combine its side-effects in sequence.
+In the last chapter, we saw that the `Applicative` type class can be used to express parallelism. This was precisely because the function arguments being lifted were independent of one another. Since the `Monad` type class allows computations to depend on the results of previous computations, the same does not apply – a monad has to combine its side-effects in sequence.
 
 ## Exercises
 
- 1. (Easy) Write a function `third` which returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type. _Hint:_ Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `arrays` package. Use do notation with the `Maybe` monad to combine these functions.
+ 1. (Easy) Write a function `third` that returns the third element of an array with three or more elements. Your function should return an appropriate `Maybe` type. _Hint:_ Look up the types of the `head` and `tail` functions from the `Data.Array` module in the `arrays` package. Use do notation with the `Maybe` monad to combine these functions.
  1. (Medium) Write a function `possibleSums` which uses `foldM` to determine all possible totals that could be made using a set of coins. The coins will be specified as an array which contains the value of each coin. Your function should have the following result:
 
      ```text
@@ -318,7 +318,7 @@ In the last chapter, we saw that the `Applicative` type class can be used to exp
      [0,1,2,3,10,11,12,13]
      ```
 
-     _Hint_: This function can be written as a one-liner using `foldM`. You might want to use the `nub` and `sort` functions to remove duplicates and sort the result respectively.
+     _Hint_: This function can be written as a one-liner using `foldM`. You might want to use the `nub` and `sort` functions to remove duplicates and sort the result.
  1. (Medium) Confirm that the `ap` function and the `apply` operator agree for the `Maybe` monad. _Note:_ There are no tests for this exercise.
  1. (Medium) Verify that the monad laws hold for the `Monad` instance for the `Maybe` type, as defined in the `maybe` package. _Note:_ There are no tests for this exercise.
  1. (Medium) Write a function `filterM` which generalizes the `filter` function on lists. Your function should have the following type signature:
@@ -341,7 +341,7 @@ In the last chapter, we saw that the `Applicative` type class can be used to exp
      lift2 f (pure a) (pure b) = pure (f a b)
      ```
 
-     where the `Apply` instance uses the `ap` function defined above. Recall that `lift2` was defined as follows:
+     Where the `Apply` instance uses the `ap` function defined above. Recall that `lift2` was defined as follows:
 
      ```hs
      lift2 :: forall f a b c. Apply f => (a -> b -> c) -> f a -> f b -> f c
@@ -352,11 +352,11 @@ In the last chapter, we saw that the `Applicative` type class can be used to exp
 
 ## Native Effects
 
-We will now look at one particular monad which is of central importance in PureScript - the `Effect` monad.
+We will now look at one particular monad of central importance in PureScript – the `Effect` monad.
 
 The `Effect` monad is defined in the `Effect` module. It is used to manage so-called _native_ side-effects. If you are familiar with Haskell, it is the equivalent of the `IO` monad.
 
-What are native side-effects? They are the side-effects which distinguish JavaScript expressions from idiomatic PureScript expressions, which typically are free from side-effects. Some examples of native effects are:
+What are native side-effects? They are the side-effects that distinguish JavaScript expressions from idiomatic PureScript expressions, which typically are free from side-effects. Some examples of native effects are:
 
 - Console IO
 - Random number generation
@@ -376,26 +376,27 @@ We have already seen plenty of examples of "non-native" side-effects:
 - Errors, as represented by the `Either` data type
 - Multi-functions, as represented by arrays or lists
 
-Note that the distinction is subtle. It is true, for example, that an error message is a possible side-effect of a JavaScript expression, in the form of an exception. In that sense, exceptions do represent native side-effects, and it is possible to represent them using `Effect`. However, error messages implemented using `Either` are not a side-effect of the JavaScript runtime, and so it is not appropriate to implement error messages in that style using `Effect`. So it is not the effect itself which is native, but rather how it is implemented at runtime.
+Note that the distinction is subtle. It is true, for example, that an error message is a possible side-effect of a JavaScript expression in the form of an exception. In that sense, exceptions do represent native side-effects, and it is possible to represent them using `Effect`. However, error messages implemented using `Either` are not a side-effect of the JavaScript runtime, and so it is not appropriate to implement error messages in that style using `Effect`. So it is not the effect itself, which is native, but rather how it is implemented at runtime.
 
 ## Side-Effects and Purity
 
-In a pure language like PureScript, one question which presents itself is: without side-effects, how can one write useful real-world code?
+In a pure language like PureScript, one question presents itself: without side-effects, how can one write useful real-world code?
 
-The answer is that PureScript does not aim to eliminate side-effects. It aims to represent side-effects in such a way that pure computations can be distinguished from computations with side-effects in the type system. In this sense, the language is still pure.
+The answer is that PureScript does not aim to eliminate side-effects but to represent them in such a way that pure computations can be distinguished from computations with side-effects in the type system. In this sense, the language is still pure.
 
-Values with side-effects have different types from pure values. As such, it is not possible to pass a side-effecting argument to a function, for example, and have side-effects performed unexpectedly.
+Values with side-effects have different types from pure values. As such, it is impossible to pass a side-effecting argument to a function, for example, and have side-effects performed unexpectedly.
 
-The only way in which side-effects managed by the `Effect` monad will be presented is to run a computation of type `Effect a` from JavaScript.
+The only way side-effects managed by the `Effect` monad will be presented is to run a computation of type `Effect a` from JavaScript.
 
-The Spago build tool (and other tools) provide a shortcut, by generating additional JavaScript to invoke the `main` computation when the application starts. `main` is required to be a computation in the `Effect` monad.
+The Spago build tool (and other tools) provide a shortcut by generating additional JavaScript to invoke the `main` computation when the application starts. `main` is required to be a computation in the `Effect` monad.
 
 ## The Effect Monad
 
 The `Effect` monad provides a well-typed API for computations with side-effects, while at the same time generating efficient JavaScript.
 
-Let's take a closer look at the return type of the familiar `log` function. `Effect` indicates that this function produces a native effect, console IO in this case.
-`Unit` indicates that no _meaningful_ data is returned. You can think of `Unit` as being analogous to the `void` keyword in other languages, such as C, Java, etc.
+Let's look at the return type of the familiar `log` function. `Effect` indicates that this function produces a native effect, console IO in this case.
+
+`Unit` indicates that no _meaningful_ data is returned. You can think of `Unit` as analogous to the `void` keyword in other languages, such as C, Java, etc.
 
 ```hs
 log :: String -> Effect Unit
@@ -434,15 +435,15 @@ spago run --main Test.Random
 
 You should see a randomly chosen number between `0.0` and `1.0` printed to the console.
 
-> _Aside:_ `spago run` defaults to searching in the `Main` module for a `main` function. You may also specify an alternate module as an entry point with the `--main` flag, as is done in the above example. Just be sure that this alternate module also contains a `main` function.
+> _Aside:_ `spago run` defaults to searching in the `Main` module for a `main` function. You may also specify an alternate module as an entry point with the `--main` flag, as in the above example. Just be sure that this alternate module also contains a `main` function.
 
 Note that it's also possible to generate "random" (technically pseudorandom) data without resorting to impure effectful code. We'll cover these techniques in the "Generative Testing" chapter.
 
-As mentioned previously, the `Effect` monad is of central importance to PureScript. The reason why it's central is because it is the conventional way to interoperate with PureScript's `Foreign Function Interface`, which provides the mechanism to execute a program and perform side effects. While it's desireable to avoid using the `Foreign Function Interface`, it's fairly critical to understand how it works and how to use it, so I recommend reading that chapter before doing any serious PureScript work. That said, the `Effect` monad is fairly simple. It has a few helper functions, but aside from that it doesn't do much except encapsulate side effects.
+As mentioned previously, the `Effect` monad is of central importance to PureScript. The reason why it's central is that it is the conventional way to interoperate with PureScript's `Foreign Function Interface`, which provides the mechanism to execute a program and perform side effects. While it's desirable to avoid using the `Foreign Function Interface`, it's fairly critical to understand how it works and how to use it, so I recommend reading that chapter before doing any serious PureScript work. That said, the `Effect` monad is fairly simple. It has a few helper functions but doesn't do much except encapsulate side effects.
 
 ## Exceptions
 
-Let's examine a function from the `node-fs` package that involves two _native_ side effects: reading mutable state, and exceptions:
+Let's examine a function from the `node-fs` package that involves two _native_ side effects: reading mutable state and exceptions:
 
 ```hs
 readTextFile :: Encoding -> String -> Effect String
@@ -490,7 +491,7 @@ main = do
 try :: forall a. Effect a -> Effect (Either Error a)
 ```
 
-We can also generate our own exceptions. Here is an alternative implementation of `Data.List.head` which throws an exception if the list is empty, rather than returning a `Maybe` value of `Nothing`.
+We can also generate our own exceptions. Here is an alternative implementation of `Data.List.head` that throws an exception if the list is empty rather than returning a `Maybe` value of `Nothing`.
 
 ```hs
 exceptionHead :: List Int -> Effect Int
@@ -519,9 +520,9 @@ write :: forall a r. a -> STRef r a -> ST r a
 modify :: forall r a. (a -> a) -> STRef r a -> ST r a
 ```
 
-`new` is used to create a new mutable reference cell of type `STRef r a`, which can be read using the `read` action, and modified using the `write` and `modify` actions. The type `a` is the type of the value stored in the cell, and the type `r` is used to indicate a _memory region_ (or _heap_) in the type system.
+`new` is used to create a new mutable reference cell of type `STRef r a`, which can be read using the `read` action and modified using the `write` and `modify` actions. The type `a` is the type of the value stored in the cell, and the type `r` is used to indicate a _memory region_ (or _heap_) in the type system.
 
-Here is an example. Suppose we want to simulate the movement of a particle falling under gravity by iterating a simple update function over a large number of small time steps.
+Here is an example. Suppose we want to simulate the movement of a particle falling under gravity by iterating a simple update function over many small time steps.
 
 We can do this by creating a mutable reference cell to hold the position and velocity of the particle, and then using a `for` loop to update the value stored in that cell:
 
@@ -546,9 +547,9 @@ simulate x0 v0 time = do
   pure final.x
 ```
 
-At the end of the computation, we read the final value of the reference cell, and return the position of the particle.
+At the end of the computation, we read the final value of the reference cell and return the position of the particle.
 
-Note that even though this function uses mutable state, it is still a pure function, so long as the reference cell `ref` is not allowed to be used by other parts of the program. We will see that this is exactly what the `ST` effect disallows.
+Note that even though this function uses a mutable state, it is still a pure function, so long as the reference cell `ref` is not allowed to be used by other program parts. We will see that this is exactly what the `ST` effect disallows.
 
 To run a computation with the `ST` effect, we have to use the `run` function:
 
@@ -558,7 +559,7 @@ run :: forall a. (forall r. ST r a) -> a
 
 The thing to notice here is that the region type `r` is quantified _inside the parentheses_ on the left of the function arrow. That means that whatever action we pass to `run` has to work with _any region_ `r` whatsoever.
 
-However, once a reference cell has been created by `new`, its region type is already fixed, so it would be a type error to try to use the reference cell outside the code delimited by `run`.  This is what allows `run` to safely remove the `ST` effect, and turn `simulate` into a pure function!
+However, once a reference cell has been created by `new`, its region type is already fixed, so it would be a type error to try to use the reference cell outside the code delimited by `run`.  This allows `run` to safely remove the `ST` effect and turn `simulate` into a pure function!
 
 ```hs
 simulate' :: Number -> Number -> Int -> Number
@@ -605,7 +606,7 @@ simulate x0 v0 time =
     pure final.x
 ```
 
-then the compiler will notice that the reference cell is not allowed to escape its scope, and can safely turn `ref` into a `var`. Here is the generated JavaScript for `simulate` inlined with `run`:
+Then the compiler will notice that the reference cell cannot escape its scope and can safely turn `ref` into a `var`. Here is the generated JavaScript for `simulate` inlined with `run`:
 
 ```javascript
 var simulate = function (x0) {
@@ -632,7 +633,7 @@ var simulate = function (x0) {
 };
 ```
 
-Note that this resulting JavaScript is not as optimal as it could be. See [this issue](https://github.com/purescript-contrib/purescript-book/issues/121) for more details. The above snippet should be updated once that issue is resolved.
+> Note that this resulting JavaScript is not as optimal as it could be. See [this issue](https://github.com/purescript-contrib/purescript-book/issues/121) for more details. The above snippet should be updated once that issue is resolved.
 
 For comparison, this is the generated JavaScript of the non-inlined form:
 
@@ -661,7 +662,7 @@ var simulate = function (x0) {
 };
 ```
 
-The `ST` effect is a good way to generate short JavaScript when working with locally-scoped mutable state, especially when used together with actions like `for`, `foreach`, and `while` which generate efficient loops.
+The `ST` effect is a good way to generate short JavaScript when working with locally-scoped mutable state, especially when used together with actions like `for`, `foreach`, and `while`, which generate efficient loops.
 
 ## Exercises
 
@@ -673,17 +674,17 @@ The `ST` effect is a good way to generate short JavaScript when working with loc
 
 In the final sections of this chapter, we will apply what we have learned about effects in the `Effect` monad to the problem of working with the DOM.
 
-There are a number of PureScript packages for working directly with the DOM, or with open-source DOM libraries. For example:
+There are several PureScript packages for working directly with the DOM or open-source DOM libraries. For example:
 
-- [`web-dom`](https://github.com/purescript-web/purescript-web-dom) provides type definitions and low level interface implementations for the W3C DOM spec.
-- [`web-html`](https://github.com/purescript-web/purescript-web-html) provides type definitions and low level interface implementations for the W3C HTML5 spec.
+- [`web-dom`](https://github.com/purescript-web/purescript-web-dom) provides type definitions and low-level interface implementations for the W3C DOM spec.
+- [`web-html`](https://github.com/purescript-web/purescript-web-html) provides type definitions and low-level interface implementations for the W3C HTML5 spec.
 - [`jquery`](https://github.com/paf31/purescript-jquery) is a set of bindings to the [jQuery](http://jquery.org) library.
 
-There are also PureScript libraries which build abstractions on top of these libraries, such as
+There are also PureScript libraries that build abstractions on top of these libraries, such as
 
-- [`thermite`](https://github.com/paf31/purescript-thermite), which builds on [`react`](https://github.com/purescript-contrib/purescript-react)
-- [`react-basic-hooks`](https://github.com/megamaddu/purescript-react-basic-hooks), which builds on [`react-basic`](https://github.com/lumihq/purescript-react-basic)
-- [`halogen`](https://github.com/purescript-halogen/purescript-halogen) which provides a type-safe set of abstractions on top of a custom virtual DOM library.
+- [`thermite`](https://github.com/paf31/purescript-thermite) builds on [`react`](https://github.com/purescript-contrib/purescript-react)
+- [`react-basic-hooks`](https://github.com/megamaddu/purescript-react-basic-hooks) builds on [`react-basic`](https://github.com/lumihq/purescript-react-basic)
+- [`halogen`](https://github.com/purescript-halogen/purescript-halogen) provides a type-safe set of abstractions on top of a custom virtual DOM library.
 
 In this chapter, we will use the `react-basic-hooks` library to add a user interface to our address book application, but the interested reader is encouraged to explore alternative approaches.
 
@@ -693,7 +694,7 @@ Using the `react-basic-hooks` library, we will define our application as a React
 
 A full tutorial for the React library is well beyond the scope of this chapter, but the reader is encouraged to consult its documentation where needed. For our purposes, React will provide a practical example of the `Effect` monad.
 
-We are going to build a form which will allow a user to add a new entry into our address book. The form will contain text boxes for the various fields (first name, last name, city, state, etc.), and an area in which validation errors will be displayed. As the user types text into the text boxes, the validation errors will be updated.
+We are going to build a form that will allow a user to add a new entry into our address book. The form will contain text boxes for the various fields (first name, last name, city, state, etc.) and an area where validation errors will be displayed. As the user types text into the text boxes, the validation errors will be updated.
 
 To keep things simple, the form will have a fixed shape: the different phone number types (home, cell, work, other) will be expanded into separate text boxes.
 
@@ -707,9 +708,9 @@ $ npx parcel src/index.html --open
 
 If development tools such as `spago` and `parcel` are installed globally, then the `npx` prefix may be omitted. You have likely already installed `spago` globally with `npm i -g spago`, and the same can be done for `parcel`.
 
-`parcel` should launch a browser window with our "Address Book" app. If you keep the `parcel` terminal open, and rebuild with `spago` in another terminal, the page should automatically refresh with your latest edits. You can also configure automatic rebuilds (and therefore automatic page refresh) on file-save if you're using an [editor](https://github.com/purescript/documentation/blob/master/ecosystem/Editor-and-tool-support.md#editors) that supports [`purs ide`](https://github.com/purescript/purescript/tree/master/psc-ide) or are running [`pscid`](https://github.com/kRITZCREEK/pscid).
+`parcel` should launch a browser window with our "Address Book" app. If you keep the `parcel` terminal open and rebuild with `spago` in another terminal, the page should automatically refresh with your latest edits. You can also configure automatic rebuilds (and therefore automatic page refresh) on file-save if you're using an [editor](https://github.com/purescript/documentation/blob/master/ecosystem/Editor-and-tool-support.md#editors) that supports [`purs ide`](https://github.com/purescript/purescript/tree/master/psc-ide) or are running [`pscid`](https://github.com/kRITZCREEK/pscid).
 
-In this Address Book app, you should be able to enter some values into the form fields and see the validation errors printed onto the page.
+In this Address Book app, you can enter some values into the form fields and see the validation errors printed onto the page.
 
 Let's explore how it works.
 
@@ -758,7 +759,7 @@ ctr <- window >>= document >>= toNonElementParentNode >>> getElementById "contai
 
 It is a matter of personal preference whether the intermediate `w` and `doc` variables aid in readability.
 
-Let's dig into our AddressBook `reactComponent`. We'll start with a simplified component, and then build up to the actual code in `Main.purs`.
+Let's dig into our AddressBook `reactComponent`. We'll start with a simplified component and then build up to the actual code in `Main.purs`.
 
 Take a look at this minimal component. Feel free to substitute the full component with this one to see it run:
 
@@ -793,7 +794,7 @@ The props-to-JSX function is simply:
 
 `props` are ignored, `D.text` returns `JSX`, and `pure` lifts to rendered JSX. Now `component` has everything it needs to produce the `ReactComponent`.
 
-Next we'll examine some of the additional complexities of the full Address Book component.
+Next, we'll examine some of the additional complexities of the full Address Book component.
 
 These are the first few lines of our full component:
 
@@ -810,7 +811,7 @@ We track `person` as a piece of state with the `useState` hook.
 Tuple person setPerson <- useState examplePerson
 ```
 
-Note that you are free to break-up component state into multiple pieces of state with multiple calls to `useState`. For example, we could rewrite this app to use a separate piece of state for each record field of `Person`, but that happens to result in a slightly less convenient architecture in this case.
+Note that you are free to break-up component state into multiple pieces of state with multiple calls to `useState`. For example, we could rewrite this app to use a separate piece of state for each record field of `Person`, but that results in a slightly less convenient architecture in this case.
 
 In other examples, you may encounter the `/\` infix operator for `Tuple`. This is equivalent to the above line:
 
@@ -840,14 +841,14 @@ The specific type of `state` is determined by our initial default value. `Person
 
 `person` is how we access the current state at each rerender.
 
-`setPerson` is how we update the state. We simply provide a function that describes how to transform the current state to the new state. The record update syntax is perfect for this when the type of `state` happens to be a `Record`, for example:
+`setPerson` is how we update the state. We provide a function describing how to transform the current state into the new one. The record update syntax is perfect for this when the type of `state` happens to be a `Record`, for example:
 
 ```hs
 setPerson (\currentPerson -> currentPerson {firstName = "NewName"})
 
 ```
 
-or as shorthand:
+Or as shorthand:
 
 ```hs
 setPerson _ {firstName = "NewName"}
@@ -892,7 +893,7 @@ pure
       }
 ```
 
-Here we produce `JSX` which represents the intended state of the DOM. This JSX is typically created by applying functions corresponding to HTML tags (e.g. `div`, `form`, `h3`, `li`, `ul`, `label`, `input`) which create single HTML elements. These HTML elements are actually React components themselves, converted to JSX. There are usually three variants of each of these functions:
+Here we produce `JSX`, which represents the intended state of the DOM. This JSX is typically created by applying functions corresponding to HTML tags (e.g., `div`, `form`, `h3`, `li`, `ul`, `label`, `input`) which create single HTML elements. These HTML elements are React components themselves, converted to JSX. There are usually three variants of each of these functions:
 
 - `div_`: Accepts an array of child elements. Uses default attributes.
 - `div`: Accepts a `Record` of attributes. An array of child elements may be passed to the `children` field of this record.
@@ -936,7 +937,7 @@ For the first argument to `handler` we use `targetValue`, which provides the val
 targetValue :: EventFn SyntheticEvent (Maybe String)
 ```
 
-In JavaScript, the `input` element's `onChange` event is actually accompanied by a `String` value, but since strings in JavaScript can be null, `Maybe` is used for safety.
+In JavaScript, the `input` element's `onChange` event is accompanied by a `String` value, but since strings in JavaScript can be null, `Maybe` is used for safety.
 
 The second argument to `handler`, `(a -> Effect Unit)`, must therefore have this signature:
 
@@ -966,7 +967,7 @@ onChange: handler targetValue $ traverse_ setValue
 
 Feel free to investigate the definition of `traverse_` to see how both forms are indeed equivalent.
 
-That covers the basics of our component implementation. However, you should read the source accompanying this chapter in order to get a full understanding of the way the component works.
+That covers the basics of our component implementation. However, you should read the source accompanying this chapter to get a full understanding of the way the component works.
 
 Obviously, this user interface can be improved in a number of ways. The exercises will explore some ways in which we can make the application more usable.
 
@@ -975,12 +976,12 @@ Obviously, this user interface can be improved in a number of ways. The exercise
 Modify `src/Main.purs` in the following exercises. There are no unit tests for these exercises.
 
 1. (Easy) Modify the application to include a work phone number text box.
-1. (Medium) Right now the application shows validation errors collected in a single "pink-alert" background.  Modify to give each validation error its own pink-alert background by separating them  with blank lines.
+1. (Medium) Right now, the application shows validation errors collected in a single "pink-alert" background.  Modify to give each validation error its own pink-alert background by separating them with blank lines.
 
     _Hint_: Instead of using a `ul` element to show the validation errors in a list, modify the code to create one `div` with the `alert` and `alert-danger` styles for each error.
 1. (Difficult, Extended) One problem with this user interface is that the validation errors are not displayed next to the form fields they originated from. Modify the code to fix this problem.
 
-    _Hint_: the error type returned by the validator should be extended to indicate which field caused the error. You might want to use the following modified `Errors` type:
+    _Hint_: The error type returned by the validator should be extended to indicate which field caused the error. You might want to use the following modified `Errors` type:
 
     ```hs
     data Field = FirstNameField
@@ -995,17 +996,17 @@ Modify `src/Main.purs` in the following exercises. There are no unit tests for t
     type Errors = Array ValidationError
     ```
 
-    You will need to write a function which extracts the validation error for a particular `Field` from the `Errors` structure.
+    You will need to write a function that extracts the validation error for a particular `Field` from the `Errors` structure.
 
 ## Conclusion
 
 This chapter has covered a lot of ideas about handling side-effects in PureScript:
 
-- We met the `Monad` type class, and its connection to do notation.
-- We introduced the monad laws, and saw how they allow us to transform code written using do notation.
-- We saw how monads can be used abstractly, to write code which works with different side-effects.
+- We met the `Monad` type class and its connection to do notation.
+- We introduced the monad laws and saw how they allow us to transform code written using do notation.
+- We saw how monads can be used abstractly to write code that works with different side-effects.
 - We saw how monads are examples of applicative functors, how both allow us to compute with side-effects, and the differences between the two approaches.
-- The concept of native effects was defined, and we met the `Effect` monad, which is used to handle native side-effects.
+- The concept of native effects was defined, and we met the `Effect` monad, which handles native side-effects.
 - We used the `Effect` monad to handle a variety of effects: random number generation, exceptions, console IO, mutable state, and DOM manipulation using React.
 
 The `Effect` monad is a fundamental tool in real-world PureScript code. It will be used in the rest of the book to handle side-effects in a number of other use-cases.

--- a/text/chapter9.md
+++ b/text/chapter9.md
@@ -2,7 +2,7 @@
 
 ## Chapter Goals
 
-This chapter focuses on the `Aff` monad, which is similar to the `Effect` monad, but represents _asynchronous_ side-effects. We'll demonstrate examples of asynchronously interacting with the filesystem and making HTTP requests. We'll also cover how to manage sequential and parallel execution of asynchronous effects.
+This chapter focuses on the `Aff` monad, which is similar to the `Effect` monad, but represents _asynchronous_ side-effects. We'll demonstrate examples of asynchronously interacting with the filesystem and making HTTP requests. We'll also cover managing sequential and parallel execution of asynchronous effects.
 
 ## Project Setup
 
@@ -13,7 +13,7 @@ New PureScript libraries introduced in this chapter are:
 - `affjax` - HTTP requests with AJAX and `Aff`.
 - `parallel` - parallel execution of `Aff`.
 
-When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module, which is listed as dependency in the `package.json` of this chapter. Install that by running:
+When running outside of the browser (such as in our Node.js environment), the `affjax` library requires the `xhr2` NPM module, which is listed as a dependency in the `package.json` of this chapter. Install that by running:
 
 ```shell
 $ npm install
@@ -39,7 +39,7 @@ copyFile('file1.txt', 'file2.txt')
 });
 ```
 
-It is also possible to use callbacks or synchronous functions, but those are less desireable because:
+It is also possible to use callbacks or synchronous functions, but those are less desirable because:
 
 - Callbacks lead to excessive nesting, known as "Callback Hell" or the "Pyramid of Doom".
 - Synchronous functions block execution of the other code in your app.
@@ -54,9 +54,9 @@ The `Aff` monad in PureScript offers similar ergonomics of JavaScript's `async`/
 
 Note that we have to use `launchAff_` to convert the `Aff` to `Effect` because `main` must be `Effect Unit`.
 
-It is also possible to re-write the above snippet using callbacks or synchronous functions (for example with `Node.FS.Async` and `Node.FS.Sync` respectively), but those share the same downsides as discussed earlier with JavaScript, and so that coding style is not recommended.
+It is also possible to re-write the above snippet using callbacks or synchronous functions (for example, with `Node.FS.Async` and `Node.FS.Sync`, respectively), but those share the same downsides as discussed earlier with JavaScript, so that coding style is not recommended.
 
-The syntax for working with `Aff` is very similar to working with `Effect`. They are both monads, and can therefore be written with do notation.
+The syntax for working with `Aff` is very similar to working with `Effect`. They are both monads and can therefore be written with do notation.
 
 For example, if we look at the signature of `readTextFile`, we see that it returns the file contents as a `String` wrapped in `Aff`:
 
@@ -86,15 +86,15 @@ You should hopefully be able to draw on your knowledge of concepts from previous
 
 ## Exercises
 
- 1. (Easy) Write a `concatenateFiles` function which concatenates two text files.
+ 1. (Easy) Write a `concatenateFiles` function that concatenates two text files.
 
- 1. (Medium) Write a function `concatenateMany` to concatenate multiple text files, given an array of input file names and an output file name. _Hint_: use `traverse`.
+ 1. (Medium) Write a function `concatenateMany` to concatenate multiple text files, given an array of input and output file names. _Hint_: use `traverse`.
 
  1. (Medium) Write a function `countCharacters :: FilePath -> Aff (Either Error Int)` that returns the number of characters in a file, or an error if one is encountered.
 
 ## Additional Aff Resources
 
-If you haven't already taken a look at the [official Aff guide](https://pursuit.purescript.org/packages/purescript-aff/), skim through that now. It's not a direct prerequisite for completing the remaining exercises in this chapter, but you may find it helpful to lookup some functions on Pursuit.
+If you haven't already looked at the [official Aff guide](https://pursuit.purescript.org/packages/purescript-aff/), skim through that now. It's not a direct prerequisite for completing the remaining exercises in this chapter, but you may find it helpful to lookup some functions on Pursuit.
 
 You're also welcome to consult these supplemental resources too, but again, the exercises in this chapter don't depend on them:
 
@@ -103,8 +103,9 @@ You're also welcome to consult these supplemental resources too, but again, the 
 
 ## A HTTP Client
 
-The `affjax` library offers a convenient way to make asynchronous AJAX HTTP requests with `Aff`. Depending on what environment you are targeting you need to use either the [purescript-affjax-web](https://github.com/purescript-contrib/purescript-affjax-web) or the [purescript-affjax-node](https://github.com/purescript-contrib/purescript-affjax-node) library.
-In the rest of this chapter we will be targeting node and thus using `purescript-affjax-node`.
+The `affjax` library offers a convenient way to make asynchronous AJAX HTTP requests with `Aff`. Depending on what environment you are targeting, you need to use either the [purescript-affjax-web](https://github.com/purescript-contrib/purescript-affjax-web) or the [purescript-affjax-node](https://github.com/purescript-contrib/purescript-affjax-node) library.
+
+In the rest of this chapter, we will be targeting node and thus using `purescript-affjax-node`.
 Consult the [Affjax docs](https://pursuit.purescript.org/packages/purescript-affjax) for more usage information. Here is an example that makes HTTP GET requests at a provided URL and returns the response body or an error message:
 
 ```hs
@@ -138,7 +139,7 @@ unit
 
 We've seen how to use the `Aff` monad and do notation to compose asynchronous computations in sequence. It would also be useful to be able to compose asynchronous computations _in parallel_. With `Aff`, we can compute in parallel simply by initiating our two computations one after the other.
 
-The `parallel` package defines a type class `Parallel` for monads like `Aff` which support parallel execution. When we met applicative functors earlier in the book, we observed how applicative functors can be useful for combining parallel computations. In fact, an instance for `Parallel` defines a correspondence between a monad `m` (such as `Aff`) and an applicative functor `f` which can be used to combine computations in parallel:
+The `parallel` package defines a type class `Parallel` for monads like `Aff`, which support parallel execution. When we met applicative functors earlier in the book, we observed how applicative functors can be useful for combining parallel computations. In fact, an instance for `Parallel` defines a correspondence between a monad `m` (such as `Aff`) and an applicative functor `f` that can be used to combine computations in parallel:
 
 ```hs
 class (Monad m, Applicative f) <= Parallel f m | m -> f, f -> m where
@@ -151,11 +152,11 @@ The class defines two functions:
 - `parallel`, which takes computations in the monad `m` and turns them into computations in the applicative functor `f`, and
 - `sequential`, which performs a conversion in the opposite direction.
 
-The `aff` library provides a `Parallel` instance for the `Aff` monad. It uses mutable references to combine `Aff` actions in parallel, by keeping track of which of the two continuations has been called. When both results have been returned, we can compute the final result and pass it to the main continuation.
+The `aff` library provides a `Parallel` instance for the `Aff` monad. It uses mutable references to combine `Aff` actions in parallel by keeping track of which of the two continuations has been called. When both results have been returned, we can compute the final result and pass it to the main continuation.
 
 Because applicative functors support lifting of functions of arbitrary arity, we can perform more computations in parallel by using the applicative combinators. We can also benefit from all of the standard library functions which work with applicative functors, such as `traverse` and `sequence`!
 
-We can also combine parallel computations with sequential portions of code, by using applicative combinators in a do notation block, or vice versa, using `parallel` and `sequential` to change type constructors where appropriate.
+We can also combine parallel computations with sequential portions of code by using applicative combinators in a do notation block, or vice versa, using `parallel` and `sequential` to change type constructors where appropriate.
 
 To demonstrate the difference between sequential and parallel execution, we'll create an array of 100 10-millisecond delays, then execute those delays with both techniques.
 You'll notice in the repl that `seqDelay` is much slower than `parDelay`.
@@ -199,13 +200,13 @@ A full listing of available parallel functions can be found in the [`parallel` d
 
 ## Exercises
 
-1. (Easy) Write a `concatenateManyParallel` function which has the same signature as the earlier `concatenateMany` function, but reads all input files in parallel.
+1. (Easy) Write a `concatenateManyParallel` function with the same signature as the earlier `concatenateMany` function but reads all input files in parallel.
 
 1. (Medium) Write a `getWithTimeout :: Number -> String -> Aff (Maybe String)` function which makes an HTTP `GET` request at the provided URL and returns either:
     - `Nothing`: if the request takes longer than the provided timeout (in milliseconds).
     - The string response: if the request succeeds before the timeout elapses.
 
-1. (Difficult) Write a `recurseFiles` function which takes a "root" file and returns an array of all paths listed in that file (and listed in the listed files too). Read listed files in parallel. Paths are relative to the directory of the file they appear in. _Hint:_ The `node-path` module has some helpful functions for negotiating directories.
+1. (Difficult) Write a `recurseFiles` function that takes a "root" file and returns an array of all paths listed in that file (and listed in the listed files too). Read listed files in parallel. Paths are relative to the directory of the file they appear in. _Hint:_ The `node-path` module has some helpful functions for negotiating directories.
 
 For example, if starting from the following `root.txt` file:
 
@@ -236,7 +237,7 @@ The expected output is:
 
 ## Conclusion
 
-In this chapter we covered asynchronous effects and learned how to:
+In this chapter, we covered asynchronous effects and learned how to:
 
 - Run asynchronous code in the `Aff` monad with the `aff` library.
 - Make HTTP requests asynchronously with the `affjax` library.


### PR DESCRIPTION
Apply grammarly suggestions accumulated while reviewing the content. It mostly moves commas around, simplifies sentences (for example, removing "just" and "simply"), swaps "that" and "which", etc.