### PR TITLE
Add publish date on CI

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -16,10 +16,13 @@ jobs:
         with:
           mdbook-version: 'latest'
 
-      - name: Add publish date
+      - name: Add version section
         run: |
+          version=$(purs --version)
           today=$(date -I)
-          echo -e "\n\nPublished on $today." >> README.md
+          echo -e "\n## Release\n" >> README.md
+          echo -e "PureScript v$version\n" >> README.md
+          echo -e "Published on $today" >> README.md
 
       - run: mdbook build
 

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Add publish date
+        run: |
+          today=$(date -I)
+          echo -e "\n\nPublished on $today." >> README.md
+
       - run: mdbook build
 
       - name: Deploy

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Set up PureScript toolchain
+        uses: purescript-contrib/setup-purescript@main
+
       - name: Add version section
         run: |
           version=$(purs --version)


### PR DESCRIPTION
## Description

This PR is supposed to add the information about when the book was published to the hosted version on <https://book.purescript.org>.

## Motivation

Because of the history of the book, I personally always had the feeling that I'm looking at an outdated version. Having some indicator might be helpful that one is indeed looking at an up-to-date copy of the (awesome!) book.

## Technical Considerations

The current PR is super simple. It will add a single line. It is mostly untested on CI, btw. I have no right to execute the github action, so testing wasn't really possible.

### Alternatives

There is also https://github.com/badboy/mdbook-last-changed. It will add a footer to every page and, by default, refer to commits. This might be helpful, but is not actually what I'd intend with this PR. Therefore, I went with the simpler command-line approach, where the result was more to my liking.